### PR TITLE
Add metrics scraping from Pods and Prometheus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ streaming platforms. Java 21, Quarkus 3.x, Strimzi API 0.51.x, Fabric8 Kubernete
 ## Modules
 
 - **`common`** (`streamshub-mcp-common`) - Generic Kubernetes helpers, DTOs, and utilities shared across modules
+- **`metrics-prometheus`** (`streamshub-metrics-prometheus`) - Prometheus/Thanos metrics provider (pluggable, replaceable JAR)
 - **`strimzi-mcp`** (`strimzi-mcp`) - Strimzi Kafka management MCP tools and services
 
 ## Build & Test
@@ -24,11 +25,23 @@ Checkstyle runs during compile phase. Fix all violations before committing.
 
 ```
 io.streamshub.mcp.common.
-├── config/      → KubernetesConstants (labels, conditions, phases, health status)
-├── dto/         → PodSummaryResponse, PodLogsResult, LogCollectionOptions (generic pod DTOs)
+├── config/         → KubernetesConstants (labels, conditions, phases, health status)
+├── dto/            → PodSummaryResponse, PodLogsResult, LogCollectionOptions (generic pod DTOs)
+│   └── metrics/    → MetricSample, PodTarget, MetricsQueryParams
 ├── readiness/   → KubernetesConnectionReadinessCheck (health check for kube API)
-├── service/     → KubernetesResourceService, PodsService, DeploymentService, CompletionHelper
-└── util/        → InputUtils
+├──service/        → KubernetesResourceService, PodsService, DeploymentService, CompletionHelper
+│   └── metrics/    → MetricsProvider (interface), PodScrapingMetricsProvider
+└── util/           → InputUtils
+    └── metrics/    → PrometheusTextParser
+```
+
+### Prometheus metrics module (`metrics-prometheus/`)
+
+```
+io.streamshub.mcp.metrics.prometheus.
+├── dto/       → PrometheusResponse
+├── service/   → PrometheusClient, PrometheusAuthFilter, PrometheusMetricsProvider
+└── util/      → PromQLSanitizer
 ```
 
 ### Strimzi module (`strimzi-mcp/`)
@@ -54,6 +67,8 @@ io.streamshub.mcp.strimzi.
 - **Domain services** (strimzi) contain all business logic. Throw `ToolCallException` for errors.
 - **Common services** are generic Kubernetes helpers shared across modules.
 - **DTOs** are immutable `record` types. Use static factory methods (`of()`, `empty()`) not constructors directly.
+- **Metrics providers** implement `MetricsProvider` interface. Selected via `@LookupIfProperty` on `mcp.metrics.provider`.
+  Inject with `Instance<MetricsProvider>` and check `isUnsatisfied()` before calling `get()`.
 
 ## MCP Tool Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ io.streamshub.mcp.common.
 │   └── metrics/    → MetricSample, PodTarget, MetricsQueryParams
 ├── readiness/   → KubernetesConnectionReadinessCheck (health check for kube API)
 ├──service/        → KubernetesResourceService, PodsService, DeploymentService, CompletionHelper
-│   └── metrics/    → MetricsProvider (interface), PodScrapingMetricsProvider
+│   └── metrics/    → MetricsProvider (interface), PodScrapingMetricsProvider, MetricsQueryService
 └── util/           → InputUtils
     └── metrics/    → PrometheusTextParser
 ```
@@ -68,7 +68,8 @@ io.streamshub.mcp.strimzi.
 - **Common services** are generic Kubernetes helpers shared across modules.
 - **DTOs** are immutable `record` types. Use static factory methods (`of()`, `empty()`) not constructors directly.
 - **Metrics providers** implement `MetricsProvider` interface. Selected via `@LookupIfProperty` on `mcp.metrics.provider`.
-  Inject with `Instance<MetricsProvider>` and check `isUnsatisfied()` before calling `get()`.
+  Domain services use `MetricsQueryService` (in common/) to query metrics — it handles provider lookup,
+  query param construction, and delegation. Do not inject `Instance<MetricsProvider>` directly in domain services.
 
 ## MCP Tool Pattern
 

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricSample.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricSample.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * A single metric sample scraped from a Prometheus-compatible endpoint or query result.
+ *
+ * @param name      the metric name
+ * @param labels    the metric labels as key-value pairs
+ * @param value     the metric value
+ * @param timestamp the time the sample was collected (null if not available)
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MetricSample(
+    @JsonProperty("name") String name,
+    @JsonProperty("labels") Map<String, String> labels,
+    @JsonProperty("value") double value,
+    @JsonProperty("timestamp") Instant timestamp
+) {
+
+    /**
+     * Creates a metric sample with a timestamp.
+     *
+     * @param name      the metric name
+     * @param labels    the metric labels
+     * @param value     the metric value
+     * @param timestamp the collection timestamp
+     * @return a new metric sample
+     */
+    public static MetricSample of(final String name, final Map<String, String> labels,
+                                   final double value, final Instant timestamp) {
+        return new MetricSample(name, labels, value, timestamp);
+    }
+
+    /**
+     * Creates a metric sample without a timestamp.
+     *
+     * @param name   the metric name
+     * @param labels the metric labels
+     * @param value  the metric value
+     * @return a new metric sample with null timestamp
+     */
+    public static MetricSample of(final String name, final Map<String, String> labels,
+                                   final double value) {
+        return new MetricSample(name, labels, value, null);
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeries.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeries.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A compact representation of a metric time series, grouping data points that share
+ * the same metric name and labels. This avoids repeating label maps for every data point,
+ * significantly reducing response size for range queries.
+ *
+ * @param name       the metric name
+ * @param labels     the metric labels (shared across all data points)
+ * @param dataPoints the time-value pairs as [epochSeconds, value] arrays
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MetricTimeSeries(
+    @JsonProperty("name") String name,
+    @JsonProperty("labels") Map<String, String> labels,
+    @JsonProperty("data_points") List<List<Object>> dataPoints
+) {
+
+    /**
+     * Groups a list of metric samples by name and labels into compact time series.
+     * Samples without timestamps are returned as-is (not grouped).
+     *
+     * @param samples the metric samples to group
+     * @return a list of grouped time series
+     */
+    public static List<MetricTimeSeries> fromSamples(final List<MetricSample> samples) {
+        Map<String, MetricTimeSeries> seriesMap = new LinkedHashMap<>();
+
+        for (MetricSample sample : samples) {
+            String key = sample.name() + "|" + sample.labels();
+            MetricTimeSeries series = seriesMap.get(key);
+
+            if (series == null) {
+                series = new MetricTimeSeries(sample.name(), sample.labels(), new ArrayList<>());
+                seriesMap.put(key, series);
+            }
+
+            long epochSeconds = sample.timestamp() != null
+                ? sample.timestamp().getEpochSecond() : 0L;
+            series.dataPoints().add(List.of(epochSeconds, sample.value()));
+        }
+
+        return List.copyOf(seriesMap.values());
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeries.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeries.java
@@ -6,6 +6,7 @@ package io.streamshub.mcp.common.dto.metrics;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.common.util.metrics.TimeSeriesCompressor;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -14,44 +15,61 @@ import java.util.Map;
 
 /**
  * A compact representation of a metric time series, grouping data points that share
- * the same metric name and labels. This avoids repeating label maps for every data point,
- * significantly reducing response size for range queries.
+ * the same metric name and labels. Consecutive data points with the same value are
+ * compressed to keep only the first and last of each constant run, and per-series
+ * summary statistics are computed to give the LLM a quick overview.
  *
  * @param name       the metric name
  * @param labels     the metric labels (shared across all data points)
- * @param dataPoints the time-value pairs as [epochSeconds, value] arrays
+ * @param dataPoints the time-value pairs as [epochSeconds, value] arrays (compressed)
+ * @param summary    summary statistics computed from the original (uncompressed) data
+ * @param compressed true if constant-value runs were collapsed, null otherwise
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MetricTimeSeries(
     @JsonProperty("name") String name,
     @JsonProperty("labels") Map<String, String> labels,
-    @JsonProperty("data_points") List<List<Object>> dataPoints
+    @JsonProperty("data_points") List<List<Object>> dataPoints,
+    @JsonProperty("summary") TimeSeriesSummary summary,
+    @JsonProperty("compressed") Boolean compressed
 ) {
 
     /**
      * Groups a list of metric samples by name and labels into compact time series.
-     * Samples without timestamps are returned as-is (not grouped).
+     * Each series is compressed by collapsing constant-value runs and enriched with
+     * summary statistics (min, max, avg, latest, delta).
      *
      * @param samples the metric samples to group
-     * @return a list of grouped time series
+     * @return a list of grouped, compressed time series with summaries
      */
     public static List<MetricTimeSeries> fromSamples(final List<MetricSample> samples) {
-        Map<String, MetricTimeSeries> seriesMap = new LinkedHashMap<>();
+        Map<String, List<List<Object>>> rawSeriesMap = new LinkedHashMap<>();
+        Map<String, MetricSample> firstSampleMap = new LinkedHashMap<>();
 
         for (MetricSample sample : samples) {
             String key = sample.name() + "|" + sample.labels();
-            MetricTimeSeries series = seriesMap.get(key);
-
-            if (series == null) {
-                series = new MetricTimeSeries(sample.name(), sample.labels(), new ArrayList<>());
-                seriesMap.put(key, series);
-            }
+            rawSeriesMap.computeIfAbsent(key, k -> new ArrayList<>());
+            firstSampleMap.putIfAbsent(key, sample);
 
             long epochSeconds = sample.timestamp() != null
                 ? sample.timestamp().getEpochSecond() : 0L;
-            series.dataPoints().add(List.of(epochSeconds, sample.value()));
+            rawSeriesMap.get(key).add(List.of(epochSeconds, sample.value()));
         }
 
-        return List.copyOf(seriesMap.values());
+        List<MetricTimeSeries> result = new ArrayList<>();
+        for (Map.Entry<String, List<List<Object>>> entry : rawSeriesMap.entrySet()) {
+            MetricSample firstSample = firstSampleMap.get(entry.getKey());
+            List<List<Object>> originalPoints = entry.getValue();
+
+            TimeSeriesSummary summary = TimeSeriesSummary.of(originalPoints);
+            List<List<Object>> compressedPoints = TimeSeriesCompressor.compress(originalPoints);
+            Boolean wasCompressed = compressedPoints.size() < originalPoints.size()
+                ? Boolean.TRUE : null;
+
+            result.add(new MetricTimeSeries(firstSample.name(), firstSample.labels(),
+                compressedPoints, summary, wasCompressed));
+        }
+
+        return List.copyOf(result);
     }
 }

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricsQueryParams.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricsQueryParams.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parameters for a metrics query. Supports both pod-scraping and Prometheus providers
+ * through union fields: {@code podTargets} for scraping and {@code labelMatchers} for Prometheus.
+ *
+ * @param metricNames   the metric names to retrieve
+ * @param labelMatchers label key-value pairs for Prometheus query filtering
+ * @param podTargets    pod endpoints to scrape (used by pod-scraping provider)
+ * @param startTime     range query start time (null for instant queries)
+ * @param endTime       range query end time (null for instant queries)
+ * @param stepSeconds   range query step interval in seconds
+ */
+public record MetricsQueryParams(
+    List<String> metricNames,
+    Map<String, String> labelMatchers,
+    List<PodTarget> podTargets,
+    Instant startTime,
+    Instant endTime,
+    Integer stepSeconds
+) {
+
+    /**
+     * Creates parameters for an instant (point-in-time) query.
+     *
+     * @param metricNames   the metric names to retrieve
+     * @param labelMatchers label matchers for Prometheus filtering
+     * @param podTargets    pod endpoints to scrape
+     * @return instant query parameters
+     */
+    public static MetricsQueryParams instant(final List<String> metricNames,
+                                              final Map<String, String> labelMatchers,
+                                              final List<PodTarget> podTargets) {
+        return new MetricsQueryParams(metricNames, labelMatchers, podTargets, null, null, null);
+    }
+
+    /**
+     * Creates parameters for a range query over a time window.
+     *
+     * @param metricNames   the metric names to retrieve
+     * @param labelMatchers label matchers for Prometheus filtering
+     * @param startTime     the range start time
+     * @param endTime       the range end time
+     * @param stepSeconds   the step interval in seconds
+     * @return range query parameters
+     */
+    public static MetricsQueryParams range(final List<String> metricNames,
+                                            final Map<String, String> labelMatchers,
+                                            final Instant startTime,
+                                            final Instant endTime,
+                                            final int stepSeconds) {
+        return new MetricsQueryParams(metricNames, labelMatchers, List.of(),
+            startTime, endTime, stepSeconds);
+    }
+
+    /**
+     * Returns whether this represents a range query (both start and end time are set).
+     *
+     * @return true if this is a range query
+     */
+    public boolean isRangeQuery() {
+        return startTime != null && endTime != null;
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/PodTarget.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/PodTarget.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+/**
+ * Identifies a pod endpoint to scrape for metrics.
+ *
+ * @param namespace the Kubernetes namespace of the pod
+ * @param podName   the pod name
+ * @param port      the metrics port (null for auto-detection)
+ * @param path      the metrics endpoint path (default {@code /metrics})
+ */
+public record PodTarget(
+    String namespace,
+    String podName,
+    Integer port,
+    String path
+) {
+
+    /** Default metrics endpoint path. */
+    public static final String DEFAULT_PATH = "/metrics";
+
+    /**
+     * Creates a pod target with auto-detected port and default path.
+     *
+     * @param namespace the Kubernetes namespace
+     * @param podName   the pod name
+     * @return a new pod target
+     */
+    public static PodTarget of(final String namespace, final String podName) {
+        return new PodTarget(namespace, podName, null, DEFAULT_PATH);
+    }
+
+    /**
+     * Creates a pod target with explicit port and path.
+     *
+     * @param namespace the Kubernetes namespace
+     * @param podName   the pod name
+     * @param port      the metrics port
+     * @param path      the metrics endpoint path
+     * @return a new pod target
+     */
+    public static PodTarget of(final String namespace, final String podName,
+                                final Integer port, final String path) {
+        return new PodTarget(namespace, podName, port, path);
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummary.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummary.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Summary statistics for a metric time series. Provides a compact overview of
+ * the data without requiring the LLM to process every individual data point.
+ *
+ * @param min                    the minimum value in the series
+ * @param max                    the maximum value in the series
+ * @param avg                    the average value across all data points
+ * @param latest                 the most recent value in the series
+ * @param delta                  the change from first to last value (last - first)
+ * @param originalDataPointCount the number of data points before compression
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TimeSeriesSummary(
+    @JsonProperty("min") double min,
+    @JsonProperty("max") double max,
+    @JsonProperty("avg") double avg,
+    @JsonProperty("latest") double latest,
+    @JsonProperty("delta") double delta,
+    @JsonProperty("original_data_point_count") int originalDataPointCount
+) {
+
+    /**
+     * Computes summary statistics from a list of time-value data points.
+     * Each data point is a {@code [epochSeconds, value]} list.
+     *
+     * @param dataPoints the raw data points to summarize
+     * @return the computed summary, or null if the list is empty
+     */
+    public static TimeSeriesSummary of(final List<List<Object>> dataPoints) {
+        if (dataPoints == null || dataPoints.isEmpty()) {
+            return null;
+        }
+
+        double minVal = Double.MAX_VALUE;
+        double maxVal = -Double.MAX_VALUE;
+        double sum = 0.0;
+        double firstVal = extractValue(dataPoints.getFirst());
+        double lastVal = firstVal;
+
+        for (List<Object> dp : dataPoints) {
+            double val = extractValue(dp);
+            if (val < minVal) {
+                minVal = val;
+            }
+            if (val > maxVal) {
+                maxVal = val;
+            }
+            sum += val;
+            lastVal = val;
+        }
+
+        double avg = sum / dataPoints.size();
+        return new TimeSeriesSummary(minVal, maxVal, avg, lastVal, lastVal - firstVal,
+            dataPoints.size());
+    }
+
+    private static double extractValue(final List<Object> dataPoint) {
+        return ((Number) dataPoint.get(1)).doubleValue();
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/service/PodsService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/PodsService.java
@@ -10,12 +10,17 @@ import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.streamshub.mcp.common.config.KubernetesConstants;
 import io.streamshub.mcp.common.dto.ConditionInfo;
 import io.streamshub.mcp.common.dto.LogCollectionOptions;
@@ -161,9 +166,9 @@ public class PodsService {
      */
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     public PodSummaryResponse.PodInfo extractPodInfo(String namespace, Pod pod, Set<String> sections) {
-        var metadata = pod.getMetadata();
-        var spec = pod.getSpec();
-        var podStatus = pod.getStatus();
+        ObjectMeta metadata = pod.getMetadata();
+        PodSpec spec = pod.getSpec();
+        PodStatus podStatus = pod.getStatus();
 
         String podName = metadata.getName();
         String phase = podStatus != null ? podStatus.getPhase() : KubernetesConstants.PodPhases.UNKNOWN;
@@ -375,7 +380,7 @@ public class PodsService {
         for (Container container : containers) {
             if (container.getResources() != null) {
                 if (container.getResources().getRequests() != null) {
-                    var reqs = container.getResources().getRequests();
+                    Map<String, Quantity> reqs = container.getResources().getRequests();
                     if (reqs.get("cpu") != null) {
                         cpuRequest = reqs.get("cpu").toString();
                     }
@@ -384,7 +389,7 @@ public class PodsService {
                     }
                 }
                 if (container.getResources().getLimits() != null) {
-                    var lims = container.getResources().getLimits();
+                    Map<String, Quantity> lims = container.getResources().getLimits();
                     if (lims.get("cpu") != null) {
                         cpuLimit = lims.get("cpu").toString();
                     }
@@ -471,7 +476,7 @@ public class PodsService {
         if (container.getResources() == null) {
             return null;
         }
-        var res = container.getResources();
+        ResourceRequirements res = container.getResources();
         String cpuReq = null;
         String cpuLim = null;
         String memReq = null;
@@ -769,7 +774,7 @@ public class PodsService {
     private String fetchPodLog(final String namespace, final String podName,
                                final int tailLines, final Integer sinceSeconds,
                                final Boolean previous) {
-        var podResource = kubernetesClient.pods()
+        PodResource podResource = kubernetesClient.pods()
             .inNamespace(namespace)
             .withName(podName);
 

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsProvider.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+
+import java.util.List;
+
+/**
+ * Interface for metrics retrieval providers.
+ * Implementations handle specific backends such as pod scraping or Prometheus.
+ */
+public interface MetricsProvider {
+
+    /**
+     * Queries metrics according to the given parameters.
+     *
+     * @param params the query parameters including metric names, labels, and pod targets
+     * @return a list of metric samples matching the query
+     */
+    List<MetricSample> queryMetrics(MetricsQueryParams params);
+}

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
@@ -7,6 +7,7 @@ package io.streamshub.mcp.common.service.metrics;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
 import io.streamshub.mcp.common.dto.metrics.PodTarget;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -42,6 +43,20 @@ public class MetricsQueryService {
     }
 
     /**
+     * Validates metrics provider configuration at startup.
+     * Logs a warning if no provider is configured.
+     */
+    @PostConstruct
+    void validateConfiguration() {
+        if (metricsProviderInstance.isUnsatisfied()) {
+            LOG.warnf("No metrics provider configured. Set 'mcp.metrics.provider' to "
+                + "'streamshub-pod-scraping' or 'streamshub-prometheus'. Provider name: %s", providerName);
+        } else {
+            LOG.infof("Metrics provider initialized: %s", providerName);
+        }
+    }
+
+    /**
      * Returns the configured metrics provider name.
      *
      * @return the provider name (e.g. "streamshub-pod-scraping", "streamshub-prometheus")
@@ -57,6 +72,8 @@ public class MetricsQueryService {
      * @param labelMatchers label key-value pairs for Prometheus query filtering
      * @param metricNames   the metric names to retrieve
      * @param rangeMinutes  range query duration in minutes (null for instant query)
+     * @param startTime     absolute start time in ISO 8601 format (null for relative or instant query)
+     * @param endTime       absolute end time in ISO 8601 format (null for relative or instant query)
      * @param stepSeconds   range query step interval in seconds (null for default)
      * @return a list of metric samples matching the query
      */
@@ -64,11 +81,13 @@ public class MetricsQueryService {
                                             final Map<String, String> labelMatchers,
                                             final List<String> metricNames,
                                             final Integer rangeMinutes,
+                                            final String startTime,
+                                            final String endTime,
                                             final Integer stepSeconds) {
         requireProvider();
 
         MetricsQueryParams params = buildParams(podTargets, labelMatchers, metricNames,
-            rangeMinutes, stepSeconds);
+            rangeMinutes, startTime, endTime, stepSeconds);
 
         LOG.debugf("Querying metrics: %d metric names, %d pod targets (provider=%s)",
             metricNames.size(), podTargets.size(), providerName);
@@ -88,13 +107,37 @@ public class MetricsQueryService {
                                             final Map<String, String> labelMatchers,
                                             final List<String> metricNames,
                                             final Integer rangeMinutes,
+                                            final String startTimeStr,
+                                            final String endTimeStr,
                                             final Integer stepSeconds) {
+        // Absolute time range (NEW)
+        if (startTimeStr != null && endTimeStr != null) {
+            try {
+                Instant start = Instant.parse(startTimeStr);
+                Instant end = Instant.parse(endTimeStr);
+
+                if (start.isAfter(end)) {
+                    throw new IllegalArgumentException("startTime must be before endTime");
+                }
+
+                int step = stepSeconds != null ? stepSeconds : defaultStepSeconds;
+                return MetricsQueryParams.range(metricNames, labelMatchers, start, end, step);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                    "Invalid time format. Use ISO 8601 format (e.g., '2026-04-05T10:00:00Z'): "
+                        + e.getMessage(), e);
+            }
+        }
+
+        // Relative time range (existing)
         if (rangeMinutes != null && rangeMinutes > 0) {
             Instant end = Instant.now();
             Instant start = end.minusSeconds((long) rangeMinutes * SECONDS_PER_MINUTE);
             int step = stepSeconds != null ? stepSeconds : defaultStepSeconds;
             return MetricsQueryParams.range(metricNames, labelMatchers, start, end, step);
         }
+
+        // Instant query (existing)
         return MetricsQueryParams.instant(metricNames, labelMatchers, podTargets);
     }
 }

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
@@ -110,7 +110,7 @@ public class MetricsQueryService {
                                             final String startTimeStr,
                                             final String endTimeStr,
                                             final Integer stepSeconds) {
-        // Absolute time range (NEW)
+        // Absolute time range
         if (startTimeStr != null && endTimeStr != null) {
             try {
                 Instant start = Instant.parse(startTimeStr);

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+import io.streamshub.mcp.common.dto.metrics.PodTarget;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * General-purpose metrics query service that delegates to a pluggable {@link MetricsProvider}.
+ * Domain-specific services (Kafka, operator, etc.) use this service to execute metric queries
+ * without needing to manage provider lookup or query parameter construction.
+ */
+@ApplicationScoped
+public class MetricsQueryService {
+
+    private static final Logger LOG = Logger.getLogger(MetricsQueryService.class);
+    private static final int SECONDS_PER_MINUTE = 60;
+
+    @Inject
+    Instance<MetricsProvider> metricsProviderInstance;
+
+    @ConfigProperty(name = "mcp.metrics.provider", defaultValue = "streamshub-pod-scraping")
+    String providerName;
+
+    @ConfigProperty(name = "mcp.metrics.default-step-seconds", defaultValue = "60")
+    int defaultStepSeconds;
+
+    MetricsQueryService() {
+        // package-private no-arg constructor for CDI
+    }
+
+    /**
+     * Returns the configured metrics provider name.
+     *
+     * @return the provider name (e.g. "streamshub-pod-scraping", "streamshub-prometheus")
+     */
+    public String providerName() {
+        return providerName;
+    }
+
+    /**
+     * Queries metrics using the configured provider.
+     *
+     * @param podTargets    pod endpoints to scrape (used by pod-scraping provider)
+     * @param labelMatchers label key-value pairs for Prometheus query filtering
+     * @param metricNames   the metric names to retrieve
+     * @param rangeMinutes  range query duration in minutes (null for instant query)
+     * @param stepSeconds   range query step interval in seconds (null for default)
+     * @return a list of metric samples matching the query
+     */
+    public List<MetricSample> queryMetrics(final List<PodTarget> podTargets,
+                                            final Map<String, String> labelMatchers,
+                                            final List<String> metricNames,
+                                            final Integer rangeMinutes,
+                                            final Integer stepSeconds) {
+        requireProvider();
+
+        MetricsQueryParams params = buildParams(podTargets, labelMatchers, metricNames,
+            rangeMinutes, stepSeconds);
+
+        LOG.debugf("Querying metrics: %d metric names, %d pod targets (provider=%s)",
+            metricNames.size(), podTargets.size(), providerName);
+
+        return metricsProviderInstance.get().queryMetrics(params);
+    }
+
+    private void requireProvider() {
+        if (metricsProviderInstance.isUnsatisfied()) {
+            throw new IllegalStateException(
+                "No metrics provider configured."
+                    + " Set 'mcp.metrics.provider' to 'streamshub-pod-scraping' or 'streamshub-prometheus'.");
+        }
+    }
+
+    private MetricsQueryParams buildParams(final List<PodTarget> podTargets,
+                                            final Map<String, String> labelMatchers,
+                                            final List<String> metricNames,
+                                            final Integer rangeMinutes,
+                                            final Integer stepSeconds) {
+        if (rangeMinutes != null && rangeMinutes > 0) {
+            Instant end = Instant.now();
+            Instant start = end.minusSeconds((long) rangeMinutes * SECONDS_PER_MINUTE);
+            int step = stepSeconds != null ? stepSeconds : defaultStepSeconds;
+            return MetricsQueryParams.range(metricNames, labelMatchers, start, end, step);
+        }
+        return MetricsQueryParams.instant(metricNames, labelMatchers, podTargets);
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/PodScrapingMetricsProvider.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/PodScrapingMetricsProvider.java
@@ -11,6 +11,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
 import io.streamshub.mcp.common.dto.metrics.PodTarget;
+import io.streamshub.mcp.common.util.metrics.MetricLabelFilter;
 import io.streamshub.mcp.common.util.metrics.PrometheusTextParser;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -77,7 +78,11 @@ public class PodScrapingMetricsProvider implements MetricsProvider {
                 String body = kubernetesClient.raw(proxyUrl);
                 if (body != null && !body.isEmpty()) {
                     List<MetricSample> samples = PrometheusTextParser.parse(body, metricFilter);
-                    allSamples.addAll(samples);
+                    for (MetricSample sample : samples) {
+                        allSamples.add(MetricSample.of(sample.name(),
+                            MetricLabelFilter.filterLabels(sample.labels()),
+                            sample.value(), sample.timestamp()));
+                    }
                 } else {
                     LOG.warnf("Empty metrics response from pod %s/%s",
                         target.namespace(), target.podName());

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/PodScrapingMetricsProvider.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/PodScrapingMetricsProvider.java
@@ -116,7 +116,7 @@ public class PodScrapingMetricsProvider implements MetricsProvider {
 
             if (pod != null && pod.getSpec() != null && pod.getSpec().getContainers() != null) {
                 // First look for a port named "tcp-prometheus"
-                for (var container : pod.getSpec().getContainers()) {
+                for (io.fabric8.kubernetes.api.model.Container container : pod.getSpec().getContainers()) {
                     if (container.getPorts() != null) {
                         for (ContainerPort cp : container.getPorts()) {
                             if (PROMETHEUS_PORT_NAME.equals(cp.getName())) {
@@ -127,7 +127,7 @@ public class PodScrapingMetricsProvider implements MetricsProvider {
                 }
 
                 // Fallback: check for known default ports
-                for (var container : pod.getSpec().getContainers()) {
+                for (io.fabric8.kubernetes.api.model.Container container : pod.getSpec().getContainers()) {
                     if (container.getPorts() != null) {
                         for (ContainerPort cp : container.getPorts()) {
                             if (cp.getContainerPort() == STRIMZI_METRICS_PORT) {

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/PodScrapingMetricsProvider.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/PodScrapingMetricsProvider.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service.metrics;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+import io.streamshub.mcp.common.dto.metrics.PodTarget;
+import io.streamshub.mcp.common.util.metrics.PrometheusTextParser;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Metrics provider that scrapes Prometheus text exposition endpoints directly from pods
+ * via the Kubernetes API pod proxy.
+ */
+@ApplicationScoped
+@LookupIfProperty(name = "mcp.metrics.provider", stringValue = "streamshub-pod-scraping")
+public class PodScrapingMetricsProvider implements MetricsProvider {
+
+    private static final Logger LOG = Logger.getLogger(PodScrapingMetricsProvider.class);
+
+    /** Strimzi convention for the Prometheus metrics port name. */
+    private static final String PROMETHEUS_PORT_NAME = "tcp-prometheus";
+
+    /** Strimzi default metrics port. */
+    private static final int STRIMZI_METRICS_PORT = 9404;
+
+    /** Generic fallback metrics port. */
+    private static final int DEFAULT_METRICS_PORT = 8080;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    PodScrapingMetricsProvider() {
+        // package-private no-arg constructor for CDI
+    }
+
+    @Override
+    public List<MetricSample> queryMetrics(final MetricsQueryParams params) {
+        if (params.isRangeQuery()) {
+            LOG.warn("Pod scraping provider does not support range queries."
+                + " Returning point-in-time data instead.");
+        }
+
+        List<PodTarget> targets = params.podTargets();
+        if (targets == null || targets.isEmpty()) {
+            LOG.debug("No pod targets provided for scraping");
+            return List.of();
+        }
+
+        Set<String> metricFilter = params.metricNames() != null
+            ? new HashSet<>(params.metricNames()) : null;
+
+        List<MetricSample> allSamples = new ArrayList<>();
+
+        for (PodTarget target : targets) {
+            int port = resolvePort(target);
+            String path = target.path() != null ? target.path() : PodTarget.DEFAULT_PATH;
+            String proxyUrl = String.format("/api/v1/namespaces/%s/pods/%s:%d/proxy%s",
+                target.namespace(), target.podName(), port, path);
+
+            LOG.debugf("Scraping metrics from %s", proxyUrl);
+
+            try {
+                String body = kubernetesClient.raw(proxyUrl);
+                if (body != null && !body.isEmpty()) {
+                    List<MetricSample> samples = PrometheusTextParser.parse(body, metricFilter);
+                    allSamples.addAll(samples);
+                } else {
+                    LOG.warnf("Empty metrics response from pod %s/%s",
+                        target.namespace(), target.podName());
+                }
+            } catch (Exception e) {
+                LOG.warnf("Error scraping metrics from pod %s/%s: %s",
+                    target.namespace(), target.podName(), e.getMessage());
+            }
+        }
+
+        return allSamples;
+    }
+
+    /**
+     * Resolves the metrics port for a pod target. If the target has an explicit port,
+     * use it. Otherwise, look up the pod and try to auto-detect the port.
+     *
+     * @param target the pod target
+     * @return the resolved port number
+     */
+    private int resolvePort(final PodTarget target) {
+        if (target.port() != null) {
+            return target.port();
+        }
+
+        try {
+            Pod pod = kubernetesClient.pods()
+                .inNamespace(target.namespace())
+                .withName(target.podName())
+                .get();
+
+            if (pod != null && pod.getSpec() != null && pod.getSpec().getContainers() != null) {
+                // First look for a port named "tcp-prometheus"
+                for (var container : pod.getSpec().getContainers()) {
+                    if (container.getPorts() != null) {
+                        for (ContainerPort cp : container.getPorts()) {
+                            if (PROMETHEUS_PORT_NAME.equals(cp.getName())) {
+                                return cp.getContainerPort();
+                            }
+                        }
+                    }
+                }
+
+                // Fallback: check for known default ports
+                for (var container : pod.getSpec().getContainers()) {
+                    if (container.getPorts() != null) {
+                        for (ContainerPort cp : container.getPorts()) {
+                            if (cp.getContainerPort() == STRIMZI_METRICS_PORT) {
+                                return STRIMZI_METRICS_PORT;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugf("Could not auto-detect metrics port for pod %s/%s: %s",
+                target.namespace(), target.podName(), e.getMessage());
+        }
+
+        return DEFAULT_METRICS_PORT;
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilter.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Filters internal Prometheus and infrastructure labels from metric samples.
+ * Keeps domain-relevant labels that help understand metric context (namespace, pod, kind, etc.)
+ * while stripping scrape-config and monitoring-infrastructure labels.
+ */
+public final class MetricLabelFilter {
+
+    private static final Set<String> INTERNAL_LABELS = Set.of(
+        "__name__",
+        "job",
+        "instance",
+        "endpoint",
+        "container",
+        "prometheus",
+        "service"
+    );
+
+    private MetricLabelFilter() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Filters out internal/infrastructure labels, returning only domain-relevant labels.
+     *
+     * @param labels the original label map (may be null)
+     * @return a new map with internal labels removed, or an empty map if input is null
+     */
+    public static Map<String, String> filterLabels(final Map<String, String> labels) {
+        if (labels == null || labels.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> filtered = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            if (!INTERNAL_LABELS.contains(entry.getKey())) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return filtered;
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParser.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParser.java
@@ -5,6 +5,7 @@
 package io.streamshub.mcp.common.util.metrics;
 
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -19,6 +20,8 @@ import java.util.Set;
  * Handles comment lines, metrics with and without labels, and optional timestamps.
  */
 public final class PrometheusTextParser {
+
+    private static final Logger LOG = Logger.getLogger(PrometheusTextParser.class);
 
     private PrometheusTextParser() {
         // Utility class — no instantiation
@@ -56,6 +59,7 @@ public final class PrometheusTextParser {
 
             MetricSample sample = parseLine(trimmed);
             if (sample == null) {
+                LOG.debugf("Skipping malformed metric line: %s", trimmed);
                 continue;
             }
 

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParser.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParser.java
@@ -23,6 +23,24 @@ public final class PrometheusTextParser {
 
     private static final Logger LOG = Logger.getLogger(PrometheusTextParser.class);
 
+    /**
+     * Prometheus exposition format uses curly braces to delimit the label set.
+     */
+    private static final char LABELS_OPEN_CHAR = '{';
+    private static final char LABELS_CLOSE_CHAR = '}';
+    private static final char FIELD_SEPARATOR_CHAR = ' ';
+    private static final char LABEL_SEPARATOR_CHAR = ',';
+    private static final char KEY_VALUE_SEPARATOR_CHAR = '=';
+    private static final char QUOTED_VALUE_CHAR = '"';
+    private static final char ESCAPE_CHAR = '\\';
+
+    /**
+     * A metric sample may contain the numeric value only, or value plus timestamp.
+     */
+    private static final int MAX_VALUE_AND_TIMESTAMP_PARTS = 2;
+    private static final int VALUE_PART_INDEX = 0;
+    private static final int TIMESTAMP_PART_INDEX = 1;
+
     private PrometheusTextParser() {
         // Utility class — no instantiation
     }
@@ -76,17 +94,19 @@ public final class PrometheusTextParser {
         Map<String, String> labels;
         String remainder;
 
-        int braceOpen = line.indexOf('{');
+        int braceOpen = line.indexOf(LABELS_OPEN_CHAR);
         if (braceOpen >= 0) {
             metricName = line.substring(0, braceOpen);
-            int braceClose = line.indexOf('}', braceOpen);
+            int braceClose = line.indexOf(LABELS_CLOSE_CHAR, braceOpen);
             if (braceClose < 0) {
                 return null;
             }
             labels = parseLabels(line.substring(braceOpen + 1, braceClose));
+            // Everything after the label block should contain the metric value
+            // and optionally the sample timestamp in epoch milliseconds.
             remainder = line.substring(braceClose + 1).trim();
         } else {
-            int firstSpace = line.indexOf(' ');
+            int firstSpace = line.indexOf(FIELD_SEPARATOR_CHAR);
             if (firstSpace < 0) {
                 return null;
             }
@@ -99,18 +119,19 @@ public final class PrometheusTextParser {
             return null;
         }
 
-        String[] parts = remainder.split("\\s+", 2);
+        // Split into at most two tokens: mandatory metric value and optional timestamp.
+        String[] parts = remainder.split("\\s+", MAX_VALUE_AND_TIMESTAMP_PARTS);
         double value;
         try {
-            value = Double.parseDouble(parts[0]);
+            value = Double.parseDouble(parts[VALUE_PART_INDEX]);
         } catch (NumberFormatException e) {
             return null;
         }
 
         Instant timestamp = null;
-        if (parts.length > 1) {
+        if (parts.length > TIMESTAMP_PART_INDEX) {
             try {
-                timestamp = Instant.ofEpochMilli(Long.parseLong(parts[1]));
+                timestamp = Instant.ofEpochMilli(Long.parseLong(parts[TIMESTAMP_PART_INDEX]));
             } catch (NumberFormatException e) {
                 // Ignore invalid timestamp
             }
@@ -119,6 +140,21 @@ public final class PrometheusTextParser {
         return MetricSample.of(metricName, labels, value, timestamp);
     }
 
+    /**
+     * Parse the content of a Prometheus label block into a map of label names to values.
+     * <p>
+     * The input is expected to be the text between the surrounding curly braces, for example
+     * {@code instance="broker-0",namespace="kafka"}. The parser walks the string from left
+     * to right, skipping separators, reading each label key up to {@code =}, and then reading
+     * the quoted label value. Escaped characters inside quoted values are preserved as their
+     * literal character values.
+     * <p>
+     * If the label string is blank, an empty map is returned. If malformed content is encountered,
+     * parsing stops and the labels collected so far are returned.
+     *
+     * @param labelString raw label content without the surrounding {@code {}} characters
+     * @return immutable map of parsed labels
+     */
     private static Map<String, String> parseLabels(final String labelString) {
         if (labelString.isBlank()) {
             return Map.of();
@@ -130,7 +166,8 @@ public final class PrometheusTextParser {
 
         while (i < len) {
             // Skip whitespace and commas
-            while (i < len && (labelString.charAt(i) == ',' || labelString.charAt(i) == ' ')) {
+            while (i < len && (labelString.charAt(i) == LABEL_SEPARATOR_CHAR
+                || labelString.charAt(i) == FIELD_SEPARATOR_CHAR)) {
                 i++;
             }
             if (i >= len) {
@@ -138,7 +175,7 @@ public final class PrometheusTextParser {
             }
 
             // Read key
-            int eqIdx = labelString.indexOf('=', i);
+            int eqIdx = labelString.indexOf(KEY_VALUE_SEPARATOR_CHAR, i);
             if (eqIdx < 0) {
                 break;
             }
@@ -146,7 +183,7 @@ public final class PrometheusTextParser {
 
             // Read value (expect ="...")
             int valStart = eqIdx + 1;
-            if (valStart >= len || labelString.charAt(valStart) != '"') {
+            if (valStart >= len || labelString.charAt(valStart) != QUOTED_VALUE_CHAR) {
                 break;
             }
             valStart++; // skip opening quote
@@ -155,10 +192,11 @@ public final class PrometheusTextParser {
             int j = valStart;
             while (j < len) {
                 char c = labelString.charAt(j);
-                if (c == '\\' && j + 1 < len) {
+                if (c == ESCAPE_CHAR && j + 1 < len) {
+                    // Preserve the escaped next character without the escape prefix.
                     value.append(labelString.charAt(j + 1));
                     j += 2;
-                } else if (c == '"') {
+                } else if (c == QUOTED_VALUE_CHAR) {
                     break;
                 } else {
                     value.append(c);

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParser.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParser.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parses Prometheus text exposition format into {@link MetricSample} objects.
+ * Handles comment lines, metrics with and without labels, and optional timestamps.
+ */
+public final class PrometheusTextParser {
+
+    private PrometheusTextParser() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Parses all metrics from Prometheus text exposition format.
+     *
+     * @param text the raw Prometheus text output
+     * @return a list of parsed metric samples
+     */
+    public static List<MetricSample> parse(final String text) {
+        return parse(text, null);
+    }
+
+    /**
+     * Parses metrics from Prometheus text exposition format, optionally filtering by metric name.
+     *
+     * @param text        the raw Prometheus text output
+     * @param metricNames metric names to include (null or empty to include all)
+     * @return a list of parsed metric samples matching the filter
+     */
+    public static List<MetricSample> parse(final String text, final Set<String> metricNames) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+
+        List<MetricSample> samples = new ArrayList<>();
+
+        for (String line : text.lines().toList()) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+
+            MetricSample sample = parseLine(trimmed);
+            if (sample == null) {
+                continue;
+            }
+
+            if (metricNames == null || metricNames.isEmpty() || metricNames.contains(sample.name())) {
+                samples.add(sample);
+            }
+        }
+
+        return Collections.unmodifiableList(samples);
+    }
+
+    private static MetricSample parseLine(final String line) {
+        String metricName;
+        Map<String, String> labels;
+        String remainder;
+
+        int braceOpen = line.indexOf('{');
+        if (braceOpen >= 0) {
+            metricName = line.substring(0, braceOpen);
+            int braceClose = line.indexOf('}', braceOpen);
+            if (braceClose < 0) {
+                return null;
+            }
+            labels = parseLabels(line.substring(braceOpen + 1, braceClose));
+            remainder = line.substring(braceClose + 1).trim();
+        } else {
+            int firstSpace = line.indexOf(' ');
+            if (firstSpace < 0) {
+                return null;
+            }
+            metricName = line.substring(0, firstSpace);
+            labels = Map.of();
+            remainder = line.substring(firstSpace + 1).trim();
+        }
+
+        if (metricName.isEmpty() || remainder.isEmpty()) {
+            return null;
+        }
+
+        String[] parts = remainder.split("\\s+", 2);
+        double value;
+        try {
+            value = Double.parseDouble(parts[0]);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+
+        Instant timestamp = null;
+        if (parts.length > 1) {
+            try {
+                timestamp = Instant.ofEpochMilli(Long.parseLong(parts[1]));
+            } catch (NumberFormatException e) {
+                // Ignore invalid timestamp
+            }
+        }
+
+        return MetricSample.of(metricName, labels, value, timestamp);
+    }
+
+    private static Map<String, String> parseLabels(final String labelString) {
+        if (labelString.isBlank()) {
+            return Map.of();
+        }
+
+        Map<String, String> labels = new LinkedHashMap<>();
+        int i = 0;
+        int len = labelString.length();
+
+        while (i < len) {
+            // Skip whitespace and commas
+            while (i < len && (labelString.charAt(i) == ',' || labelString.charAt(i) == ' ')) {
+                i++;
+            }
+            if (i >= len) {
+                break;
+            }
+
+            // Read key
+            int eqIdx = labelString.indexOf('=', i);
+            if (eqIdx < 0) {
+                break;
+            }
+            String key = labelString.substring(i, eqIdx).trim();
+
+            // Read value (expect ="...")
+            int valStart = eqIdx + 1;
+            if (valStart >= len || labelString.charAt(valStart) != '"') {
+                break;
+            }
+            valStart++; // skip opening quote
+
+            StringBuilder value = new StringBuilder();
+            int j = valStart;
+            while (j < len) {
+                char c = labelString.charAt(j);
+                if (c == '\\' && j + 1 < len) {
+                    value.append(labelString.charAt(j + 1));
+                    j += 2;
+                } else if (c == '"') {
+                    break;
+                } else {
+                    value.append(c);
+                    j++;
+                }
+            }
+
+            labels.put(key, value.toString());
+            i = j + 1; // skip closing quote
+        }
+
+        return Collections.unmodifiableMap(labels);
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/TimeSeriesCompressor.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/TimeSeriesCompressor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Compresses metric time series data by collapsing consecutive runs of identical values.
+ * For each run of constant values, only the first and last data points are kept,
+ * significantly reducing the number of data points for stable metrics.
+ */
+public final class TimeSeriesCompressor {
+
+    private static final double EPSILON = 1e-9;
+
+    private TimeSeriesCompressor() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Compresses a list of time-value data points by collapsing constant-value runs.
+     * Each data point is a {@code [epochSeconds, value]} list. Consecutive points with
+     * the same value (within epsilon {@value EPSILON}) are reduced to just the first
+     * and last point of each run.
+     *
+     * @param dataPoints the raw data points to compress
+     * @return a compressed list with constant runs collapsed to first+last
+     */
+    public static List<List<Object>> compress(final List<List<Object>> dataPoints) {
+        if (dataPoints.size() <= 2) {
+            return dataPoints;
+        }
+
+        List<List<Object>> compressed = new ArrayList<>();
+        compressed.add(dataPoints.getFirst());
+
+        int runStart = 0;
+
+        for (int i = 1; i < dataPoints.size(); i++) {
+            double currentVal = extractValue(dataPoints.get(i));
+            double runStartVal = extractValue(dataPoints.get(runStart));
+
+            if (Math.abs(currentVal - runStartVal) > EPSILON) {
+                // Value changed — end the previous run
+                if (runStart != i - 1) {
+                    // Add the last point of the previous constant run
+                    compressed.add(dataPoints.get(i - 1));
+                }
+                // Start a new run with the current point
+                compressed.add(dataPoints.get(i));
+                runStart = i;
+            } else if (i == dataPoints.size() - 1) {
+                // Last point — always include to close the final run
+                compressed.add(dataPoints.get(i));
+            }
+        }
+
+        return compressed;
+    }
+
+    private static double extractValue(final List<Object> dataPoint) {
+        return ((Number) dataPoint.get(1)).doubleValue();
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeriesTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeriesTest.java
@@ -7,10 +7,13 @@ package io.streamshub.mcp.common.dto.metrics;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -40,6 +43,7 @@ class MetricTimeSeriesTest {
         assertEquals(1, result.getFirst().dataPoints().size());
         assertEquals(1000L, result.getFirst().dataPoints().getFirst().get(0));
         assertEquals(42.0, result.getFirst().dataPoints().getFirst().get(1));
+        assertNull(result.getFirst().compressed());
     }
 
     @Test
@@ -53,10 +57,12 @@ class MetricTimeSeriesTest {
         List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
 
         assertEquals(1, result.size());
+        // All values are different, so no compression occurs
         assertEquals(3, result.getFirst().dataPoints().size());
         assertEquals(List.of(100L, 1.0), result.getFirst().dataPoints().get(0));
         assertEquals(List.of(200L, 2.0), result.getFirst().dataPoints().get(1));
         assertEquals(List.of(300L, 3.0), result.getFirst().dataPoints().get(2));
+        assertNull(result.getFirst().compressed());
     }
 
     @Test
@@ -112,5 +118,57 @@ class MetricTimeSeriesTest {
         assertEquals("z_metric", result.get(0).name());
         assertEquals("a_metric", result.get(1).name());
         assertEquals("m_metric", result.get(2).name());
+    }
+
+    @Test
+    void constantValuesAreCompressed() {
+        List<MetricSample> samples = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            samples.add(MetricSample.of("metric_a", Map.of("pod", "pod-0"),
+                0.0, Instant.ofEpochSecond(100 + i * 60)));
+        }
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertEquals(1, result.size());
+        MetricTimeSeries series = result.getFirst();
+        assertEquals(2, series.dataPoints().size());
+        assertEquals(Boolean.TRUE, series.compressed());
+        assertEquals(List.of(100L, 0.0), series.dataPoints().get(0));
+        assertEquals(List.of(6040L, 0.0), series.dataPoints().get(1));
+    }
+
+    @Test
+    void summaryIsPopulated() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of(), 10.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("metric_a", Map.of(), 20.0, Instant.ofEpochSecond(200)),
+            MetricSample.of("metric_a", Map.of(), 30.0, Instant.ofEpochSecond(300))
+        );
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertEquals(1, result.size());
+        TimeSeriesSummary summary = result.getFirst().summary();
+        assertNotNull(summary);
+        assertEquals(10.0, summary.min());
+        assertEquals(30.0, summary.max());
+        assertEquals(20.0, summary.avg(), 1e-9);
+        assertEquals(30.0, summary.latest());
+        assertEquals(20.0, summary.delta());
+        assertEquals(3, summary.originalDataPointCount());
+    }
+
+    @Test
+    void compressedFlagNullWhenNoCompression() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of(), 1.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("metric_a", Map.of(), 2.0, Instant.ofEpochSecond(200)),
+            MetricSample.of("metric_a", Map.of(), 3.0, Instant.ofEpochSecond(300))
+        );
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertNull(result.getFirst().compressed());
     }
 }

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeriesTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/MetricTimeSeriesTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link MetricTimeSeries}.
+ */
+class MetricTimeSeriesTest {
+
+    MetricTimeSeriesTest() {
+    }
+
+    @Test
+    void emptyInputReturnsEmptyList() {
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(List.of());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void singleSampleCreatesOneSeries() {
+        MetricSample sample = MetricSample.of("metric_a",
+            Map.of("pod", "pod-0"), 42.0, Instant.ofEpochSecond(1000));
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(List.of(sample));
+
+        assertEquals(1, result.size());
+        assertEquals("metric_a", result.getFirst().name());
+        assertEquals(Map.of("pod", "pod-0"), result.getFirst().labels());
+        assertEquals(1, result.getFirst().dataPoints().size());
+        assertEquals(1000L, result.getFirst().dataPoints().getFirst().get(0));
+        assertEquals(42.0, result.getFirst().dataPoints().getFirst().get(1));
+    }
+
+    @Test
+    void multipleSamplesSameNameAndLabelsGroupedIntoOneSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 2.0, Instant.ofEpochSecond(200)),
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 3.0, Instant.ofEpochSecond(300))
+        );
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertEquals(1, result.size());
+        assertEquals(3, result.getFirst().dataPoints().size());
+        assertEquals(List.of(100L, 1.0), result.getFirst().dataPoints().get(0));
+        assertEquals(List.of(200L, 2.0), result.getFirst().dataPoints().get(1));
+        assertEquals(List.of(300L, 3.0), result.getFirst().dataPoints().get(2));
+    }
+
+    @Test
+    void differentNamesCreateDistinctSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("metric_b", Map.of("pod", "pod-0"), 2.0, Instant.ofEpochSecond(100))
+        );
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertEquals(2, result.size());
+        assertEquals("metric_a", result.get(0).name());
+        assertEquals("metric_b", result.get(1).name());
+    }
+
+    @Test
+    void differentLabelsCreateDistinctSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("metric_a", Map.of("pod", "pod-1"), 2.0, Instant.ofEpochSecond(100))
+        );
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertEquals(2, result.size());
+        assertEquals(Map.of("pod", "pod-0"), result.get(0).labels());
+        assertEquals(Map.of("pod", "pod-1"), result.get(1).labels());
+    }
+
+    @Test
+    void samplesWithoutTimestampsUseZeroEpoch() {
+        MetricSample sample = MetricSample.of("metric_a", Map.of(), 5.0, null);
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(List.of(sample));
+
+        assertEquals(1, result.size());
+        assertEquals(0L, result.getFirst().dataPoints().getFirst().get(0));
+        assertEquals(5.0, result.getFirst().dataPoints().getFirst().get(1));
+    }
+
+    @Test
+    void orderingIsPreserved() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("z_metric", Map.of(), 1.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("a_metric", Map.of(), 2.0, Instant.ofEpochSecond(100)),
+            MetricSample.of("m_metric", Map.of(), 3.0, Instant.ofEpochSecond(100))
+        );
+
+        List<MetricTimeSeries> result = MetricTimeSeries.fromSamples(samples);
+
+        assertEquals(3, result.size());
+        assertEquals("z_metric", result.get(0).name());
+        assertEquals("a_metric", result.get(1).name());
+        assertEquals("m_metric", result.get(2).name());
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummaryTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummaryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link TimeSeriesSummary}.
+ */
+class TimeSeriesSummaryTest {
+
+    TimeSeriesSummaryTest() {
+    }
+
+    @Test
+    void nullInputReturnsNull() {
+        assertNull(TimeSeriesSummary.of(null));
+    }
+
+    @Test
+    void emptyInputReturnsNull() {
+        assertNull(TimeSeriesSummary.of(List.of()));
+    }
+
+    @Test
+    void singleDataPointSummary() {
+        List<List<Object>> dataPoints = List.of(List.of(100L, 42.0));
+
+        TimeSeriesSummary summary = TimeSeriesSummary.of(dataPoints);
+
+        assertEquals(42.0, summary.min());
+        assertEquals(42.0, summary.max());
+        assertEquals(42.0, summary.avg());
+        assertEquals(42.0, summary.latest());
+        assertEquals(0.0, summary.delta());
+        assertEquals(1, summary.originalDataPointCount());
+    }
+
+    @Test
+    void multipleDataPointsSummary() {
+        List<List<Object>> dataPoints = List.of(
+            List.of(100L, 10.0),
+            List.of(200L, 20.0),
+            List.of(300L, 30.0)
+        );
+
+        TimeSeriesSummary summary = TimeSeriesSummary.of(dataPoints);
+
+        assertEquals(10.0, summary.min());
+        assertEquals(30.0, summary.max());
+        assertEquals(20.0, summary.avg(), 1e-9);
+        assertEquals(30.0, summary.latest());
+        assertEquals(20.0, summary.delta());
+        assertEquals(3, summary.originalDataPointCount());
+    }
+
+    @Test
+    void constantValuesSummary() {
+        List<List<Object>> dataPoints = List.of(
+            List.of(100L, 5.0),
+            List.of(200L, 5.0),
+            List.of(300L, 5.0)
+        );
+
+        TimeSeriesSummary summary = TimeSeriesSummary.of(dataPoints);
+
+        assertEquals(5.0, summary.min());
+        assertEquals(5.0, summary.max());
+        assertEquals(5.0, summary.avg());
+        assertEquals(5.0, summary.latest());
+        assertEquals(0.0, summary.delta());
+        assertEquals(3, summary.originalDataPointCount());
+    }
+
+    @Test
+    void negativeDelta() {
+        List<List<Object>> dataPoints = List.of(
+            List.of(100L, 100.0),
+            List.of(200L, 50.0),
+            List.of(300L, 25.0)
+        );
+
+        TimeSeriesSummary summary = TimeSeriesSummary.of(dataPoints);
+
+        assertEquals(25.0, summary.min());
+        assertEquals(100.0, summary.max());
+        assertEquals(-75.0, summary.delta());
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/service/metrics/MetricsQueryServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/metrics/MetricsQueryServiceTest.java
@@ -70,7 +70,7 @@ class MetricsQueryServiceTest {
         List<String> metrics = List.of("metric_a");
 
         IllegalStateException ex = assertThrows(IllegalStateException.class,
-            () -> metricsQueryService.queryMetrics(targets, labels, metrics, null, null));
+            () -> metricsQueryService.queryMetrics(targets, labels, metrics, null, null, null, null));
         assertTrue(ex.getMessage().contains("No metrics provider configured"));
     }
 
@@ -87,7 +87,7 @@ class MetricsQueryServiceTest {
         List<String> metrics = List.of("metric_a");
 
         List<MetricSample> result = metricsQueryService.queryMetrics(
-            targets, labels, metrics, null, null);
+            targets, labels, metrics, null, null, null, null);
 
         assertEquals(expected, result);
 
@@ -109,7 +109,7 @@ class MetricsQueryServiceTest {
         labels.put("namespace", "ns");
         List<String> metrics = List.of("metric_a");
 
-        metricsQueryService.queryMetrics(targets, labels, metrics, 5, 30);
+        metricsQueryService.queryMetrics(targets, labels, metrics, 5, null, null, 30);
 
         ArgumentCaptor<MetricsQueryParams> captor = ArgumentCaptor.forClass(MetricsQueryParams.class);
         verify(metricsProvider).queryMetrics(captor.capture());
@@ -128,7 +128,7 @@ class MetricsQueryServiceTest {
         metricsQueryService.queryMetrics(
             List.of(PodTarget.of("ns", "pod")),
             Map.of("namespace", "ns"),
-            List.of("metric_a"), 5, null);
+            List.of("metric_a"), 5, null, null, null);
 
         ArgumentCaptor<MetricsQueryParams> captor = ArgumentCaptor.forClass(MetricsQueryParams.class);
         verify(metricsProvider).queryMetrics(captor.capture());

--- a/common/src/test/java/io/streamshub/mcp/common/service/metrics/MetricsQueryServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/metrics/MetricsQueryServiceTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+import io.streamshub.mcp.common.dto.metrics.PodTarget;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MetricsQueryService}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MetricsQueryServiceTest {
+
+    MetricsQueryServiceTest() {
+        // default constructor for checkstyle
+    }
+
+    @Mock
+    Instance<MetricsProvider> metricsProviderInstance;
+
+    @Mock
+    MetricsProvider metricsProvider;
+
+    private MetricsQueryService metricsQueryService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        metricsQueryService = new MetricsQueryService();
+        setField(metricsQueryService, "metricsProviderInstance", metricsProviderInstance);
+        setField(metricsQueryService, "providerName", "pod-scraping");
+        setField(metricsQueryService, "defaultStepSeconds", 60);
+
+        when(metricsProviderInstance.isUnsatisfied()).thenReturn(false);
+        when(metricsProviderInstance.get()).thenReturn(metricsProvider);
+    }
+
+    @Test
+    void providerUnsatisfiedThrows() {
+        when(metricsProviderInstance.isUnsatisfied()).thenReturn(true);
+
+        List<PodTarget> targets = List.of(PodTarget.of("ns", "pod"));
+        Map<String, String> labels = Map.of("namespace", "ns");
+        List<String> metrics = List.of("metric_a");
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> metricsQueryService.queryMetrics(targets, labels, metrics, null, null));
+        assertTrue(ex.getMessage().contains("No metrics provider configured"));
+    }
+
+    @Test
+    void instantQueryDelegatesToProvider() {
+        List<MetricSample> expected = List.of(
+            MetricSample.of("metric_a", Map.of("namespace", "ns"), 1.0));
+        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+            .thenReturn(expected);
+
+        List<PodTarget> targets = List.of(PodTarget.of("ns", "pod"));
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("namespace", "ns");
+        List<String> metrics = List.of("metric_a");
+
+        List<MetricSample> result = metricsQueryService.queryMetrics(
+            targets, labels, metrics, null, null);
+
+        assertEquals(expected, result);
+
+        ArgumentCaptor<MetricsQueryParams> captor = ArgumentCaptor.forClass(MetricsQueryParams.class);
+        verify(metricsProvider).queryMetrics(captor.capture());
+        MetricsQueryParams params = captor.getValue();
+        assertFalse(params.isRangeQuery());
+        assertEquals(metrics, params.metricNames());
+        assertEquals(1, params.podTargets().size());
+    }
+
+    @Test
+    void rangeQueryBuildsCorrectParams() {
+        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+            .thenReturn(List.of());
+
+        List<PodTarget> targets = List.of(PodTarget.of("ns", "pod"));
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("namespace", "ns");
+        List<String> metrics = List.of("metric_a");
+
+        metricsQueryService.queryMetrics(targets, labels, metrics, 5, 30);
+
+        ArgumentCaptor<MetricsQueryParams> captor = ArgumentCaptor.forClass(MetricsQueryParams.class);
+        verify(metricsProvider).queryMetrics(captor.capture());
+        MetricsQueryParams params = captor.getValue();
+        assertTrue(params.isRangeQuery());
+        assertNotNull(params.startTime());
+        assertNotNull(params.endTime());
+        assertEquals(30, params.stepSeconds());
+    }
+
+    @Test
+    void rangeQueryUsesDefaultStepWhenNotProvided() {
+        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+            .thenReturn(List.of());
+
+        metricsQueryService.queryMetrics(
+            List.of(PodTarget.of("ns", "pod")),
+            Map.of("namespace", "ns"),
+            List.of("metric_a"), 5, null);
+
+        ArgumentCaptor<MetricsQueryParams> captor = ArgumentCaptor.forClass(MetricsQueryParams.class);
+        verify(metricsProvider).queryMetrics(captor.capture());
+        assertEquals(60, captor.getValue().stepSeconds());
+    }
+
+    @Test
+    void providerNameReturnsConfiguredValue() {
+        assertEquals("pod-scraping", metricsQueryService.providerName());
+    }
+
+    private static void setField(final Object target, final String fieldName,
+                                  final Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilterTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link MetricLabelFilter}.
+ */
+class MetricLabelFilterTest {
+
+    MetricLabelFilterTest() {
+    }
+
+    @Test
+    void nullInputReturnsEmptyMap() {
+        Map<String, String> result = MetricLabelFilter.filterLabels(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void emptyMapReturnsEmptyMap() {
+        Map<String, String> result = MetricLabelFilter.filterLabels(Map.of());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void onlyInternalLabelsReturnsEmptyMap() {
+        Map<String, String> labels = Map.of(
+            "__name__", "kafka_metric",
+            "job", "kafka",
+            "instance", "10.0.0.1:9090",
+            "endpoint", "metrics",
+            "container", "kafka",
+            "prometheus", "monitoring/prometheus",
+            "service", "kafka-metrics"
+        );
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void domainLabelsAreKept() {
+        Map<String, String> labels = Map.of(
+            "namespace", "kafka-system",
+            "kind", "Kafka",
+            "strimzi_io_cluster", "my-cluster"
+        );
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertEquals(3, result.size());
+        assertEquals("kafka-system", result.get("namespace"));
+        assertEquals("Kafka", result.get("kind"));
+        assertEquals("my-cluster", result.get("strimzi_io_cluster"));
+    }
+
+    @Test
+    void podLabelIsKept() {
+        Map<String, String> labels = Map.of("pod", "my-cluster-kafka-0");
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertEquals(1, result.size());
+        assertEquals("my-cluster-kafka-0", result.get("pod"));
+    }
+
+    @Test
+    void mixedLabelsFiltersCorrectly() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("__name__", "kafka_metric");
+        labels.put("namespace", "kafka-system");
+        labels.put("job", "kafka");
+        labels.put("pod", "broker-0");
+        labels.put("instance", "10.0.0.1:9090");
+        labels.put("kind", "Kafka");
+
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertEquals(3, result.size());
+        assertEquals("kafka-system", result.get("namespace"));
+        assertEquals("broker-0", result.get("pod"));
+        assertEquals("Kafka", result.get("kind"));
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParserTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/util/metrics/PrometheusTextParserTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PrometheusTextParser}.
+ */
+class PrometheusTextParserTest {
+
+    PrometheusTextParserTest() {
+        // default constructor for checkstyle
+    }
+
+    @Test
+    void parseSimpleMetricWithoutLabels() {
+        String text = "http_requests_total 1027";
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(1, samples.size());
+        MetricSample sample = samples.get(0);
+        assertEquals("http_requests_total", sample.name());
+        assertEquals(1027.0, sample.value());
+        assertTrue(sample.labels().isEmpty());
+        assertNull(sample.timestamp());
+    }
+
+    @Test
+    void parseMetricWithLabels() {
+        String text = "http_requests_total{method=\"GET\",handler=\"/api\"} 1027";
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(1, samples.size());
+        MetricSample sample = samples.get(0);
+        assertEquals("http_requests_total", sample.name());
+        assertEquals(1027.0, sample.value());
+        assertEquals("GET", sample.labels().get("method"));
+        assertEquals("/api", sample.labels().get("handler"));
+    }
+
+    @Test
+    void parseMetricWithTimestamp() {
+        String text = "http_requests_total 1027 1395066363000";
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(1, samples.size());
+        MetricSample sample = samples.get(0);
+        assertEquals(1027.0, sample.value());
+        assertNotNull(sample.timestamp());
+        assertEquals(1395066363000L, sample.timestamp().toEpochMilli());
+    }
+
+    @Test
+    void parseSkipsCommentLines() {
+        String text = """
+            # HELP http_requests_total Total requests.
+            # TYPE http_requests_total counter
+            http_requests_total 1027
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(1, samples.size());
+        assertEquals("http_requests_total", samples.get(0).name());
+    }
+
+    @Test
+    void parseSkipsEmptyLines() {
+        String text = """
+            http_requests_total 100
+
+            http_errors_total 5
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(2, samples.size());
+    }
+
+    @Test
+    void parseReturnsEmptyForNullInput() {
+        assertTrue(PrometheusTextParser.parse(null).isEmpty());
+    }
+
+    @Test
+    void parseReturnsEmptyForBlankInput() {
+        assertTrue(PrometheusTextParser.parse("   ").isEmpty());
+    }
+
+    @Test
+    void parseSkipsMalformedLines() {
+        String text = """
+            valid_metric 42
+            no_value_here
+            another{broken
+            good_metric 99
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(2, samples.size());
+        assertEquals("valid_metric", samples.get(0).name());
+        assertEquals("good_metric", samples.get(1).name());
+    }
+
+    @Test
+    void parseFiltersMetricsByName() {
+        String text = """
+            metric_a 1
+            metric_b 2
+            metric_c 3
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text, Set.of("metric_a", "metric_c"));
+
+        assertEquals(2, samples.size());
+        assertEquals("metric_a", samples.get(0).name());
+        assertEquals("metric_c", samples.get(1).name());
+    }
+
+    @Test
+    void parseWithEmptyFilterReturnsAll() {
+        String text = """
+            metric_a 1
+            metric_b 2
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text, Set.of());
+
+        assertEquals(2, samples.size());
+    }
+
+    @Test
+    void parseWithNullFilterReturnsAll() {
+        String text = """
+            metric_a 1
+            metric_b 2
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text, null);
+
+        assertEquals(2, samples.size());
+    }
+
+    @Test
+    void parseHandlesEscapedLabelValues() {
+        String text = "metric{path=\"/api/v1\",desc=\"line\\\"quoted\\\"\"} 42";
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(1, samples.size());
+        assertEquals("/api/v1", samples.get(0).labels().get("path"));
+        assertEquals("line\"quoted\"", samples.get(0).labels().get("desc"));
+    }
+
+    @Test
+    void parseMultipleMetricsFromRealOutput() {
+        String text = """
+            # HELP jvm_memory_used_bytes Used bytes of a given JVM memory area.
+            # TYPE jvm_memory_used_bytes gauge
+            jvm_memory_used_bytes{area="heap"} 1.073741824E9
+            jvm_memory_used_bytes{area="nonheap"} 1.34217728E8
+            # HELP kafka_server_replica_manager_under_replicated_partitions Value
+            # TYPE kafka_server_replica_manager_under_replicated_partitions gauge
+            kafka_server_replica_manager_under_replicated_partitions 0.0
+            """;
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(3, samples.size());
+        assertEquals("jvm_memory_used_bytes", samples.get(0).name());
+        assertEquals("heap", samples.get(0).labels().get("area"));
+        assertEquals(1.073741824E9, samples.get(0).value());
+    }
+
+    @Test
+    void parseHandlesFloatingPointValues() {
+        String text = "metric_value 3.14159";
+        List<MetricSample> samples = PrometheusTextParser.parse(text);
+
+        assertEquals(1, samples.size());
+        assertEquals(3.14159, samples.get(0).value(), 0.00001);
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/util/metrics/TimeSeriesCompressorTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/util/metrics/TimeSeriesCompressorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link TimeSeriesCompressor}.
+ */
+class TimeSeriesCompressorTest {
+
+    TimeSeriesCompressorTest() {
+    }
+
+    @Test
+    void emptyListReturnsEmpty() {
+        List<List<Object>> result = TimeSeriesCompressor.compress(List.of());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void singlePointReturnsSinglePoint() {
+        List<List<Object>> input = List.of(List.of(100L, 5.0));
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+        assertEquals(1, result.size());
+        assertEquals(List.of(100L, 5.0), result.getFirst());
+    }
+
+    @Test
+    void twoPointsReturnedAsIs() {
+        List<List<Object>> input = List.of(
+            List.of(100L, 5.0),
+            List.of(200L, 5.0)
+        );
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void allConstantValuesCompressedToFirstAndLast() {
+        List<List<Object>> input = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            input.add(List.of((long) (i * 60), 42.0));
+        }
+
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+
+        assertEquals(2, result.size());
+        assertEquals(List.of(0L, 42.0), result.get(0));
+        assertEquals(List.of(5940L, 42.0), result.get(1));
+    }
+
+    @Test
+    void allDifferentValuesNoCompression() {
+        List<List<Object>> input = List.of(
+            List.of(100L, 1.0),
+            List.of(200L, 2.0),
+            List.of(300L, 3.0),
+            List.of(400L, 4.0)
+        );
+
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+
+        assertEquals(4, result.size());
+    }
+
+    @Test
+    void constantRunThenChangingValues() {
+        List<List<Object>> input = List.of(
+            List.of(100L, 0.0),
+            List.of(200L, 0.0),
+            List.of(300L, 0.0),
+            List.of(400L, 5.0),
+            List.of(500L, 10.0)
+        );
+
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+
+        assertEquals(4, result.size());
+        assertEquals(List.of(100L, 0.0), result.get(0));
+        assertEquals(List.of(300L, 0.0), result.get(1));
+        assertEquals(List.of(400L, 5.0), result.get(2));
+        assertEquals(List.of(500L, 10.0), result.get(3));
+    }
+
+    @Test
+    void changingValuesThenConstantRun() {
+        List<List<Object>> input = List.of(
+            List.of(100L, 1.0),
+            List.of(200L, 2.0),
+            List.of(300L, 5.0),
+            List.of(400L, 5.0),
+            List.of(500L, 5.0)
+        );
+
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+
+        assertEquals(4, result.size());
+        assertEquals(List.of(100L, 1.0), result.get(0));
+        assertEquals(List.of(200L, 2.0), result.get(1));
+        assertEquals(List.of(300L, 5.0), result.get(2));
+        assertEquals(List.of(500L, 5.0), result.get(3));
+    }
+
+    @Test
+    void multipleConstantRuns() {
+        List<List<Object>> input = List.of(
+            List.of(100L, 0.0),
+            List.of(200L, 0.0),
+            List.of(300L, 0.0),
+            List.of(400L, 5.0),
+            List.of(500L, 5.0),
+            List.of(600L, 5.0),
+            List.of(700L, 0.0),
+            List.of(800L, 0.0)
+        );
+
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+
+        assertEquals(6, result.size());
+        assertEquals(List.of(100L, 0.0), result.get(0));
+        assertEquals(List.of(300L, 0.0), result.get(1));
+        assertEquals(List.of(400L, 5.0), result.get(2));
+        assertEquals(List.of(600L, 5.0), result.get(3));
+        assertEquals(List.of(700L, 0.0), result.get(4));
+        assertEquals(List.of(800L, 0.0), result.get(5));
+    }
+
+    @Test
+    void valuesWithinEpsilonTreatedAsEqual() {
+        List<List<Object>> input = List.of(
+            List.of(100L, 1.0),
+            List.of(200L, 1.0 + 1e-10),
+            List.of(300L, 1.0 - 1e-10)
+        );
+
+        List<List<Object>> result = TimeSeriesCompressor.compress(input);
+
+        assertEquals(2, result.size());
+        assertEquals(List.of(100L, 1.0), result.get(0));
+        assertEquals(List.of(300L, 1.0 - 1e-10), result.get(1));
+    }
+}

--- a/dev/manifests/prometheus/additional-properties/kustomization.yaml
+++ b/dev/manifests/prometheus/additional-properties/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namespace: monitoring
+
 resources:
-  - strimzi-operator
-  - kafka
+  - prometheus-additional.yaml

--- a/dev/manifests/prometheus/additional-properties/prometheus-additional.yaml
+++ b/dev/manifests/prometheus/additional-properties/prometheus-additional.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: additional-scrape-configs
+type: Opaque
+stringData:
+  prometheus-additional.yaml: |
+    - job_name: kubernetes-cadvisor
+      honor_labels: true
+      scrape_interval: 10s
+      scrape_timeout: 10s
+      metrics_path: /metrics/cadvisor
+      scheme: https
+      kubernetes_sd_configs:
+      - role: node
+        namespaces:
+          names: []
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      relabel_configs:
+      - separator: ;
+        regex: __meta_kubernetes_node_label_(.+)
+        replacement: $1
+        action: labelmap
+      - separator: ;
+        regex: (.*)
+        target_label: __address__
+        replacement: kubernetes.default.svc:443
+        action: replace
+      - source_labels: [__meta_kubernetes_node_name]
+        separator: ;
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        action: replace
+      - source_labels: [__meta_kubernetes_node_name]
+        separator: ;
+        regex: (.*)
+        target_label: node_name
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        separator: ;
+        regex: (.*)
+        target_label: node_ip
+        replacement: $1
+        action: replace
+      metric_relabel_configs:
+      - source_labels: [container, __name__]
+        separator: ;
+        regex: POD;container_(network).*
+        target_label: container
+        replacement: $1
+        action: replace
+      - source_labels: [container]
+        separator: ;
+        regex: POD
+        replacement: $1
+        action: drop
+      - source_labels: [container]
+        separator: ;
+        regex: ^$
+        replacement: $1
+        action: drop
+      - source_labels: [__name__]
+        separator: ;
+        regex: container_(network_tcp_usage_total|tasks_state|memory_failures_total|network_udp_usage_total)
+        replacement: $1
+        action: drop
+
+    - job_name: kubernetes-nodes-kubelet
+      scrape_interval: 10s
+      scrape_timeout: 10s
+      scheme: https
+      kubernetes_sd_configs:
+      - role: node
+        namespaces:
+          names: []
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics

--- a/dev/manifests/prometheus/instance/kustomization.yaml
+++ b/dev/manifests/prometheus/instance/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - prometheus.yaml
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      name: prometheus-server
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: monitoring

--- a/dev/manifests/prometheus/instance/prometheus.yaml
+++ b/dev/manifests/prometheus/instance/prometheus.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-server
+  labels:
+    app: strimzi
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-server
+  labels:
+    app: strimzi
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-server
+  labels:
+    app: strimzi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-server
+    namespace: myproject
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  serviceAccountName: prometheus-server
+  podMonitorSelector:
+    matchLabels:
+      mcp: strimzi
+  podMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
+  serviceMonitorNamespaceSelector: {}
+  resources:
+    requests:
+      memory: 400Mi
+  enableAdminAPI: false
+  ruleSelector:
+    matchLabels:
+      role: alert-rules
+      mcp: strimzi
+  alerting:
+    alertmanagers:
+    - namespace: myproject
+      name: alertmanager
+      port: alertmanager
+  additionalScrapeConfigs:
+    name: additional-scrape-configs
+    key: prometheus-additional.yaml

--- a/dev/manifests/prometheus/kustomization.yaml
+++ b/dev/manifests/prometheus/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - strimzi-operator
-  - kafka
+  - operator
+  - instance
+  - additional-properties

--- a/dev/manifests/prometheus/operator/kustomization.yaml
+++ b/dev/manifests/prometheus/operator/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/bundle.yaml
+  - namespace.yaml
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      name: prometheus-operator
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: monitoring

--- a/dev/manifests/prometheus/operator/namespace.yaml
+++ b/dev/manifests/prometheus/operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/dev/manifests/strimzi/kafka-kubernetes/kustomization.yaml
+++ b/dev/manifests/strimzi/kafka-kubernetes/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../kafka
+
+patches:
+  - target:
+      kind: Kafka
+      name: mcp-cluster
+    patch: |-
+      - op: replace
+        path: /spec/kafka/listeners
+        value:
+          - name: plain
+            port: 9092
+            type: internal
+            tls: false
+          - name: tls
+            port: 9093
+            type: internal
+            tls: true
+            authentication:
+              type: tls
+          - name: external
+            port: 9666
+            type: nodeport
+            tls: true
+            authentication:
+              type: tls
+          - name: console
+            port: 9777
+            tls: true
+            type: internal
+            authentication:
+              type: scram-sha-512

--- a/dev/manifests/strimzi/strimzi-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/dev/manifests/strimzi/strimzi-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: strimzi
   labels:
     app: strimzi
-    namespace: strimzi
 data:
   log4j2.properties: |
     name = COConfig

--- a/dev/manifests/strimzi/strimzi-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/dev/manifests/strimzi/strimzi-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -55,16 +55,19 @@ spec:
               value: |
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
                 4.1.1=quay.io/strimzi/kafka:latest-kafka-4.1.1
+                4.1.2=quay.io/strimzi/kafka:latest-kafka-4.1.2
                 4.2.0=quay.io/strimzi/kafka:latest-kafka-4.2.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
                 4.1.1=quay.io/strimzi/kafka:latest-kafka-4.1.1
+                4.1.2=quay.io/strimzi/kafka:latest-kafka-4.1.2
                 4.2.0=quay.io/strimzi/kafka:latest-kafka-4.2.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
                 4.1.1=quay.io/strimzi/kafka:latest-kafka-4.1.1
+                4.1.2=quay.io/strimzi/kafka:latest-kafka-4.1.2
                 4.2.0=quay.io/strimzi/kafka:latest-kafka-4.2.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: quay.io/strimzi/operator:latest

--- a/dev/manifests/strimzi/strimzi-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/dev/manifests/strimzi/strimzi-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-cluster-operator
-  namespace: strimzi
   labels:
     app: strimzi
 spec:
@@ -41,48 +40,44 @@ spec:
               mountPath: /opt/strimzi/custom-config/
           env:
             - name: STRIMZI_NAMESPACE
-              # Cluster-wide CO
               value: "*"
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
             - name: STRIMZI_OPERATION_TIMEOUT_MS
               value: "300000"
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: quay.io/strimzi/kafka:latest-kafka-4.2.0
+              value: quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: quay.io/strimzi/kafka:latest-kafka-4.2.0
+              value: quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
             - name: STRIMZI_KAFKA_IMAGES
               value: |
-                4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
-                4.1.1=quay.io/strimzi/kafka:latest-kafka-4.1.1
-                4.1.2=quay.io/strimzi/kafka:latest-kafka-4.1.2
-                4.2.0=quay.io/strimzi/kafka:latest-kafka-4.2.0
+                4.1.0=quay.io/strimzi/kafka:0.51.0-kafka-4.1.0
+                4.1.1=quay.io/strimzi/kafka:0.51.0-kafka-4.1.1
+                4.2.0=quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
-                4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
-                4.1.1=quay.io/strimzi/kafka:latest-kafka-4.1.1
-                4.1.2=quay.io/strimzi/kafka:latest-kafka-4.1.2
-                4.2.0=quay.io/strimzi/kafka:latest-kafka-4.2.0
+                4.1.0=quay.io/strimzi/kafka:0.51.0-kafka-4.1.0
+                4.1.1=quay.io/strimzi/kafka:0.51.0-kafka-4.1.1
+                4.2.0=quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
-                4.1.0=quay.io/strimzi/kafka:latest-kafka-4.1.0
-                4.1.1=quay.io/strimzi/kafka:latest-kafka-4.1.1
-                4.1.2=quay.io/strimzi/kafka:latest-kafka-4.1.2
-                4.2.0=quay.io/strimzi/kafka:latest-kafka-4.2.0
+                4.1.0=quay.io/strimzi/kafka:0.51.0-kafka-4.1.0
+                4.1.1=quay.io/strimzi/kafka:0.51.0-kafka-4.1.1
+                4.2.0=quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:latest
+              value: quay.io/strimzi/operator:0.51.0
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:latest
+              value: quay.io/strimzi/operator:0.51.0
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: quay.io/strimzi/operator:latest
+              value: quay.io/strimzi/operator:0.51.0
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
               value: quay.io/strimzi/kafka-bridge:0.33.1
             - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-              value: quay.io/strimzi/kaniko-executor:latest
+              value: quay.io/strimzi/kaniko-executor:0.51.0
             - name: STRIMZI_DEFAULT_BUILDAH_IMAGE
-              value: quay.io/strimzi/buildah:latest
+              value: quay.io/strimzi/buildah:0.51.0
             - name: STRIMZI_DEFAULT_MAVEN_BUILDER
-              value: quay.io/strimzi/maven-builder:latest
+              value: quay.io/strimzi/maven-builder:0.51.0
             - name: STRIMZI_OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/dev/manifests/strimzi/strimzi-operator/kustomization.yaml
+++ b/dev/manifests/strimzi/strimzi-operator/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namespace: strimzi
+
 resources:
   - 000-Namespace.yaml
   - 000-Lease-strimzi-cluster-operator.yaml

--- a/dev/scripts/setup-strimzi.sh
+++ b/dev/scripts/setup-strimzi.sh
@@ -5,11 +5,16 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EXAMPLES_DIR="$SCRIPT_DIR/../manifests/strimzi"
+STRIMZI_DIR="$SCRIPT_DIR/../manifests/strimzi"
+PROMETHEUS_DIR="$SCRIPT_DIR/../manifests/prometheus"
 
 OPERATOR_NS="strimzi"
 KAFKA_NS="strimzi-kafka"
 CLUSTER_NAME="mcp-cluster"
+MONITORING_NS="monitoring"
+
+INSTALL_PROMETHEUS=false
+OCP=false
 
 # Colors
 RED='\033[0;31m'
@@ -35,11 +40,51 @@ check_kubectl() {
     log_success "kubectl connected to cluster"
 }
 
+deploy_prometheus() {
+    log_info "Deploying Prometheus operator and instance..."
+    kubectl apply --server-side -k "$PROMETHEUS_DIR/operator/"
+
+    log_info "Waiting for Prometheus operator to be ready..."
+    kubectl wait --for=condition=Available \
+        deployment/prometheus-operator \
+        -n "$MONITORING_NS" \
+        --timeout=120s
+    log_success "Prometheus operator is ready"
+
+    kubectl apply -k "$PROMETHEUS_DIR/additional-properties/"
+    kubectl apply -k "$PROMETHEUS_DIR/instance/"
+
+    log_info "Waiting for Prometheus instance to be ready..."
+    kubectl wait --for=condition=Available \
+        prometheus/prometheus \
+        -n "$MONITORING_NS" \
+        --timeout=120s 2>/dev/null || \
+    kubectl rollout status statefulset/prometheus-prometheus \
+        -n "$MONITORING_NS" \
+        --timeout=120s 2>/dev/null || true
+    log_success "Prometheus is ready"
+}
+
+teardown_prometheus() {
+    log_info "Removing Prometheus instance..."
+    kubectl delete -k "$PROMETHEUS_DIR/instance/" --ignore-not-found
+    kubectl delete -k "$PROMETHEUS_DIR/additional-properties/" --ignore-not-found
+
+    log_info "Removing Prometheus operator..."
+    kubectl delete -k "$PROMETHEUS_DIR/operator/" --ignore-not-found
+
+    log_success "Prometheus teardown complete"
+}
+
 deploy() {
     check_kubectl
 
+    if [ "$INSTALL_PROMETHEUS" = true ]; then
+        deploy_prometheus
+    fi
+
     log_info "Deploying Strimzi operator..."
-    kubectl apply -k "$EXAMPLES_DIR/strimzi-operator/"
+    kubectl apply -k "$STRIMZI_DIR/strimzi-operator/"
 
     log_info "Waiting for Strimzi operator to be ready..."
     kubectl wait --for=condition=Available \
@@ -49,7 +94,13 @@ deploy() {
     log_success "Strimzi operator is ready"
 
     log_info "Deploying Kafka cluster '$CLUSTER_NAME'..."
-    kubectl apply -k "$EXAMPLES_DIR/kafka/"
+    if [ "$OCP" = true ]; then
+        log_info "Using OpenShift route listener"
+        kubectl apply -k "$STRIMZI_DIR/kafka/"
+    else
+        log_info "Using NodePort listener"
+        kubectl apply -k "$STRIMZI_DIR/kafka-kubernetes/"
+    fi
 
     log_info "Waiting for Kafka cluster to be ready (this may take a few minutes)..."
     kubectl wait kafka/"$CLUSTER_NAME" \
@@ -59,13 +110,19 @@ deploy() {
     log_success "Kafka cluster '$CLUSTER_NAME' is ready"
 
     echo ""
-    log_success "Strimzi deployment complete"
+    log_success "Deployment complete"
     echo ""
+    if [ "$INSTALL_PROMETHEUS" = true ]; then
+        echo "Monitoring namespace: $MONITORING_NS"
+    fi
     echo "Operator namespace:  $OPERATOR_NS"
     echo "Kafka namespace:     $KAFKA_NS"
     echo "Cluster name:        $CLUSTER_NAME"
     echo ""
     echo "Verify with:"
+    if [ "$INSTALL_PROMETHEUS" = true ]; then
+        echo "  kubectl get pods -n $MONITORING_NS"
+    fi
     echo "  kubectl get pods -n $OPERATOR_NS"
     echo "  kubectl get pods -n $KAFKA_NS"
     echo "  kubectl get kafka -n $KAFKA_NS"
@@ -75,15 +132,41 @@ teardown() {
     check_kubectl
 
     log_info "Removing Kafka cluster..."
-    kubectl delete -k "$EXAMPLES_DIR/kafka/" --ignore-not-found
+    if [ "$OCP" = true ]; then
+        kubectl delete -k "$STRIMZI_DIR/kafka/" --ignore-not-found
+    else
+        kubectl delete -k "$STRIMZI_DIR/kafka-kubernetes/" --ignore-not-found
+    fi
 
     log_info "Removing Strimzi operator..."
-    kubectl delete -k "$EXAMPLES_DIR/strimzi-operator/" --ignore-not-found
+    kubectl delete -k "$STRIMZI_DIR/strimzi-operator/" --ignore-not-found
 
-    log_success "Strimzi teardown complete"
+    if [ "$INSTALL_PROMETHEUS" = true ]; then
+        teardown_prometheus
+    fi
+
+    log_success "Teardown complete"
 }
 
-case "${1:-deploy}" in
+COMMAND="${1:-deploy}"
+shift || true
+
+for arg in "$@"; do
+    case "$arg" in
+        "--prometheus")
+            INSTALL_PROMETHEUS=true
+            ;;
+        "--ocp")
+            OCP=true
+            ;;
+        *)
+            log_error "Unknown option: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+case "$COMMAND" in
     "deploy"|"up")
         deploy
         ;;
@@ -91,15 +174,19 @@ case "${1:-deploy}" in
         teardown
         ;;
     "help"|"-h"|"--help")
-        echo "Usage: $0 [command]"
+        echo "Usage: $0 [command] [options]"
         echo ""
         echo "Commands:"
         echo "  deploy   - Deploy Strimzi operator and Kafka cluster (default)"
         echo "  teardown - Remove Strimzi operator and Kafka cluster"
         echo "  help     - Show this help"
+        echo ""
+        echo "Options:"
+        echo "  --ocp         Use OpenShift route listener (default: NodePort)"
+        echo "  --prometheus  Also deploy/remove Prometheus for metrics collection"
         ;;
     *)
-        log_error "Unknown command: $1"
+        log_error "Unknown command: $COMMAND"
         echo "Use '$0 help' for usage information"
         exit 1
         ;;

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.streamshub</groupId>
+        <artifactId>streamshub-mcp</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>streamshub-metrics-prometheus</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.streamshub</groupId>
+            <artifactId>streamshub-mcp-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -29,4 +29,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/dto/PrometheusResponse.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/dto/PrometheusResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DTO for deserializing Prometheus HTTP API JSON responses.
+ * Covers both instant and range query result formats.
+ *
+ * @param status the response status (e.g. "success")
+ * @param data   the response data payload
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PrometheusResponse(
+    @JsonProperty("status") String status,
+    @JsonProperty("data") PrometheusData data
+) {
+
+    /**
+     * The data payload of a Prometheus response.
+     *
+     * @param resultType the result type ("vector" for instant, "matrix" for range)
+     * @param result     the list of result entries
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record PrometheusData(
+        @JsonProperty("resultType") String resultType,
+        @JsonProperty("result") List<PrometheusResult> result
+    ) {
+    }
+
+    /**
+     * A single result entry containing metric labels and value(s).
+     * For instant queries, {@code value} is populated.
+     * For range queries, {@code values} is populated.
+     *
+     * @param metric the metric labels as key-value pairs
+     * @param value  the single value for instant queries (a two-element array: [timestamp, value])
+     * @param values the list of values for range queries (each a two-element array: [timestamp, value])
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record PrometheusResult(
+        @JsonProperty("metric") Map<String, String> metric,
+        @JsonProperty("value") List<Object> value,
+        @JsonProperty("values") List<List<Object>> values
+    ) {
+    }
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusAuthFilter.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusAuthFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.service;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * JAX-RS client request filter that adds authentication to Prometheus API calls.
+ * Supports service account token, explicit bearer token, and no-auth modes.
+ * Basic auth and mTLS are handled natively by Quarkus REST client properties.
+ *
+ * <p>Registered on {@link PrometheusClient} via {@code @RegisterProvider},
+ * so it only applies to Prometheus API calls.</p>
+ */
+public class PrometheusAuthFilter implements ClientRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(PrometheusAuthFilter.class);
+
+    private static final String AUTH_MODE_KEY = "mcp.metrics.prometheus.auth-mode";
+    private static final String BEARER_TOKEN_KEY = "mcp.metrics.prometheus.bearer-token";
+    private static final String SA_TOKEN_PATH_KEY = "mcp.metrics.prometheus.sa-token-path";
+    private static final String DEFAULT_SA_TOKEN_PATH =
+        "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+    PrometheusAuthFilter() {
+        // package-private no-arg constructor for CDI
+    }
+
+    @Override
+    public void filter(final ClientRequestContext requestContext) throws IOException {
+        String authMode = ConfigProvider.getConfig()
+            .getOptionalValue(AUTH_MODE_KEY, String.class)
+            .orElse("none")
+            .toLowerCase(Locale.ROOT);
+
+        switch (authMode) {
+            case "sa-token":
+                addServiceAccountToken(requestContext);
+                break;
+            case "bearer-token":
+                addBearerToken(requestContext);
+                break;
+            case "basic":
+                // Basic auth is handled by Quarkus REST client properties:
+                // quarkus.rest-client.prometheus.username / password
+                break;
+            case "none":
+                break;
+            default:
+                LOG.warnf("Unknown Prometheus auth mode: '%s'. No authentication applied.", authMode);
+                break;
+        }
+    }
+
+    private void addServiceAccountToken(final ClientRequestContext requestContext) {
+        String tokenPath = ConfigProvider.getConfig()
+            .getOptionalValue(SA_TOKEN_PATH_KEY, String.class)
+            .orElse(DEFAULT_SA_TOKEN_PATH);
+
+        try {
+            String token = Files.readString(Path.of(tokenPath)).trim();
+            requestContext.getHeaders().putSingle("Authorization", "Bearer " + token);
+        } catch (IOException e) {
+            LOG.warnf("Failed to read service account token from '%s': %s", tokenPath, e.getMessage());
+        }
+    }
+
+    private void addBearerToken(final ClientRequestContext requestContext) {
+        Optional<String> token = ConfigProvider.getConfig()
+            .getOptionalValue(BEARER_TOKEN_KEY, String.class);
+
+        if (token.isPresent() && !token.get().isBlank()) {
+            requestContext.getHeaders().putSingle("Authorization", "Bearer " + token.get().trim());
+        } else {
+            LOG.warn("Bearer token auth mode selected but no token configured."
+                + " Set '" + BEARER_TOKEN_KEY + "' property.");
+        }
+    }
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusClient.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusClient.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.service;
+
+import io.streamshub.mcp.metrics.prometheus.dto.PrometheusResponse;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * REST client for the Prometheus HTTP API.
+ * Supports both instant and range queries.
+ */
+@Path("/api/v1")
+@RegisterRestClient(configKey = "prometheus")
+@RegisterProvider(PrometheusAuthFilter.class)
+public interface PrometheusClient {
+
+    /**
+     * Executes an instant query at the current time or at a specific timestamp.
+     *
+     * @param query the PromQL query expression
+     * @param time  optional evaluation timestamp (RFC3339 or Unix timestamp)
+     * @return the Prometheus response containing query results
+     */
+    @GET
+    @Path("/query")
+    PrometheusResponse instantQuery(@QueryParam("query") String query,
+                                     @QueryParam("time") String time);
+
+    /**
+     * Executes a range query over a time window.
+     *
+     * @param query the PromQL query expression
+     * @param start the range start time (RFC3339 or Unix timestamp)
+     * @param end   the range end time (RFC3339 or Unix timestamp)
+     * @param step  the query resolution step (e.g. "60s")
+     * @return the Prometheus response containing query results
+     */
+    @GET
+    @Path("/query_range")
+    PrometheusResponse rangeQuery(@QueryParam("query") String query,
+                                   @QueryParam("start") String start,
+                                   @QueryParam("end") String end,
+                                   @QueryParam("step") String step);
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProvider.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProvider.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.service;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+import io.streamshub.mcp.common.service.metrics.MetricsProvider;
+import io.streamshub.mcp.metrics.prometheus.dto.PrometheusResponse;
+import io.streamshub.mcp.metrics.prometheus.util.PromQLSanitizer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Metrics provider that queries a Prometheus-compatible API (Prometheus, Thanos, etc.)
+ * using PromQL. Supports both instant and range queries.
+ */
+@ApplicationScoped
+@LookupIfProperty(name = "mcp.metrics.provider", stringValue = "streamshub-prometheus")
+public class PrometheusMetricsProvider implements MetricsProvider {
+
+    private static final Logger LOG = Logger.getLogger(PrometheusMetricsProvider.class);
+
+    @Inject
+    @RestClient
+    Instance<PrometheusClient> prometheusClientInstance;
+
+    PrometheusMetricsProvider() {
+        // package-private no-arg constructor for CDI
+    }
+
+    @Override
+    public List<MetricSample> queryMetrics(final MetricsQueryParams params) {
+        if (prometheusClientInstance.isUnsatisfied()) {
+            throw new IllegalStateException(
+                "Prometheus REST client is not available. Check REST client configuration.");
+        }
+
+        PrometheusClient client = prometheusClientInstance.get();
+        String promql = buildPromQL(params.metricNames(), params.labelMatchers());
+
+        LOG.debugf("Executing PromQL query: %s", promql);
+
+        PrometheusResponse response;
+        if (params.isRangeQuery()) {
+            String start = String.valueOf(params.startTime().getEpochSecond());
+            String end = String.valueOf(params.endTime().getEpochSecond());
+            String step = params.stepSeconds() + "s";
+            response = client.rangeQuery(promql, start, end, step);
+        } else {
+            response = client.instantQuery(promql, null);
+        }
+
+        return convertResponse(response);
+    }
+
+    /**
+     * Builds a PromQL query from metric names and label matchers.
+     * Single metric: {@code metric_name{label1="val1"}}
+     * Multiple metrics: {@code {__name__=~"m1|m2",label1="val1"}}
+     *
+     * @param metricNames   the metric names to query
+     * @param labelMatchers the label matchers to apply
+     * @return the PromQL query string
+     */
+    String buildPromQL(final List<String> metricNames, final Map<String, String> labelMatchers) {
+        StringBuilder query = new StringBuilder();
+
+        if (metricNames == null || metricNames.isEmpty()) {
+            query.append("{}");
+            return query.toString();
+        }
+
+        if (metricNames.size() == 1) {
+            query.append(PromQLSanitizer.sanitizeMetricName(metricNames.get(0)));
+            appendLabelMatchers(query, labelMatchers);
+        } else {
+            String nameRegex = metricNames.stream()
+                .map(PromQLSanitizer::sanitizeMetricName)
+                .collect(Collectors.joining("|"));
+            query.append("{__name__=~\"").append(nameRegex).append("\"");
+            if (labelMatchers != null && !labelMatchers.isEmpty()) {
+                appendLabelMatchersInline(query, labelMatchers);
+            }
+            query.append("}");
+        }
+
+        return query.toString();
+    }
+
+    private void appendLabelMatchers(final StringBuilder query,
+                                      final Map<String, String> labelMatchers) {
+        if (labelMatchers == null || labelMatchers.isEmpty()) {
+            return;
+        }
+
+        query.append("{");
+        boolean first = true;
+        for (Map.Entry<String, String> entry : labelMatchers.entrySet()) {
+            if (!first) {
+                query.append(",");
+            }
+            query.append(PromQLSanitizer.sanitizeLabelName(entry.getKey()));
+            query.append("=\"");
+            query.append(PromQLSanitizer.sanitizeLabelValue(entry.getValue()));
+            query.append("\"");
+            first = false;
+        }
+        query.append("}");
+    }
+
+    private void appendLabelMatchersInline(final StringBuilder query,
+                                            final Map<String, String> labelMatchers) {
+        for (Map.Entry<String, String> entry : labelMatchers.entrySet()) {
+            query.append(",");
+            query.append(PromQLSanitizer.sanitizeLabelName(entry.getKey()));
+            query.append("=\"");
+            query.append(PromQLSanitizer.sanitizeLabelValue(entry.getValue()));
+            query.append("\"");
+        }
+    }
+
+    private List<MetricSample> convertResponse(final PrometheusResponse response) {
+        if (response == null || response.data() == null || response.data().result() == null) {
+            return List.of();
+        }
+
+        if (!"success".equals(response.status())) {
+            LOG.warnf("Prometheus query returned non-success status: %s", response.status());
+            return List.of();
+        }
+
+        List<MetricSample> samples = new ArrayList<>();
+
+        for (PrometheusResponse.PrometheusResult result : response.data().result()) {
+            Map<String, String> labels = result.metric();
+            String metricName = labels != null ? labels.getOrDefault("__name__", "") : "";
+
+            if (result.values() != null) {
+                // Range query result (matrix)
+                for (List<Object> valueEntry : result.values()) {
+                    addSample(samples, metricName, labels, valueEntry);
+                }
+            } else if (result.value() != null) {
+                // Instant query result (vector)
+                addSample(samples, metricName, labels, result.value());
+            }
+        }
+
+        return samples;
+    }
+
+    private void addSample(final List<MetricSample> samples, final String metricName,
+                            final Map<String, String> labels, final List<Object> valueEntry) {
+        if (valueEntry.size() < 2) {
+            return;
+        }
+
+        try {
+            double timestamp = ((Number) valueEntry.get(0)).doubleValue();
+            double value = Double.parseDouble(String.valueOf(valueEntry.get(1)));
+            Instant instant = Instant.ofEpochSecond((long) timestamp);
+            samples.add(MetricSample.of(metricName, labels, value, instant));
+        } catch (Exception e) {
+            LOG.debugf("Failed to parse Prometheus value entry: %s", e.getMessage());
+        }
+    }
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProvider.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProvider.java
@@ -8,6 +8,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
 import io.streamshub.mcp.common.service.metrics.MetricsProvider;
+import io.streamshub.mcp.common.util.metrics.MetricLabelFilter;
 import io.streamshub.mcp.metrics.prometheus.dto.PrometheusResponse;
 import io.streamshub.mcp.metrics.prometheus.util.PromQLSanitizer;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -171,7 +172,8 @@ public class PrometheusMetricsProvider implements MetricsProvider {
             double timestamp = ((Number) valueEntry.get(0)).doubleValue();
             double value = Double.parseDouble(String.valueOf(valueEntry.get(1)));
             Instant instant = Instant.ofEpochSecond((long) timestamp);
-            samples.add(MetricSample.of(metricName, labels, value, instant));
+            samples.add(MetricSample.of(metricName, MetricLabelFilter.filterLabels(labels),
+                value, instant));
         } catch (Exception e) {
             LOG.debugf("Failed to parse Prometheus value entry: %s", e.getMessage());
         }

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/util/PromQLSanitizer.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/util/PromQLSanitizer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Sanitizes user-supplied values before interpolating them into PromQL queries.
+ * Prevents PromQL injection by validating metric names and label names against
+ * the Prometheus naming specification, and by escaping special characters in
+ * label values.
+ */
+public final class PromQLSanitizer {
+
+    /** Valid Prometheus metric name pattern: starts with letter, underscore, or colon. */
+    private static final Pattern METRIC_NAME_PATTERN =
+        Pattern.compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$");
+
+    /** Valid Prometheus label name pattern: starts with letter or underscore. */
+    private static final Pattern LABEL_NAME_PATTERN =
+        Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
+
+    private PromQLSanitizer() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Validates a metric name against the Prometheus naming specification.
+     *
+     * @param name the metric name to validate
+     * @return the validated metric name
+     * @throws IllegalArgumentException if the name is invalid
+     */
+    public static String sanitizeMetricName(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Metric name must not be null or empty");
+        }
+        if (!METRIC_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException(
+                String.format("Invalid metric name '%s'. Must match pattern: %s",
+                    name, METRIC_NAME_PATTERN.pattern()));
+        }
+        return name;
+    }
+
+    /**
+     * Validates a label name against the Prometheus naming specification.
+     *
+     * @param name the label name to validate
+     * @return the validated label name
+     * @throws IllegalArgumentException if the name is invalid
+     */
+    public static String sanitizeLabelName(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Label name must not be null or empty");
+        }
+        if (!LABEL_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException(
+                String.format("Invalid label name '%s'. Must match pattern: %s",
+                    name, LABEL_NAME_PATTERN.pattern()));
+        }
+        return name;
+    }
+
+    /**
+     * Escapes special characters in a label value for safe interpolation
+     * into PromQL string literals. Escapes backslash, double-quote, and newline.
+     *
+     * @param value the label value to escape
+     * @return the escaped label value safe for use in PromQL
+     */
+    public static String sanitizeLabelValue(final String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n");
+    }
+}

--- a/metrics-prometheus/src/main/resources/META-INF/beans.xml
+++ b/metrics-prometheus/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusAuthFilterTest.java
+++ b/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusAuthFilterTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.service;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PrometheusAuthFilter}.
+ */
+class PrometheusAuthFilterTest {
+
+    PrometheusAuthFilterTest() {
+    }
+
+    @Mock
+    private ClientRequestContext requestContext;
+
+    @Mock
+    private Config config;
+
+    private MultivaluedMap<String, Object> headers;
+    private PrometheusAuthFilter filter;
+    private MockedStatic<ConfigProvider> configProviderMock;
+    private AutoCloseable mocks;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        filter = new PrometheusAuthFilter();
+        headers = new MultivaluedHashMap<>();
+
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        configProviderMock = mockStatic(ConfigProvider.class);
+        configProviderMock.when(ConfigProvider::getConfig).thenReturn(config);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        configProviderMock.close();
+        mocks.close();
+    }
+
+    @Test
+    void noAuthModeDoesNotAddHeaders() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("none"));
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void defaultAuthModeIsNone() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.empty());
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void basicAuthModeDoesNotAddHeaders() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("basic"));
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void bearerTokenModeAddsAuthorizationHeader() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("bearer-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.bearer-token"), eq(String.class)))
+            .thenReturn(Optional.of("test-token-123"));
+
+        filter.filter(requestContext);
+
+        assertEquals("Bearer test-token-123", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void bearerTokenModeTrimsToken() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("bearer-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.bearer-token"), eq(String.class)))
+            .thenReturn(Optional.of("  test-token-456  "));
+
+        filter.filter(requestContext);
+
+        assertEquals("Bearer test-token-456", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void bearerTokenModeWithoutTokenDoesNotAddHeader() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("bearer-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.bearer-token"), eq(String.class)))
+            .thenReturn(Optional.empty());
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void bearerTokenModeWithBlankTokenDoesNotAddHeader() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("bearer-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.bearer-token"), eq(String.class)))
+            .thenReturn(Optional.of("   "));
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void serviceAccountTokenModeReadsTokenFromFile() throws IOException {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "sa-token-content");
+
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("sa-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.sa-token-path"), eq(String.class)))
+            .thenReturn(Optional.of(tokenFile.toString()));
+
+        filter.filter(requestContext);
+
+        assertEquals("Bearer sa-token-content", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void serviceAccountTokenModeTrimsTokenFromFile() throws IOException {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "  sa-token-with-whitespace  \n");
+
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("sa-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.sa-token-path"), eq(String.class)))
+            .thenReturn(Optional.of(tokenFile.toString()));
+
+        filter.filter(requestContext);
+
+        assertEquals("Bearer sa-token-with-whitespace", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void serviceAccountTokenModeWithMissingFileDoesNotAddHeader() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("sa-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.sa-token-path"), eq(String.class)))
+            .thenReturn(Optional.of("/nonexistent/token"));
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void serviceAccountTokenModeUsesDefaultPath() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("sa-token"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.sa-token-path"), eq(String.class)))
+            .thenReturn(Optional.empty());
+
+        filter.filter(requestContext);
+
+        // Default path won't exist in test environment, so no header should be added
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void unknownAuthModeDoesNotAddHeader() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("unknown-mode"));
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void authModeIsCaseInsensitive() throws IOException {
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.auth-mode"), eq(String.class)))
+            .thenReturn(Optional.of("BEARER-TOKEN"));
+        when(config.getOptionalValue(eq("mcp.metrics.prometheus.bearer-token"), eq(String.class)))
+            .thenReturn(Optional.of("test-token"));
+
+        filter.filter(requestContext);
+
+        assertEquals("Bearer test-token", headers.getFirst("Authorization"));
+    }
+}

--- a/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProviderTest.java
+++ b/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link PrometheusMetricsProvider} PromQL query building.
+ */
+class PrometheusMetricsProviderTest {
+
+    PrometheusMetricsProviderTest() {
+    }
+
+    private PrometheusMetricsProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new PrometheusMetricsProvider();
+    }
+
+    @Test
+    void buildPromQLSingleMetricNoLabels() {
+        String query = provider.buildPromQL(List.of("metric_a"), null);
+        assertEquals("metric_a", query);
+    }
+
+    @Test
+    void buildPromQLSingleMetricWithLabels() {
+        String query = provider.buildPromQL(
+            List.of("metric_a"), Map.of("namespace", "kafka"));
+        assertEquals("metric_a{namespace=\"kafka\"}", query);
+    }
+
+    @Test
+    void buildPromQLMultipleMetricsNoLabels() {
+        String query = provider.buildPromQL(
+            List.of("metric_a", "metric_b"), null);
+        assertEquals("{__name__=~\"metric_a|metric_b\"}", query);
+    }
+
+    @Test
+    void buildPromQLMultipleMetricsWithLabels() {
+        String query = provider.buildPromQL(
+            List.of("metric_a", "metric_b"),
+            Map.of("namespace", "kafka"));
+        assertEquals(
+            "{__name__=~\"metric_a|metric_b\",namespace=\"kafka\"}",
+            query);
+    }
+
+    @Test
+    void buildPromQLEmptyMetricNames() {
+        String query = provider.buildPromQL(List.of(), null);
+        assertEquals("{}", query);
+    }
+
+    @Test
+    void buildPromQLNullMetricNames() {
+        String query = provider.buildPromQL(null, null);
+        assertEquals("{}", query);
+    }
+
+    @Test
+    void buildPromQLSingleMetricWithEmptyLabels() {
+        String query = provider.buildPromQL(
+            List.of("metric_a"), Map.of());
+        assertEquals("metric_a", query);
+    }
+
+    @Test
+    void buildPromQLMultipleMetricsWithEmptyLabels() {
+        String query = provider.buildPromQL(
+            List.of("metric_a", "metric_b"), Map.of());
+        assertEquals("{__name__=~\"metric_a|metric_b\"}", query);
+    }
+
+    @Test
+    void buildPromQLSingleMetricMultipleLabels() {
+        Map<String, String> labels = new java.util.LinkedHashMap<>();
+        labels.put("namespace", "kafka");
+        labels.put("pod", "broker-0");
+
+        String query = provider.buildPromQL(
+            List.of("metric_a"), labels);
+        assertEquals(
+            "metric_a{namespace=\"kafka\",pod=\"broker-0\"}",
+            query);
+    }
+}

--- a/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/util/PromQLSanitizerTest.java
+++ b/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/util/PromQLSanitizerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link PromQLSanitizer}.
+ */
+class PromQLSanitizerTest {
+
+    PromQLSanitizerTest() {
+        // default constructor for checkstyle
+    }
+
+    @Test
+    void validMetricNamePassesThrough() {
+        assertEquals("http_requests_total", PromQLSanitizer.sanitizeMetricName("http_requests_total"));
+    }
+
+    @Test
+    void metricNameWithColonIsValid() {
+        assertEquals("namespace:http_requests:rate5m",
+            PromQLSanitizer.sanitizeMetricName("namespace:http_requests:rate5m"));
+    }
+
+    @Test
+    void metricNameStartingWithUnderscoreIsValid() {
+        assertEquals("_internal_metric", PromQLSanitizer.sanitizeMetricName("_internal_metric"));
+    }
+
+    @Test
+    void metricNameWithSpecialCharsThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeMetricName("metric-name"));
+    }
+
+    @Test
+    void metricNameStartingWithDigitThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeMetricName("1_invalid"));
+    }
+
+    @Test
+    void emptyMetricNameThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeMetricName(""));
+    }
+
+    @Test
+    void nullMetricNameThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeMetricName(null));
+    }
+
+    @Test
+    void injectionInMetricNameIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeMetricName("foo\"}or{job=\""));
+    }
+
+    @Test
+    void validLabelNamePassesThrough() {
+        assertEquals("instance", PromQLSanitizer.sanitizeLabelName("instance"));
+    }
+
+    @Test
+    void labelNameWithColonThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeLabelName("namespace:label"));
+    }
+
+    @Test
+    void emptyLabelNameThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeLabelName(""));
+    }
+
+    @Test
+    void nullLabelNameThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PromQLSanitizer.sanitizeLabelName(null));
+    }
+
+    @Test
+    void labelValueEscapesBackslash() {
+        assertEquals("path\\\\to", PromQLSanitizer.sanitizeLabelValue("path\\to"));
+    }
+
+    @Test
+    void labelValueEscapesDoubleQuote() {
+        assertEquals("say\\\"hello\\\"", PromQLSanitizer.sanitizeLabelValue("say\"hello\""));
+    }
+
+    @Test
+    void labelValueEscapesNewline() {
+        assertEquals("line1\\nline2", PromQLSanitizer.sanitizeLabelValue("line1\nline2"));
+    }
+
+    @Test
+    void labelValueInjectionIsSafelyEscaped() {
+        String malicious = "foo\"}or{job=\"bar";
+        String sanitized = PromQLSanitizer.sanitizeLabelValue(malicious);
+        assertEquals("foo\\\"}or{job=\\\"bar", sanitized);
+    }
+
+    @Test
+    void nullLabelValueReturnsEmpty() {
+        assertEquals("", PromQLSanitizer.sanitizeLabelValue(null));
+    }
+
+    @Test
+    void plainLabelValuePassesThrough() {
+        assertEquals("simple_value", PromQLSanitizer.sanitizeLabelValue("simple_value"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
 
     <modules>
         <module>common</module>
+        <module>metrics-prometheus</module>
         <module>strimzi-mcp</module>
     </modules>
 

--- a/strimzi-mcp/pom.xml
+++ b/strimzi-mcp/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.streamshub</groupId>
+            <artifactId>streamshub-metrics-prometheus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-jib</artifactId>
         </dependency>

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -88,12 +88,9 @@ public final class StrimziToolsPrompts {
      * Metrics category parameter description.
      */
     public static final String METRICS_CATEGORY_DESC =
-        "Metric category: 'replication' (CRITICAL - data availability), "
-            + "'performance' (HIGH - broker capacity), "
-            + "'resources' (MEDIUM - JVM health), "
-            + "or 'throughput' (LOW - informational). "
-            + "Defaults to 'replication' if no category or metric names are provided. "
-            + "Start with 'replication' during incident response.";
+        "Metric category: 'replication', 'performance',"
+            + " 'resources', or 'throughput'."
+            + " Defaults to 'replication' if omitted.";
 
     /**
      * Operator metrics category parameter description.
@@ -116,32 +113,25 @@ public final class StrimziToolsPrompts {
      * Range minutes parameter description.
      */
     public static final String RANGE_MINUTES_DESC =
-        "Relative time range in minutes from now backwards (e.g., 15, 60, 240). "
-            + "Use 5-15 minutes for incident investigation to see recent trends. "
-            + "Use 60-240 minutes for capacity planning or post-mortem analysis. "
-            + "Omit for current point-in-time values (instant query). "
-            + "Mutually exclusive with startTime/endTime. "
-            + "Only supported with Prometheus provider.";
+        "Relative time range in minutes from now"
+            + " (e.g., 15, 60). Omit for instant query."
+            + " Mutually exclusive with startTime/endTime.";
 
     /**
      * Start time parameter description for absolute time ranges.
      */
     public static final String START_TIME_DESC =
-        "Start time for absolute time range query (ISO 8601 format, e.g., '2026-04-05T10:00:00Z'). "
-            + "Use with endTime for incident investigation or post-mortem analysis of specific time windows. "
-            + "Mutually exclusive with rangeMinutes. "
-            + "Example: '2026-04-05T10:00:00Z' for 10:00 AM UTC on April 5, 2026. "
-            + "Only supported with Prometheus provider.";
+        "Absolute start time in ISO 8601 format"
+            + " (e.g., '2025-01-15T10:00:00Z')."
+            + " Use with endTime; mutually exclusive with rangeMinutes.";
 
     /**
      * End time parameter description for absolute time ranges.
      */
     public static final String END_TIME_DESC =
-        "End time for absolute time range query (ISO 8601 format, e.g., '2026-04-05T12:00:00Z'). "
-            + "Use with startTime for incident investigation or post-mortem analysis of specific time windows. "
-            + "Mutually exclusive with rangeMinutes. "
-            + "Example: '2026-04-05T12:00:00Z' for 12:00 PM UTC on April 5, 2026. "
-            + "Only supported with Prometheus provider.";
+        "Absolute end time in ISO 8601 format"
+            + " (e.g., '2025-01-15T12:00:00Z')."
+            + " Use with startTime; mutually exclusive with rangeMinutes.";
 
     /**
      * Step seconds parameter description.

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -70,6 +70,13 @@ public final class StrimziToolsPrompts {
             + " Omit for summary only.";
 
     /**
+     * Operator name parameter description for metrics.
+     */
+    public static final String OPERATOR_NAME_DESC =
+        "Strimzi operator deployment name."
+            + " Omit to auto-discover.";
+
+    /**
      * Listener name parameter description.
      */
     public static final String LISTENER_DESC =
@@ -84,6 +91,15 @@ public final class StrimziToolsPrompts {
         "Metric category: 'replication', 'throughput',"
             + " 'resources', or 'performance'."
             + " Defaults to 'replication' if no category"
+            + " or metric names are provided.";
+
+    /**
+     * Operator metrics category parameter description.
+     */
+    public static final String OPERATOR_METRICS_CATEGORY_DESC =
+        "Metric category: 'reconciliation', 'resources',"
+            + " or 'jvm'."
+            + " Defaults to 'reconciliation' if no category"
             + " or metric names are provided.";
 
     /**

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -88,10 +88,12 @@ public final class StrimziToolsPrompts {
      * Metrics category parameter description.
      */
     public static final String METRICS_CATEGORY_DESC =
-        "Metric category: 'replication', 'throughput',"
-            + " 'resources', or 'performance'."
-            + " Defaults to 'replication' if no category"
-            + " or metric names are provided.";
+        "Metric category: 'replication' (CRITICAL - data availability), "
+            + "'performance' (HIGH - broker capacity), "
+            + "'resources' (MEDIUM - JVM health), "
+            + "or 'throughput' (LOW - informational). "
+            + "Defaults to 'replication' if no category or metric names are provided. "
+            + "Start with 'replication' during incident response.";
 
     /**
      * Operator metrics category parameter description.
@@ -114,9 +116,32 @@ public final class StrimziToolsPrompts {
      * Range minutes parameter description.
      */
     public static final String RANGE_MINUTES_DESC =
-        "Time range in minutes for historical data."
-            + " Omit for current point-in-time values."
-            + " Only supported with Prometheus provider.";
+        "Relative time range in minutes from now backwards (e.g., 15, 60, 240). "
+            + "Use 5-15 minutes for incident investigation to see recent trends. "
+            + "Use 60-240 minutes for capacity planning or post-mortem analysis. "
+            + "Omit for current point-in-time values (instant query). "
+            + "Mutually exclusive with startTime/endTime. "
+            + "Only supported with Prometheus provider.";
+
+    /**
+     * Start time parameter description for absolute time ranges.
+     */
+    public static final String START_TIME_DESC =
+        "Start time for absolute time range query (ISO 8601 format, e.g., '2026-04-05T10:00:00Z'). "
+            + "Use with endTime for incident investigation or post-mortem analysis of specific time windows. "
+            + "Mutually exclusive with rangeMinutes. "
+            + "Example: '2026-04-05T10:00:00Z' for 10:00 AM UTC on April 5, 2026. "
+            + "Only supported with Prometheus provider.";
+
+    /**
+     * End time parameter description for absolute time ranges.
+     */
+    public static final String END_TIME_DESC =
+        "End time for absolute time range query (ISO 8601 format, e.g., '2026-04-05T12:00:00Z'). "
+            + "Use with startTime for incident investigation or post-mortem analysis of specific time windows. "
+            + "Mutually exclusive with rangeMinutes. "
+            + "Example: '2026-04-05T12:00:00Z' for 12:00 PM UTC on April 5, 2026. "
+            + "Only supported with Prometheus provider.";
 
     /**
      * Step seconds parameter description.

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -77,6 +77,38 @@ public final class StrimziToolsPrompts {
             + " (e.g., 'plain', 'tls', 'external')."
             + " Omit to return all listeners.";
 
+    /**
+     * Metrics category parameter description.
+     */
+    public static final String METRICS_CATEGORY_DESC =
+        "Metric category: 'replication', 'throughput',"
+            + " 'resources', or 'performance'."
+            + " Defaults to 'replication' if no category"
+            + " or metric names are provided.";
+
+    /**
+     * Metric names parameter description.
+     */
+    public static final String METRICS_NAMES_DESC =
+        "Comma-separated list of explicit Prometheus"
+            + " metric names to retrieve."
+            + " Can be combined with a category.";
+
+    /**
+     * Range minutes parameter description.
+     */
+    public static final String RANGE_MINUTES_DESC =
+        "Time range in minutes for historical data."
+            + " Omit for current point-in-time values."
+            + " Only supported with Prometheus provider.";
+
+    /**
+     * Step seconds parameter description.
+     */
+    public static final String STEP_SECONDS_DESC =
+        "Query resolution step in seconds for range queries."
+            + " Defaults to server-configured value (typically 60).";
+
     private StrimziToolsPrompts() {
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
@@ -84,23 +84,8 @@ public final class KafkaMetricCategories {
                 + "kafka_server_brokertopicmetrics_totalfetchrequests_total: Total fetch requests. "
                 + "Includes consumer and follower fetches.",
         "resources",
-            "**[MEDIUM - JVM HEALTH]**\n\n"
-                + "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
-                + "**IMPORTANT**: Java normally uses most of its allocated heap — high usage alone is NOT a problem. "
-                + "Only flag as concerning if combined with: (1) pod restarts (check with get_kafka_cluster_pods), "
-                + "(2) OOM errors in logs, or (3) excessive GC overhead (rapidly increasing GC count). "
-                + "**FALSE POSITIVE TRAP**: Do not raise alerts based solely on high heap usage.\n\n"
-                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n\n"
-                + "**[MEDIUM - GC PRESSURE]**\n\n"
-                + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
-                + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
-                + "**THRESHOLDS**: <5% of CPU time = healthy, 5-10% = monitor, >10% = investigate heap sizing. "
-                + "Only concerning if it correlates with performance degradation or pod restarts.\n\n"
-                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n\n"
-                + "**[LOW - THREAD HEALTH]**\n\n"
-                + "jvm_threads_current: Active JVM thread count. "
-                + "Sudden increases may indicate thread leaks or connection storms. "
-                + "**BASELINE**: Stable count is normal, rapid growth (>50% in <5 min) needs investigation.",
+            MetricsDescriptions.jvmDescription("get_kafka_cluster_pods",
+                "performance degradation or pod restarts"),
         "performance",
             "**[HIGH - BROKER CAPACITY]**\n\n"
                 + "kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent: "
@@ -163,52 +148,5 @@ public final class KafkaMetricCategories {
             .map(DESCRIPTIONS::get)
             .collect(Collectors.joining("\n\n"));
         return result.isEmpty() ? null : result;
-    }
-
-    /**
-     * Returns cascading failure patterns for cross-category correlation.
-     *
-     * @return a guide to common failure cascades
-     */
-    public static String cascadingPatterns() {
-        return """
-            **Common Cascading Failure Patterns:**
-            
-            1. **Broker Overload Cascade:**
-               - brokerrequesthandleravgidle < 0.3 (performance)
-               → requestqueuetimems increasing (performance)
-               → underreplicatedpartitions > 0 (replication)
-               → maxlag growing (replication)
-               **Root Cause**: Broker can't keep up with request load
-               **Action**: Scale horizontally or reduce producer/consumer load
-            
-            2. **Network Bottleneck Cascade:**
-               - networkprocessoravgidle < 0.3 (performance)
-               → responsequeuetimems increasing (performance)
-               → maxlag growing (replication)
-               **Root Cause**: Network threads saturated
-               **Action**: Increase network threads or reduce connection count
-            
-            3. **GC Thrashing Cascade:**
-               - jvm_gc_collection_seconds_count rapidly increasing (resources)
-               → process_cpu_seconds_total high (resources)
-               → brokerrequesthandleravgidle dropping (performance)
-               → requestqueuetimems increasing (performance)
-               **Root Cause**: Insufficient heap or memory leak
-               **Action**: Check for OOM in logs, increase heap, or investigate memory leak
-            
-            4. **Controller Failure Cascade:**
-               - offlinepartitionscount > 0 (replication)
-               + leadercount severely imbalanced (replication)
-               **Root Cause**: Controller unable to elect leaders
-               **Action**: Check controller logs, verify ZooKeeper/KRaft health
-            
-            5. **Disk I/O Cascade:**
-               - maxlag growing steadily (replication)
-               + underreplicatedpartitions increasing (replication)
-               + brokerrequesthandleravgidle normal (performance)
-               **Root Cause**: Disk I/O bottleneck (not CPU/network)
-               **Action**: Check disk metrics, consider faster storage or more brokers
-            """;
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.config.metrics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Curated metric name categories for Kafka broker metrics.
+ * Maps human-friendly category names to lists of Prometheus metric names.
+ */
+public final class KafkaMetricCategories {
+
+    private static final Map<String, List<String>> CATEGORIES = Map.of(
+        "replication", List.of(
+            "kafka_server_replicamanager_underreplicatedpartitions",
+            "kafka_server_replicamanager_leadercount",
+            "kafka_server_replicamanager_partitioncount",
+            "kafka_server_replicamanager_offlinereplicacount",
+            "kafka_controller_kafkacontroller_offlinepartitionscount",
+            "kafka_server_replicafetchermanager_maxlag"
+        ),
+        "throughput", List.of(
+            "kafka_server_brokertopicmetrics_messagesin_total",
+            "kafka_server_brokertopicmetrics_bytesin_total",
+            "kafka_server_brokertopicmetrics_bytesout_total",
+            "kafka_server_brokertopicmetrics_totalproducerequests_total",
+            "kafka_server_brokertopicmetrics_totalfetchrequests_total"
+        ),
+        "resources", List.of(
+            "jvm_memory_used_bytes",
+            "jvm_memory_max_bytes",
+            "jvm_gc_collection_seconds_count",
+            "jvm_gc_collection_seconds_sum",
+            "process_cpu_seconds_total",
+            "jvm_threads_current"
+        ),
+        "performance", List.of(
+            "kafka_network_requestmetrics_totaltimems",
+            "kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent",
+            "kafka_network_requestmetrics_requestqueuetimems",
+            "kafka_network_requestmetrics_responsequeuetimems",
+            "kafka_network_socketserver_networkprocessoravgidle_percent"
+        )
+    );
+
+    private KafkaMetricCategories() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Resolves a category name to its list of metric names.
+     *
+     * @param category the category name (case-insensitive)
+     * @return the list of metric names, or an empty list if the category is unknown
+     */
+    public static List<String> resolve(final String category) {
+        if (category == null) {
+            return List.of();
+        }
+        return CATEGORIES.getOrDefault(category.toLowerCase(java.util.Locale.ROOT), List.of());
+    }
+
+    /**
+     * Returns all available category names.
+     *
+     * @return the set of category names
+     */
+    public static Set<String> allCategories() {
+        return CATEGORIES.keySet();
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
@@ -7,10 +7,12 @@ package io.streamshub.mcp.strimzi.config.metrics;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Curated metric name categories for Kafka broker metrics.
- * Maps human-friendly category names to lists of Prometheus metric names.
+ * Maps human-friendly category names to lists of Prometheus metric names,
+ * and provides interpretation guides for each category.
  */
 public final class KafkaMetricCategories {
 
@@ -47,6 +49,57 @@ public final class KafkaMetricCategories {
         )
     );
 
+    private static final Map<String, String> DESCRIPTIONS = Map.of(
+        "replication",
+            "kafka_server_replicamanager_underreplicatedpartitions: Partitions with fewer in-sync "
+                + "replicas than configured. Should be 0. >0 means data loss risk.\n"
+                + "kafka_server_replicamanager_leadercount: Number of partition leaders per broker. "
+                + "Should be roughly equal across brokers. Large imbalance = uneven load.\n"
+                + "kafka_server_replicamanager_partitioncount: Total partitions per broker. "
+                + "Should be balanced across brokers.\n"
+                + "kafka_server_replicamanager_offlinereplicacount: Replicas that are offline. "
+                + "Should be 0. >0 = broker or disk issues.\n"
+                + "kafka_controller_kafkacontroller_offlinepartitionscount: Partitions with no active "
+                + "leader. Should be 0. >0 is critical — those partitions are unavailable.\n"
+                + "kafka_server_replicafetchermanager_maxlag: Maximum replica lag in messages. "
+                + "Growing value = followers falling behind. Transient spikes during restarts are normal.",
+        "throughput",
+            "kafka_server_brokertopicmetrics_messagesin_total: Cumulative messages received. "
+                + "Rate of change = messages/sec. Sudden drops = producer issues.\n"
+                + "kafka_server_brokertopicmetrics_bytesin_total: Cumulative bytes received. "
+                + "Compare across brokers — large imbalance = hot partitions.\n"
+                + "kafka_server_brokertopicmetrics_bytesout_total: Cumulative bytes sent to consumers. "
+                + "bytesout >> bytesin can indicate replication or high consumer fan-out.\n"
+                + "kafka_server_brokertopicmetrics_totalproducerequests_total: Total produce requests. "
+                + "Rate = produce request throughput.\n"
+                + "kafka_server_brokertopicmetrics_totalfetchrequests_total: Total fetch requests. "
+                + "Includes consumer and follower fetches.",
+        "resources",
+            "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
+                + "Java normally uses most of its allocated heap — high usage alone is not a problem. "
+                + "Only flag as concerning if combined with pod restarts (check with "
+                + "get_kafka_cluster_pods), OOM errors in logs, or excessive GC overhead.\n"
+                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n"
+                + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
+                + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
+                + "Only concerning if it correlates with performance degradation or pod restarts.\n"
+                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n"
+                + "jvm_threads_current: Active JVM thread count. "
+                + "Sudden increases may indicate thread leaks or connection storms.",
+        "performance",
+            "kafka_network_requestmetrics_totaltimems: Total time for request processing "
+                + "(queue + local + remote + response). High values = slow requests.\n"
+                + "kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent: "
+                + "Request handler thread idle ratio. <0.3 = overloaded broker, needs attention. "
+                + "<0.1 = critical.\n"
+                + "kafka_network_requestmetrics_requestqueuetimems: Time requests spend waiting "
+                + "in the request queue. Increasing = bottleneck, broker can't keep up.\n"
+                + "kafka_network_requestmetrics_responsequeuetimems: Time responses wait before being "
+                + "sent. High values = network thread bottleneck.\n"
+                + "kafka_network_socketserver_networkprocessoravgidle_percent: Network thread idle "
+                + "ratio. <0.3 = network bottleneck."
+    );
+
     private KafkaMetricCategories() {
         // Utility class — no instantiation
     }
@@ -71,5 +124,23 @@ public final class KafkaMetricCategories {
      */
     public static Set<String> allCategories() {
         return CATEGORIES.keySet();
+    }
+
+    /**
+     * Returns an interpretation guide for the given categories.
+     *
+     * @param categories the category names to get descriptions for
+     * @return a combined interpretation guide, or null if no categories match
+     */
+    public static String interpretation(final List<String> categories) {
+        if (categories == null || categories.isEmpty()) {
+            return null;
+        }
+        String result = categories.stream()
+            .map(c -> c.toLowerCase(java.util.Locale.ROOT))
+            .filter(DESCRIPTIONS::containsKey)
+            .map(DESCRIPTIONS::get)
+            .collect(Collectors.joining("\n\n"));
+        return result.isEmpty() ? null : result;
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
@@ -51,18 +51,27 @@ public final class KafkaMetricCategories {
 
     private static final Map<String, String> DESCRIPTIONS = Map.of(
         "replication",
-            "kafka_server_replicamanager_underreplicatedpartitions: Partitions with fewer in-sync "
-                + "replicas than configured. Should be 0. >0 means data loss risk.\n"
-                + "kafka_server_replicamanager_leadercount: Number of partition leaders per broker. "
-                + "Should be roughly equal across brokers. Large imbalance = uneven load.\n"
-                + "kafka_server_replicamanager_partitioncount: Total partitions per broker. "
-                + "Should be balanced across brokers.\n"
-                + "kafka_server_replicamanager_offlinereplicacount: Replicas that are offline. "
-                + "Should be 0. >0 = broker or disk issues.\n"
+            "**[CRITICAL - CLUSTER AVAILABILITY]**\n\n"
+                + "kafka_server_replicamanager_underreplicatedpartitions: Partitions with fewer in-sync "
+                + "replicas than configured. Should be 0. >0 means data loss risk. "
+                + "**TIME-SENSITIVE**: If >0 for >5 minutes during normal operations, indicates broker "
+                + "overload, network issues, or disk I/O problems. Transient spikes during rolling "
+                + "restarts are expected (2-3 minutes per broker).\n\n"
+                + "**[CRITICAL - PARTITION AVAILABILITY]**\n\n"
                 + "kafka_controller_kafkacontroller_offlinepartitionscount: Partitions with no active "
-                + "leader. Should be 0. >0 is critical — those partitions are unavailable.\n"
+                + "leader. Should be 0. >0 is critical — those partitions are unavailable to producers "
+                + "and consumers. **IMMEDIATE ACTION REQUIRED**. Check broker health and controller logs.\n\n"
+                + "**[HIGH - REPLICATION LAG]**\n\n"
                 + "kafka_server_replicafetchermanager_maxlag: Maximum replica lag in messages. "
-                + "Growing value = followers falling behind. Transient spikes during restarts are normal.",
+                + "Growing value = followers falling behind. Transient spikes during restarts are normal. "
+                + "**THRESHOLDS**: <1000 = healthy, 1000-10000 = monitor, >10000 = investigate broker load.\n\n"
+                + "kafka_server_replicamanager_leadercount: Number of partition leaders per broker. "
+                + "Should be roughly equal across brokers. Large imbalance = uneven load. "
+                + "**THRESHOLD**: >20% variance indicates need for partition reassignment.\n\n"
+                + "kafka_server_replicamanager_partitioncount: Total partitions per broker. "
+                + "Should be balanced across brokers.\n\n"
+                + "kafka_server_replicamanager_offlinereplicacount: Replicas that are offline. "
+                + "Should be 0. >0 = broker or disk issues. Check pod status and logs.",
         "throughput",
             "kafka_server_brokertopicmetrics_messagesin_total: Cumulative messages received. "
                 + "Rate of change = messages/sec. Sudden drops = producer issues.\n"
@@ -75,29 +84,41 @@ public final class KafkaMetricCategories {
                 + "kafka_server_brokertopicmetrics_totalfetchrequests_total: Total fetch requests. "
                 + "Includes consumer and follower fetches.",
         "resources",
-            "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
-                + "Java normally uses most of its allocated heap — high usage alone is not a problem. "
-                + "Only flag as concerning if combined with pod restarts (check with "
-                + "get_kafka_cluster_pods), OOM errors in logs, or excessive GC overhead.\n"
-                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n"
+            "**[MEDIUM - JVM HEALTH]**\n\n"
+                + "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
+                + "**IMPORTANT**: Java normally uses most of its allocated heap — high usage alone is NOT a problem. "
+                + "Only flag as concerning if combined with: (1) pod restarts (check with get_kafka_cluster_pods), "
+                + "(2) OOM errors in logs, or (3) excessive GC overhead (rapidly increasing GC count). "
+                + "**FALSE POSITIVE TRAP**: Do not raise alerts based solely on high heap usage.\n\n"
+                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n\n"
+                + "**[MEDIUM - GC PRESSURE]**\n\n"
                 + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
                 + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
-                + "Only concerning if it correlates with performance degradation or pod restarts.\n"
-                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n"
+                + "**THRESHOLDS**: <5% of CPU time = healthy, 5-10% = monitor, >10% = investigate heap sizing. "
+                + "Only concerning if it correlates with performance degradation or pod restarts.\n\n"
+                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n\n"
+                + "**[LOW - THREAD HEALTH]**\n\n"
                 + "jvm_threads_current: Active JVM thread count. "
-                + "Sudden increases may indicate thread leaks or connection storms.",
+                + "Sudden increases may indicate thread leaks or connection storms. "
+                + "**BASELINE**: Stable count is normal, rapid growth (>50% in <5 min) needs investigation.",
         "performance",
-            "kafka_network_requestmetrics_totaltimems: Total time for request processing "
-                + "(queue + local + remote + response). High values = slow requests.\n"
+            "**[HIGH - BROKER CAPACITY]**\n\n"
                 + "kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent: "
-                + "Request handler thread idle ratio. <0.3 = overloaded broker, needs attention. "
-                + "<0.1 = critical.\n"
+                + "Request handler thread idle ratio. **CRITICAL THRESHOLDS**: "
+                + ">0.5 = healthy headroom, 0.3-0.5 = monitor closely, <0.3 = overloaded (add capacity), "
+                + "<0.1 = critical (clients experiencing timeouts).\n\n"
+                + "**[HIGH - REQUEST LATENCY]**\n\n"
                 + "kafka_network_requestmetrics_requestqueuetimems: Time requests spend waiting "
-                + "in the request queue. Increasing = bottleneck, broker can't keep up.\n"
+                + "in the request queue. **THRESHOLDS**: <50ms = good, 50-100ms = acceptable, "
+                + ">100ms = bottleneck, >500ms = severe (clients timing out). "
+                + "Increasing trend = broker can't keep up with load.\n\n"
+                + "kafka_network_requestmetrics_totaltimems: Total time for request processing "
+                + "(queue + local + remote + response). High values = slow requests.\n\n"
                 + "kafka_network_requestmetrics_responsequeuetimems: Time responses wait before being "
-                + "sent. High values = network thread bottleneck.\n"
+                + "sent. High values = network thread bottleneck.\n\n"
+                + "**[MEDIUM - NETWORK CAPACITY]**\n\n"
                 + "kafka_network_socketserver_networkprocessoravgidle_percent: Network thread idle "
-                + "ratio. <0.3 = network bottleneck."
+                + "ratio. **THRESHOLDS**: >0.5 = healthy, 0.3-0.5 = monitor, <0.3 = network bottleneck."
     );
 
     private KafkaMetricCategories() {
@@ -142,5 +163,52 @@ public final class KafkaMetricCategories {
             .map(DESCRIPTIONS::get)
             .collect(Collectors.joining("\n\n"));
         return result.isEmpty() ? null : result;
+    }
+
+    /**
+     * Returns cascading failure patterns for cross-category correlation.
+     *
+     * @return a guide to common failure cascades
+     */
+    public static String cascadingPatterns() {
+        return """
+            **Common Cascading Failure Patterns:**
+            
+            1. **Broker Overload Cascade:**
+               - brokerrequesthandleravgidle < 0.3 (performance)
+               → requestqueuetimems increasing (performance)
+               → underreplicatedpartitions > 0 (replication)
+               → maxlag growing (replication)
+               **Root Cause**: Broker can't keep up with request load
+               **Action**: Scale horizontally or reduce producer/consumer load
+            
+            2. **Network Bottleneck Cascade:**
+               - networkprocessoravgidle < 0.3 (performance)
+               → responsequeuetimems increasing (performance)
+               → maxlag growing (replication)
+               **Root Cause**: Network threads saturated
+               **Action**: Increase network threads or reduce connection count
+            
+            3. **GC Thrashing Cascade:**
+               - jvm_gc_collection_seconds_count rapidly increasing (resources)
+               → process_cpu_seconds_total high (resources)
+               → brokerrequesthandleravgidle dropping (performance)
+               → requestqueuetimems increasing (performance)
+               **Root Cause**: Insufficient heap or memory leak
+               **Action**: Check for OOM in logs, increase heap, or investigate memory leak
+            
+            4. **Controller Failure Cascade:**
+               - offlinepartitionscount > 0 (replication)
+               + leadercount severely imbalanced (replication)
+               **Root Cause**: Controller unable to elect leaders
+               **Action**: Check controller logs, verify ZooKeeper/KRaft health
+            
+            5. **Disk I/O Cascade:**
+               - maxlag growing steadily (replication)
+               + underreplicatedpartitions increasing (replication)
+               + brokerrequesthandleravgidle normal (performance)
+               **Root Cause**: Disk I/O bottleneck (not CPU/network)
+               **Action**: Check disk metrics, consider faster storage or more brokers
+            """;
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/MetricsDescriptions.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/MetricsDescriptions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.config.metrics;
+
+/**
+ * Shared JVM metric interpretation text used by both Kafka and operator metric categories.
+ * Parameterized by the tool name for pod health checks and the correlation context.
+ */
+final class MetricsDescriptions {
+
+    private MetricsDescriptions() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Builds the JVM metric interpretation guide.
+     *
+     * @param podCheckTool       the MCP tool name for checking pod health
+     *                           (e.g. {@code get_kafka_cluster_pods} or {@code get_strimzi_operator_pod})
+     * @param correlationContext what symptoms to correlate with GC pressure
+     *                           (e.g. {@code "performance degradation or pod restarts"})
+     * @return the formatted JVM interpretation text
+     */
+    static String jvmDescription(final String podCheckTool, final String correlationContext) {
+        return "**[MEDIUM - JVM HEALTH]**\n\n"
+            + "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
+            + "**IMPORTANT**: Java normally uses most of its allocated heap — high usage alone is NOT a problem. "
+            + "Only flag as concerning if combined with: (1) pod restarts (check with " + podCheckTool + "), "
+            + "(2) OOM errors in logs, or (3) excessive GC overhead (rapidly increasing GC count). "
+            + "**FALSE POSITIVE TRAP**: Do not raise alerts based solely on high heap usage.\n\n"
+            + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n\n"
+            + "**[MEDIUM - GC PRESSURE]**\n\n"
+            + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
+            + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
+            + "**THRESHOLDS**: <5% of CPU time = healthy, 5-10% = monitor, >10% = investigate heap sizing. "
+            + "Only concerning if it correlates with " + correlationContext + ".\n\n"
+            + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n\n"
+            + "**[LOW - THREAD HEALTH]**\n\n"
+            + "jvm_threads_current: Active JVM thread count. "
+            + "Sudden increases may indicate thread leaks or excessive concurrency. "
+            + "**BASELINE**: Stable count is normal, rapid growth (>50% in <5 min) needs investigation.";
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
@@ -65,23 +65,8 @@ public final class StrimziOperatorMetricCategories {
                 + "**IMMEDIATE ACTION**: Any value != 1 indicates a resource that needs attention. "
                 + "Check resource status with get_kafka_cluster or get_kafka_topics.",
         "jvm",
-            "**[MEDIUM - JVM HEALTH]**\n\n"
-                + "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
-                + "**IMPORTANT**: Java normally uses most of its allocated heap — high usage alone is NOT a problem. "
-                + "Only flag as concerning if combined with: (1) pod restarts (check with get_strimzi_operator_pod), "
-                + "(2) OOM errors in logs, or (3) excessive GC overhead (rapidly increasing GC count). "
-                + "**FALSE POSITIVE TRAP**: Do not raise alerts based solely on high heap usage.\n\n"
-                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n\n"
-                + "**[MEDIUM - GC PRESSURE]**\n\n"
-                + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
-                + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
-                + "**THRESHOLDS**: <5% of CPU time = healthy, 5-10% = monitor, >10% = investigate heap sizing. "
-                + "Only concerning if it correlates with slow reconciliations or pod restarts.\n\n"
-                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n\n"
-                + "**[LOW - THREAD HEALTH]**\n\n"
-                + "jvm_threads_current: Active JVM thread count. "
-                + "Sudden increases may indicate thread leaks or excessive concurrency. "
-                + "**BASELINE**: Stable count is normal, rapid growth (>50% in <5 min) needs investigation."
+            MetricsDescriptions.jvmDescription("get_strimzi_operator_pod",
+                "slow reconciliations or pod restarts")
     );
 
     private StrimziOperatorMetricCategories() {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.config.metrics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Curated metric name categories for Strimzi cluster operator metrics.
+ * Maps human-friendly category names to lists of Prometheus metric names,
+ * and provides interpretation guides for each category.
+ */
+public final class StrimziOperatorMetricCategories {
+
+    private static final Map<String, List<String>> CATEGORIES = Map.of(
+        "reconciliation", List.of(
+            "strimzi_reconciliations_successful_total",
+            "strimzi_reconciliations_failed_total",
+            "strimzi_reconciliations_total",
+            "strimzi_reconciliations_duration_seconds_sum",
+            "strimzi_reconciliations_duration_seconds_count"
+        ),
+        "resources", List.of(
+            "strimzi_resources",
+            "strimzi_resource_state"
+        ),
+        "jvm", List.of(
+            "jvm_memory_used_bytes",
+            "jvm_memory_max_bytes",
+            "jvm_gc_collection_seconds_count",
+            "jvm_gc_collection_seconds_sum",
+            "process_cpu_seconds_total",
+            "jvm_threads_current"
+        )
+    );
+
+    private static final Map<String, String> DESCRIPTIONS = Map.of(
+        "reconciliation",
+            "strimzi_reconciliations_successful_total: Cumulative count of successful reconciliations. "
+                + "Should increase steadily.\n"
+                + "strimzi_reconciliations_failed_total: Cumulative count of failed reconciliations. "
+                + "Should be 0 or stable. Increasing = operator errors, check operator logs.\n"
+                + "strimzi_reconciliations_total: Total reconciliations attempted. "
+                + "Compare with successful + failed to verify consistency.\n"
+                + "strimzi_reconciliations_duration_seconds_sum/count: Reconciliation duration. "
+                + "Divide sum by count for average. >60s average = slow reconciliation, "
+                + "may indicate resource contention or complex configurations.",
+        "resources",
+            "strimzi_resources: Count of Strimzi custom resources (Kafka, KafkaTopic, etc.) "
+                + "managed by the operator. Sudden changes = resources added/removed.\n"
+                + "strimzi_resource_state: Health state of each managed resource. "
+                + "1 = healthy/ready, 0 = unhealthy/not ready. "
+                + "Any value != 1 indicates a resource that needs attention.",
+        "jvm",
+            "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
+                + "Java normally uses most of its allocated heap — high usage alone is not a problem. "
+                + "Only flag as concerning if combined with pod restarts (check with "
+                + "get_strimzi_operator_pod), OOM errors in logs, or excessive GC overhead.\n"
+                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n"
+                + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
+                + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
+                + "Only concerning if it correlates with slow reconciliations or pod restarts.\n"
+                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n"
+                + "jvm_threads_current: Active JVM thread count. "
+                + "Sudden increases may indicate thread leaks or excessive concurrency."
+    );
+
+    private StrimziOperatorMetricCategories() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Resolves a category name to its list of metric names.
+     *
+     * @param category the category name (case-insensitive)
+     * @return the list of metric names, or an empty list if the category is unknown
+     */
+    public static List<String> resolve(final String category) {
+        if (category == null) {
+            return List.of();
+        }
+        return CATEGORIES.getOrDefault(category.toLowerCase(java.util.Locale.ROOT), List.of());
+    }
+
+    /**
+     * Returns all available category names.
+     *
+     * @return the set of category names
+     */
+    public static Set<String> allCategories() {
+        return CATEGORIES.keySet();
+    }
+
+    /**
+     * Returns an interpretation guide for the given categories.
+     *
+     * @param categories the category names to get descriptions for
+     * @return a combined interpretation guide, or null if no categories match
+     */
+    public static String interpretation(final List<String> categories) {
+        if (categories == null || categories.isEmpty()) {
+            return null;
+        }
+        String result = categories.stream()
+            .map(c -> c.toLowerCase(java.util.Locale.ROOT))
+            .filter(DESCRIPTIONS::containsKey)
+            .map(DESCRIPTIONS::get)
+            .collect(Collectors.joining("\n\n"));
+        return result.isEmpty() ? null : result;
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
@@ -40,33 +40,48 @@ public final class StrimziOperatorMetricCategories {
 
     private static final Map<String, String> DESCRIPTIONS = Map.of(
         "reconciliation",
-            "strimzi_reconciliations_successful_total: Cumulative count of successful reconciliations. "
-                + "Should increase steadily.\n"
+            "**[HIGH - OPERATOR HEALTH]**\n\n"
+                + "strimzi_reconciliations_successful_total: Cumulative count of successful reconciliations. "
+                + "Should increase steadily. Flat line = no reconciliation activity (check if expected).\n\n"
+                + "**[CRITICAL - RECONCILIATION FAILURES]**\n\n"
                 + "strimzi_reconciliations_failed_total: Cumulative count of failed reconciliations. "
-                + "Should be 0 or stable. Increasing = operator errors, check operator logs.\n"
+                + "Should be 0 or stable. **IMMEDIATE ACTION**: Increasing count = operator errors, "
+                + "resources not being managed correctly. Check operator logs for root cause.\n\n"
                 + "strimzi_reconciliations_total: Total reconciliations attempted. "
-                + "Compare with successful + failed to verify consistency.\n"
+                + "Compare with successful + failed to verify consistency.\n\n"
+                + "**[MEDIUM - RECONCILIATION PERFORMANCE]**\n\n"
                 + "strimzi_reconciliations_duration_seconds_sum/count: Reconciliation duration. "
-                + "Divide sum by count for average. >60s average = slow reconciliation, "
-                + "may indicate resource contention or complex configurations.",
+                + "Divide sum by count for average. **THRESHOLDS**: <30s = good, 30-60s = acceptable, "
+                + ">60s = slow (may indicate resource contention, complex configurations, or K8s API slowness). "
+                + "Increasing trend = operator struggling to keep up.",
         "resources",
-            "strimzi_resources: Count of Strimzi custom resources (Kafka, KafkaTopic, etc.) "
-                + "managed by the operator. Sudden changes = resources added/removed.\n"
+            "**[HIGH - RESOURCE MANAGEMENT]**\n\n"
+                + "strimzi_resources: Count of Strimzi custom resources (Kafka, KafkaTopic, KafkaUser, etc.) "
+                + "managed by the operator. Sudden changes = resources added/removed. "
+                + "**BASELINE**: Should match expected resource count. Discrepancy = operator not discovering resources.\n\n"
+                + "**[CRITICAL - RESOURCE HEALTH]**\n\n"
                 + "strimzi_resource_state: Health state of each managed resource. "
                 + "1 = healthy/ready, 0 = unhealthy/not ready. "
-                + "Any value != 1 indicates a resource that needs attention.",
+                + "**IMMEDIATE ACTION**: Any value != 1 indicates a resource that needs attention. "
+                + "Check resource status with get_kafka_cluster or get_kafka_topics.",
         "jvm",
-            "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
-                + "Java normally uses most of its allocated heap — high usage alone is not a problem. "
-                + "Only flag as concerning if combined with pod restarts (check with "
-                + "get_strimzi_operator_pod), OOM errors in logs, or excessive GC overhead.\n"
-                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n"
+            "**[MEDIUM - JVM HEALTH]**\n\n"
+                + "jvm_memory_used_bytes: Current JVM heap/non-heap memory usage. "
+                + "**IMPORTANT**: Java normally uses most of its allocated heap — high usage alone is NOT a problem. "
+                + "Only flag as concerning if combined with: (1) pod restarts (check with get_strimzi_operator_pod), "
+                + "(2) OOM errors in logs, or (3) excessive GC overhead (rapidly increasing GC count). "
+                + "**FALSE POSITIVE TRAP**: Do not raise alerts based solely on high heap usage.\n\n"
+                + "jvm_memory_max_bytes: Maximum JVM memory available per pool.\n\n"
+                + "**[MEDIUM - GC PRESSURE]**\n\n"
                 + "jvm_gc_collection_seconds_sum/count: GC time and frequency. "
                 + "High sum/count ratio = long GC pauses. Rapidly increasing count = GC thrashing. "
-                + "Only concerning if it correlates with slow reconciliations or pod restarts.\n"
-                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n"
+                + "**THRESHOLDS**: <5% of CPU time = healthy, 5-10% = monitor, >10% = investigate heap sizing. "
+                + "Only concerning if it correlates with slow reconciliations or pod restarts.\n\n"
+                + "process_cpu_seconds_total: Cumulative CPU time. Rate of change = CPU utilization.\n\n"
+                + "**[LOW - THREAD HEALTH]**\n\n"
                 + "jvm_threads_current: Active JVM thread count. "
-                + "Sudden increases may indicate thread leaks or excessive concurrency."
+                + "Sudden increases may indicate thread leaks or excessive concurrency. "
+                + "**BASELINE**: Stable count is normal, rapid growth (>50% in <5 min) needs investigation."
     );
 
     private StrimziOperatorMetricCategories() {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponse.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Response containing metrics data from a Kafka cluster.
+ *
+ * @param clusterName the Kafka cluster name
+ * @param namespace   the Kubernetes namespace
+ * @param provider    the metrics provider used (e.g. "pod-scraping", "prometheus")
+ * @param categories  the metric categories requested
+ * @param metricCount the number of distinct metric names in the response
+ * @param sampleCount the total number of metric samples
+ * @param metrics     the list of metric samples
+ * @param timestamp   the time this result was generated
+ * @param message     a human-readable summary of the result
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KafkaMetricsResponse(
+    @JsonProperty("cluster_name") String clusterName,
+    @JsonProperty("namespace") String namespace,
+    @JsonProperty("provider") String provider,
+    @JsonProperty("categories") List<String> categories,
+    @JsonProperty("metric_count") long metricCount,
+    @JsonProperty("sample_count") int sampleCount,
+    @JsonProperty("metrics") List<MetricSample> metrics,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("message") String message
+) {
+
+    /**
+     * Creates a response with metric data.
+     *
+     * @param clusterName the Kafka cluster name
+     * @param namespace   the Kubernetes namespace
+     * @param provider    the metrics provider name
+     * @param categories  the requested categories
+     * @param metrics     the metric samples
+     * @return a response with the metric data
+     */
+    public static KafkaMetricsResponse of(final String clusterName, final String namespace,
+                                           final String provider, final List<String> categories,
+                                           final List<MetricSample> metrics) {
+        long metricCount = metrics.stream()
+            .map(MetricSample::name)
+            .distinct()
+            .count();
+
+        String msg = String.format("Retrieved %d samples across %d metrics from cluster '%s'",
+            metrics.size(), metricCount, clusterName);
+
+        return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
+            metricCount, metrics.size(), metrics, Instant.now(), msg);
+    }
+
+    /**
+     * Creates an empty response when no metrics are available.
+     *
+     * @param clusterName the Kafka cluster name
+     * @param namespace   the Kubernetes namespace
+     * @param message     descriptive message explaining why no metrics are available
+     * @return an empty response
+     */
+    public static KafkaMetricsResponse empty(final String clusterName, final String namespace,
+                                              final String message) {
+        return new KafkaMetricsResponse(clusterName, namespace, null, List.of(),
+            0, 0, List.of(), Instant.now(), message);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponse.java
@@ -13,25 +13,25 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * Response containing metrics data from a Kafka cluster.
+ * Response containing metrics data from a Strimzi cluster operator.
  * For instant queries, metrics are returned as a flat list in {@code metrics}.
  * For range queries, metrics are grouped into compact time series in {@code timeSeries}.
  *
- * @param clusterName    the Kafka cluster name
- * @param namespace      the Kubernetes namespace
- * @param provider       the metrics provider used
- * @param categories     the metric categories requested
- * @param metricCount    the number of distinct metric names in the response
- * @param sampleCount    the total number of metric samples
- * @param metrics        the flat list of metric samples (instant queries)
- * @param timeSeries     the grouped time series (range queries)
+ * @param operatorName  the operator deployment name
+ * @param namespace     the Kubernetes namespace
+ * @param provider      the metrics provider used
+ * @param categories    the metric categories requested
+ * @param metricCount   the number of distinct metric names in the response
+ * @param sampleCount   the total number of metric samples
+ * @param metrics       the flat list of metric samples (instant queries)
+ * @param timeSeries    the grouped time series (range queries)
  * @param interpretation brief guide for interpreting the returned metrics
- * @param timestamp      the time this result was generated
- * @param message        a human-readable summary of the result
+ * @param timestamp     the time this result was generated
+ * @param message       a human-readable summary of the result
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record KafkaMetricsResponse(
-    @JsonProperty("cluster_name") String clusterName,
+public record StrimziOperatorMetricsResponse(
+    @JsonProperty("operator_name") String operatorName,
     @JsonProperty("namespace") String namespace,
     @JsonProperty("provider") String provider,
     @JsonProperty("categories") List<String> categories,
@@ -48,7 +48,7 @@ public record KafkaMetricsResponse(
      * Creates a response with metric data. If samples have timestamps (range query),
      * groups them into compact time series. Otherwise returns a flat metrics list.
      *
-     * @param clusterName    the Kafka cluster name
+     * @param operatorName   the operator deployment name
      * @param namespace      the Kubernetes namespace
      * @param provider       the metrics provider name
      * @param categories     the requested categories
@@ -56,41 +56,41 @@ public record KafkaMetricsResponse(
      * @param interpretation brief guide for interpreting the returned metrics
      * @return a response with the metric data
      */
-    public static KafkaMetricsResponse of(final String clusterName, final String namespace,
-                                           final String provider, final List<String> categories,
-                                           final List<MetricSample> samples,
-                                           final String interpretation) {
+    public static StrimziOperatorMetricsResponse of(final String operatorName, final String namespace,
+                                                     final String provider, final List<String> categories,
+                                                     final List<MetricSample> samples,
+                                                     final String interpretation) {
         long metricCount = samples.stream()
             .map(MetricSample::name)
             .distinct()
             .count();
 
-        String msg = String.format("Retrieved %d samples across %d metrics from cluster '%s'",
-            samples.size(), metricCount, clusterName);
+        String msg = String.format("Retrieved %d samples across %d metrics from operator '%s'",
+            samples.size(), metricCount, operatorName);
 
         boolean isRangeData = !samples.isEmpty() && samples.getFirst().timestamp() != null;
 
         if (isRangeData) {
             List<MetricTimeSeries> series = MetricTimeSeries.fromSamples(samples);
-            return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
+            return new StrimziOperatorMetricsResponse(operatorName, namespace, provider, categories,
                 metricCount, samples.size(), null, series, interpretation, Instant.now(), msg);
         }
 
-        return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
+        return new StrimziOperatorMetricsResponse(operatorName, namespace, provider, categories,
             metricCount, samples.size(), samples, null, interpretation, Instant.now(), msg);
     }
 
     /**
      * Creates an empty response when no metrics are available.
      *
-     * @param clusterName the Kafka cluster name
-     * @param namespace   the Kubernetes namespace
-     * @param message     descriptive message explaining why no metrics are available
+     * @param operatorName the operator deployment name
+     * @param namespace    the Kubernetes namespace
+     * @param message      descriptive message explaining why no metrics are available
      * @return an empty response
      */
-    public static KafkaMetricsResponse empty(final String clusterName, final String namespace,
-                                              final String message) {
-        return new KafkaMetricsResponse(clusterName, namespace, null, List.of(),
+    public static StrimziOperatorMetricsResponse empty(final String operatorName, final String namespace,
+                                                        final String message) {
+        return new StrimziOperatorMetricsResponse(operatorName, namespace, null, List.of(),
             0, 0, List.of(), null, null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeKafkaMetricsPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeKafkaMetricsPrompt.java
@@ -33,7 +33,6 @@ public class AnalyzeKafkaMetricsPrompt {
      * @param concern     optional description of the concern to investigate
      * @return prompt response with metrics analysis instructions
      */
-    @SuppressWarnings("checkstyle:MethodLength")
     @Prompt(
         name = "analyze-kafka-metrics",
         description = "Step-by-step analysis of Kafka cluster metrics."
@@ -66,148 +65,83 @@ public class AnalyzeKafkaMetricsPrompt {
         String instructions = """
             You are analyzing metrics for Kafka cluster `%s`.%s
 
-            **CRITICAL CONTEXT FOR CLUSTER HEALTH:**
-            - Kafka is a distributed system where failures cascade
-            - Replication metrics directly impact data availability (CRITICAL)
-            - Performance metrics predict imminent failures (HIGH)
-            - Resource metrics indicate long-term trends (MEDIUM)
-            
             **Analysis Priority (check in this order):**
-            1. **CRITICAL**: Replication health → affects data availability NOW
-            2. **HIGH**: Performance bottlenecks → will cause replication issues SOON
-            3. **MEDIUM**: Resource exhaustion → will cause performance issues LATER
-            4. **LOW**: Throughput trends → informational only
+            1. **CRITICAL**: Replication health → data availability
+            2. **HIGH**: Performance bottlenecks → predicts replication issues
+            3. **MEDIUM**: Resource exhaustion → predicts performance issues
+            4. **LOW**: Throughput trends → informational
 
-            Use `get_kafka_metrics` to query each category below. The response includes \
-            an `interpretation` field with metric descriptions, thresholds, and severity tags — \
-            use it to interpret the values and prioritize findings.
+            Each `get_kafka_metrics` response includes an `interpretation` field with \
+            per-metric descriptions, thresholds, and severity — use it to interpret values.
 
-            ## Step 1: Replication health [CRITICAL - affects data availability]
+            ## Step 1: Replication health [CRITICAL]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='replication')`.
-            
-            **STOP AND ESCALATE IMMEDIATELY IF:**
-            - offlinepartitionscount > 0 → partitions unavailable (CRITICAL)
-            - underreplicatedpartitions > 0 for >5 minutes → data loss risk (CRITICAL)
-            
-            **TIME-SENSITIVE CHECKS:**
-            - underreplicatedpartitions > 0: Expected during rolling restarts (2-3 min per broker). \
-            If sustained >5 minutes during normal operations → broker overload, network issues, or disk I/O problems.
-            - maxlag: <1000 = healthy, 1000-10000 = monitor, >10000 = investigate broker load
-            - leadercount: >20%% variance across brokers = uneven load, needs partition reassignment
-            
-            **If replication issues found, immediately check Step 3 (performance) to identify root cause.**
 
-            ## Step 2: Throughput analysis [LOW - informational]
+            **STOP AND ESCALATE IF:**
+            - offlinepartitionscount > 0 → partitions unavailable
+            - underreplicatedpartitions > 0 for >5 minutes → data loss risk
+
+            Use the `interpretation` field for threshold guidance on maxlag and leadercount. \
+            If replication issues found, immediately check Step 3 to identify root cause.
+
+            ## Step 2: Throughput [LOW - informational]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='throughput')`.
-            
-            Look for patterns:
-            - Sudden drops in messagesin_total rate = producer issues
-            - bytesin/bytesout imbalance across brokers = hot partitions
-            - Compare produce vs fetch request rates for workload characterization
-            
-            **Note:** Throughput metrics are informational. Only concerning if combined with \
-            replication or performance issues.
+            Look for rate drops (producer issues) and cross-broker imbalance (hot partitions). \
+            Only concerning if combined with replication or performance issues.
 
-            ## Step 3: Request performance [HIGH - predicts failures]
+            ## Step 3: Request performance [HIGH]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='performance')`.
-            
-            **CRITICAL THRESHOLDS:**
-            - brokerrequesthandleravgidle_percent:
-              * >0.5 = healthy headroom
-              * 0.3-0.5 = monitor closely
-              * <0.3 = overloaded (add capacity)
-              * <0.1 = critical (clients experiencing timeouts)
-            
-            - requestqueuetimems:
-              * <50ms = good
-              * 50-100ms = acceptable
-              * >100ms = bottleneck
-              * >500ms = severe (clients timing out)
-            
-            - networkprocessoravgidle_percent:
-              * >0.5 = healthy
-              * 0.3-0.5 = monitor
-              * <0.3 = network bottleneck
-            
-            **CASCADING FAILURE PATTERN:**
-            If brokerrequesthandleravgidle < 0.3 AND requestqueuetimems increasing \
-            → broker overload will cause replication lag (check Step 1 for confirmation)
+            Use the `interpretation` field for threshold guidance. \
+            If broker request handler idle or network processor idle are in concerning ranges, \
+            correlate with Step 1 — performance degradation causes replication lag.
 
-            ## Step 4: JVM and resource usage [MEDIUM - long-term health]
+            ## Step 4: JVM and resource usage [MEDIUM]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='resources')`.
-            
-            **IMPORTANT - AVOID FALSE POSITIVES:**
-            Java normally uses most of its allocated heap. High heap usage alone is NOT a problem. \
-            Only flag JVM memory as concerning if combined with:
-            - Pod restarts (check with `get_kafka_cluster_pods`)
-            - OOM errors in pod logs (check with `get_kafka_logs`)
-            - Excessive GC overhead (rapidly increasing GC count)
-            
-            **GC THRESHOLDS:**
-            - <5%% of CPU time = healthy
-            - 5-10%% = monitor
-            - >10%% = investigate heap sizing
-            
-            **THREAD HEALTH:**
-            - Stable thread count = normal
-            - Rapid growth (>50%% in <5 min) = connection storms or thread leaks
-            
-            **CASCADING FAILURE PATTERN:**
-            If GC count rapidly increasing AND CPU high AND brokerrequesthandleravgidle dropping \
-            → GC thrashing causing broker overload
+            Use the `interpretation` field for JVM guidance. \
+            Cross-reference with `get_kafka_cluster_pods` for restart counts \
+            before flagging memory concerns.
 
             ## Step 5: Correlate and diagnose
             Cross-reference findings from all steps to identify root causes:
-            
+
             **Common Cascading Failure Patterns:**
-            
+
             1. **Broker Overload Cascade:**
                - brokerrequesthandleravgidle < 0.3 (Step 3)
                → requestqueuetimems increasing (Step 3)
                → underreplicatedpartitions > 0 (Step 1)
-               → maxlag growing (Step 1)
-               **Action**: Scale horizontally or reduce producer/consumer load
-            
+               **Action**: Scale horizontally or reduce load
+
             2. **Network Bottleneck Cascade:**
                - networkprocessoravgidle < 0.3 (Step 3)
                → responsequeuetimems increasing (Step 3)
                → maxlag growing (Step 1)
-               **Action**: Increase network threads or reduce connection count
-            
+               **Action**: Increase network threads or reduce connections
+
             3. **GC Thrashing Cascade:**
                - GC count rapidly increasing (Step 4)
                → CPU high (Step 4)
                → brokerrequesthandleravgidle dropping (Step 3)
-               → requestqueuetimems increasing (Step 3)
-               **Action**: Check for OOM in logs, increase heap, or investigate memory leak
-            
+               **Action**: Check for OOM in logs, increase heap
+
             4. **Controller Failure Cascade:**
                - offlinepartitionscount > 0 (Step 1)
                + leadercount severely imbalanced (Step 1)
-               **Action**: Check controller logs, verify ZooKeeper/KRaft health
-            
+               **Action**: Check controller logs, verify KRaft health
+
             5. **Disk I/O Cascade:**
                - maxlag growing steadily (Step 1)
                + underreplicatedpartitions increasing (Step 1)
                + brokerrequesthandleravgidle normal (Step 3)
-               **Action**: Check disk metrics, consider faster storage or more brokers
-            
-            **Verification Steps:**
-            - If JVM memory looked high, check `get_kafka_cluster_pods` for restart counts \
-            before raising it as an issue
-            - If replication lag found, verify broker load in Step 3 to identify root cause
-            - If performance degraded, check Step 4 for resource exhaustion
+               **Action**: Check disk metrics, consider faster storage
 
             ## Final Summary
             Provide a clear summary with:
-            1. **Overall cluster health assessment** (CRITICAL/HIGH/MEDIUM/LOW severity)
-            2. **Any metrics that are concerning or critical** (with specific values and thresholds)
-            3. **Root cause analysis** (identify cascading failure patterns if present)
+            1. **Overall health** (CRITICAL/HIGH/MEDIUM/LOW severity)
+            2. **Concerning metrics** (with specific values)
+            3. **Root cause analysis** (identify cascading patterns if present)
             4. **Actionable recommendations** (prioritized by severity)
-            5. **Verification steps** (what to check next to confirm diagnosis)
-            
-            **Remember:** All metrics healthy = cluster is operating normally. \
-            Don't raise false alarms based on high heap usage alone.\
+            5. **Verification steps** (what to check next)\
             """.formatted(
                 clusterName, concernClause,
                 clusterName, nsArg,

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeKafkaMetricsPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeKafkaMetricsPrompt.java
@@ -33,6 +33,7 @@ public class AnalyzeKafkaMetricsPrompt {
      * @param concern     optional description of the concern to investigate
      * @return prompt response with metrics analysis instructions
      */
+    @SuppressWarnings("checkstyle:MethodLength")
     @Prompt(
         name = "analyze-kafka-metrics",
         description = "Step-by-step analysis of Kafka cluster metrics."
@@ -65,55 +66,148 @@ public class AnalyzeKafkaMetricsPrompt {
         String instructions = """
             You are analyzing metrics for Kafka cluster `%s`.%s
 
+            **CRITICAL CONTEXT FOR CLUSTER HEALTH:**
+            - Kafka is a distributed system where failures cascade
+            - Replication metrics directly impact data availability (CRITICAL)
+            - Performance metrics predict imminent failures (HIGH)
+            - Resource metrics indicate long-term trends (MEDIUM)
+            
+            **Analysis Priority (check in this order):**
+            1. **CRITICAL**: Replication health → affects data availability NOW
+            2. **HIGH**: Performance bottlenecks → will cause replication issues SOON
+            3. **MEDIUM**: Resource exhaustion → will cause performance issues LATER
+            4. **LOW**: Throughput trends → informational only
+
             Use `get_kafka_metrics` to query each category below. The response includes \
-            an `interpretation` field with metric descriptions and thresholds — use it \
-            to interpret the values.
+            an `interpretation` field with metric descriptions, thresholds, and severity tags — \
+            use it to interpret the values and prioritize findings.
 
-            ## Step 1: Replication health
+            ## Step 1: Replication health [CRITICAL - affects data availability]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='replication')`.
-            Critical checks:
-            - underreplicatedpartitions > 0 = data loss risk
-            - offlinepartitionscount > 0 = partitions unavailable (critical)
-            - maxlag growing = followers falling behind
-            - leadercount imbalanced across brokers = uneven load
+            
+            **STOP AND ESCALATE IMMEDIATELY IF:**
+            - offlinepartitionscount > 0 → partitions unavailable (CRITICAL)
+            - underreplicatedpartitions > 0 for >5 minutes → data loss risk (CRITICAL)
+            
+            **TIME-SENSITIVE CHECKS:**
+            - underreplicatedpartitions > 0: Expected during rolling restarts (2-3 min per broker). \
+            If sustained >5 minutes during normal operations → broker overload, network issues, or disk I/O problems.
+            - maxlag: <1000 = healthy, 1000-10000 = monitor, >10000 = investigate broker load
+            - leadercount: >20%% variance across brokers = uneven load, needs partition reassignment
+            
+            **If replication issues found, immediately check Step 3 (performance) to identify root cause.**
 
-            ## Step 2: Throughput analysis
+            ## Step 2: Throughput analysis [LOW - informational]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='throughput')`.
-            Look for:
+            
+            Look for patterns:
             - Sudden drops in messagesin_total rate = producer issues
             - bytesin/bytesout imbalance across brokers = hot partitions
-            - Compare produce vs fetch request rates
+            - Compare produce vs fetch request rates for workload characterization
+            
+            **Note:** Throughput metrics are informational. Only concerning if combined with \
+            replication or performance issues.
 
-            ## Step 3: Request performance
+            ## Step 3: Request performance [HIGH - predicts failures]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='performance')`.
-            Key thresholds:
-            - brokerrequesthandleravgidle_percent < 0.3 = overloaded broker
-            - requestqueuetimems increasing = broker can't keep up
-            - networkprocessoravgidle_percent < 0.3 = network bottleneck
+            
+            **CRITICAL THRESHOLDS:**
+            - brokerrequesthandleravgidle_percent:
+              * >0.5 = healthy headroom
+              * 0.3-0.5 = monitor closely
+              * <0.3 = overloaded (add capacity)
+              * <0.1 = critical (clients experiencing timeouts)
+            
+            - requestqueuetimems:
+              * <50ms = good
+              * 50-100ms = acceptable
+              * >100ms = bottleneck
+              * >500ms = severe (clients timing out)
+            
+            - networkprocessoravgidle_percent:
+              * >0.5 = healthy
+              * 0.3-0.5 = monitor
+              * <0.3 = network bottleneck
+            
+            **CASCADING FAILURE PATTERN:**
+            If brokerrequesthandleravgidle < 0.3 AND requestqueuetimems increasing \
+            → broker overload will cause replication lag (check Step 1 for confirmation)
 
-            ## Step 4: JVM and resource usage
+            ## Step 4: JVM and resource usage [MEDIUM - long-term health]
             Call `get_kafka_metrics(cluster_name='%s'%s, category='resources')`.
-            Important: Java normally uses most of its allocated heap. \
-            High heap usage alone is NOT a problem. Only flag JVM memory \
-            as concerning if combined with:
+            
+            **IMPORTANT - AVOID FALSE POSITIVES:**
+            Java normally uses most of its allocated heap. High heap usage alone is NOT a problem. \
+            Only flag JVM memory as concerning if combined with:
             - Pod restarts (check with `get_kafka_cluster_pods`)
-            - OOM errors in pod logs
+            - OOM errors in pod logs (check with `get_kafka_logs`)
             - Excessive GC overhead (rapidly increasing GC count)
-            Also watch for rising thread count = possible connection storms.
+            
+            **GC THRESHOLDS:**
+            - <5%% of CPU time = healthy
+            - 5-10%% = monitor
+            - >10%% = investigate heap sizing
+            
+            **THREAD HEALTH:**
+            - Stable thread count = normal
+            - Rapid growth (>50%% in <5 min) = connection storms or thread leaks
+            
+            **CASCADING FAILURE PATTERN:**
+            If GC count rapidly increasing AND CPU high AND brokerrequesthandleravgidle dropping \
+            → GC thrashing causing broker overload
 
             ## Step 5: Correlate and diagnose
-            Cross-reference findings from all steps. If JVM memory looked \
-            high, check `get_kafka_cluster_pods` for restart counts before \
-            raising it as an issue.
-            - High replication lag + high request queue time = broker overload
-            - Pod restarts + high GC = possible OOM, needs more heap
-            - Uneven leader distribution + throughput imbalance = needs partition reassignment
-            - All metrics healthy = cluster is operating normally
+            Cross-reference findings from all steps to identify root causes:
+            
+            **Common Cascading Failure Patterns:**
+            
+            1. **Broker Overload Cascade:**
+               - brokerrequesthandleravgidle < 0.3 (Step 3)
+               → requestqueuetimems increasing (Step 3)
+               → underreplicatedpartitions > 0 (Step 1)
+               → maxlag growing (Step 1)
+               **Action**: Scale horizontally or reduce producer/consumer load
+            
+            2. **Network Bottleneck Cascade:**
+               - networkprocessoravgidle < 0.3 (Step 3)
+               → responsequeuetimems increasing (Step 3)
+               → maxlag growing (Step 1)
+               **Action**: Increase network threads or reduce connection count
+            
+            3. **GC Thrashing Cascade:**
+               - GC count rapidly increasing (Step 4)
+               → CPU high (Step 4)
+               → brokerrequesthandleravgidle dropping (Step 3)
+               → requestqueuetimems increasing (Step 3)
+               **Action**: Check for OOM in logs, increase heap, or investigate memory leak
+            
+            4. **Controller Failure Cascade:**
+               - offlinepartitionscount > 0 (Step 1)
+               + leadercount severely imbalanced (Step 1)
+               **Action**: Check controller logs, verify ZooKeeper/KRaft health
+            
+            5. **Disk I/O Cascade:**
+               - maxlag growing steadily (Step 1)
+               + underreplicatedpartitions increasing (Step 1)
+               + brokerrequesthandleravgidle normal (Step 3)
+               **Action**: Check disk metrics, consider faster storage or more brokers
+            
+            **Verification Steps:**
+            - If JVM memory looked high, check `get_kafka_cluster_pods` for restart counts \
+            before raising it as an issue
+            - If replication lag found, verify broker load in Step 3 to identify root cause
+            - If performance degraded, check Step 4 for resource exhaustion
 
+            ## Final Summary
             Provide a clear summary with:
-            1. Overall cluster health assessment
-            2. Any metrics that are concerning or critical
-            3. Actionable recommendations if issues are found\
+            1. **Overall cluster health assessment** (CRITICAL/HIGH/MEDIUM/LOW severity)
+            2. **Any metrics that are concerning or critical** (with specific values and thresholds)
+            3. **Root cause analysis** (identify cascading failure patterns if present)
+            4. **Actionable recommendations** (prioritized by severity)
+            5. **Verification steps** (what to check next to confirm diagnosis)
+            
+            **Remember:** All metrics healthy = cluster is operating normally. \
+            Don't raise false alarms based on high heap usage alone.\
             """.formatted(
                 clusterName, concernClause,
                 clusterName, nsArg,

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeKafkaMetricsPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeKafkaMetricsPrompt.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.prompt;
+
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptArg;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+/**
+ * MCP prompt template for analyzing Kafka cluster metrics.
+ *
+ * <p>Guides the LLM through a structured metrics analysis workflow:
+ * query metrics by category, interpret values against known thresholds,
+ * and correlate findings to diagnose cluster health issues.</p>
+ */
+@Singleton
+public class AnalyzeKafkaMetricsPrompt {
+
+    AnalyzeKafkaMetricsPrompt() {
+    }
+
+    /**
+     * Generate a metrics analysis prompt for a Kafka cluster.
+     *
+     * @param clusterName the name of the Kafka cluster
+     * @param namespace   the Kubernetes namespace of the cluster
+     * @param concern     optional description of the concern to investigate
+     * @return prompt response with metrics analysis instructions
+     */
+    @Prompt(
+        name = "analyze-kafka-metrics",
+        description = "Step-by-step analysis of Kafka cluster metrics."
+            + " Guides through replication, throughput, performance, and resource metrics."
+    )
+    public PromptResponse analyzeKafkaMetrics(
+        @PromptArg(
+            name = "cluster_name",
+            description = "Name of the Kafka cluster to analyze."
+        ) final String clusterName,
+        @PromptArg(
+            name = "namespace",
+            description = "Kubernetes namespace where the Kafka cluster is deployed.",
+            required = false
+        ) final String namespace,
+        @PromptArg(
+            name = "concern",
+            description = "Specific concern to investigate, e.g. 'high latency', "
+                + "'replication lag', 'consumer lag'.",
+            required = false
+        ) final String concern
+    ) {
+        String nsArg = namespace != null && !namespace.isBlank()
+            ? ", namespace='" + namespace + "'"
+            : "";
+        String concernClause = concern != null && !concern.isBlank()
+            ? " The specific concern is: " + concern + "."
+            : "";
+
+        String instructions = """
+            You are analyzing metrics for Kafka cluster `%s`.%s
+
+            Use `get_kafka_metrics` to query each category below. The response includes \
+            an `interpretation` field with metric descriptions and thresholds — use it \
+            to interpret the values.
+
+            ## Step 1: Replication health
+            Call `get_kafka_metrics(cluster_name='%s'%s, category='replication')`.
+            Critical checks:
+            - underreplicatedpartitions > 0 = data loss risk
+            - offlinepartitionscount > 0 = partitions unavailable (critical)
+            - maxlag growing = followers falling behind
+            - leadercount imbalanced across brokers = uneven load
+
+            ## Step 2: Throughput analysis
+            Call `get_kafka_metrics(cluster_name='%s'%s, category='throughput')`.
+            Look for:
+            - Sudden drops in messagesin_total rate = producer issues
+            - bytesin/bytesout imbalance across brokers = hot partitions
+            - Compare produce vs fetch request rates
+
+            ## Step 3: Request performance
+            Call `get_kafka_metrics(cluster_name='%s'%s, category='performance')`.
+            Key thresholds:
+            - brokerrequesthandleravgidle_percent < 0.3 = overloaded broker
+            - requestqueuetimems increasing = broker can't keep up
+            - networkprocessoravgidle_percent < 0.3 = network bottleneck
+
+            ## Step 4: JVM and resource usage
+            Call `get_kafka_metrics(cluster_name='%s'%s, category='resources')`.
+            Important: Java normally uses most of its allocated heap. \
+            High heap usage alone is NOT a problem. Only flag JVM memory \
+            as concerning if combined with:
+            - Pod restarts (check with `get_kafka_cluster_pods`)
+            - OOM errors in pod logs
+            - Excessive GC overhead (rapidly increasing GC count)
+            Also watch for rising thread count = possible connection storms.
+
+            ## Step 5: Correlate and diagnose
+            Cross-reference findings from all steps. If JVM memory looked \
+            high, check `get_kafka_cluster_pods` for restart counts before \
+            raising it as an issue.
+            - High replication lag + high request queue time = broker overload
+            - Pod restarts + high GC = possible OOM, needs more heap
+            - Uneven leader distribution + throughput imbalance = needs partition reassignment
+            - All metrics healthy = cluster is operating normally
+
+            Provide a clear summary with:
+            1. Overall cluster health assessment
+            2. Any metrics that are concerning or critical
+            3. Actionable recommendations if issues are found\
+            """.formatted(
+                clusterName, concernClause,
+                clusterName, nsArg,
+                clusterName, nsArg,
+                clusterName, nsArg,
+                clusterName, nsArg);
+
+        return PromptResponse.withMessages(List.of(
+            PromptMessage.withUserRole(instructions)
+        ));
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeStrimziOperatorMetricsPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeStrimziOperatorMetricsPrompt.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.prompt;
+
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptArg;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+/**
+ * MCP prompt template for analyzing Strimzi cluster operator metrics.
+ *
+ * <p>Guides the LLM through a structured metrics analysis workflow:
+ * query reconciliation, resource, and JVM metrics from the operator,
+ * interpret values, and correlate with operator logs.</p>
+ */
+@Singleton
+public class AnalyzeStrimziOperatorMetricsPrompt {
+
+    AnalyzeStrimziOperatorMetricsPrompt() {
+    }
+
+    /**
+     * Generate a metrics analysis prompt for a Strimzi cluster operator.
+     *
+     * @param namespace the Kubernetes namespace of the operator
+     * @param concern   optional description of the concern to investigate
+     * @return prompt response with operator metrics analysis instructions
+     */
+    @Prompt(
+        name = "analyze-strimzi-operator-metrics",
+        description = "Step-by-step analysis of Strimzi cluster operator metrics."
+            + " Guides through reconciliation, resource, and JVM metrics."
+    )
+    public PromptResponse analyzeStrimziOperatorMetrics(
+        @PromptArg(
+            name = "namespace",
+            description = "Kubernetes namespace where the Strimzi operator is deployed.",
+            required = false
+        ) final String namespace,
+        @PromptArg(
+            name = "concern",
+            description = "Specific concern to investigate, e.g. 'reconciliation failures', "
+                + "'slow reconciliation', 'operator high memory'.",
+            required = false
+        ) final String concern
+    ) {
+        String nsArg = namespace != null && !namespace.isBlank()
+            ? ", namespace='" + namespace + "'"
+            : "";
+        String concernClause = concern != null && !concern.isBlank()
+            ? " The specific concern is: " + concern + "."
+            : "";
+
+        String instructions = """
+            You are analyzing metrics for the Strimzi cluster operator.%s
+
+            Use `get_strimzi_operator_metrics` to query each category below. The response \
+            includes an `interpretation` field with metric descriptions and thresholds — \
+            use it to interpret the values.
+
+            ## Step 1: Reconciliation health
+            Call `get_strimzi_operator_metrics(%scategory='reconciliation')`.
+            Critical checks:
+            - strimzi_reconciliations_failed_total increasing = operator errors, \
+            check operator logs for details
+            - strimzi_reconciliations_duration_seconds: divide sum by count for average. \
+            >60s average = slow reconciliation, may indicate resource contention
+            - Compare successful_total + failed_total with total to verify consistency
+
+            ## Step 2: Managed resources
+            Call `get_strimzi_operator_metrics(%scategory='resources')`.
+            Look for:
+            - strimzi_resources count changes = resources added/removed
+            - strimzi_resource_state: any value != 1 = unhealthy resource that needs attention
+            - Cross-reference unhealthy resources with cluster status using `get_kafka_cluster`
+
+            ## Step 3: Operator JVM health
+            Call `get_strimzi_operator_metrics(%scategory='jvm')`.
+            Important: Java normally uses most of its allocated heap. \
+            High heap usage alone is NOT a problem. Only flag JVM memory \
+            as concerning if combined with:
+            - Pod restarts (check with `get_strimzi_operator_pod`)
+            - OOM errors in operator logs
+            - Excessive GC overhead (rapidly increasing GC count)
+            Also watch for rising thread count = possible resource leak.
+
+            ## Step 4: Check pod restarts and correlate with logs
+            Use `get_strimzi_operator_pod` to check for pod restarts.
+            Use `get_strimzi_operator_logs` to check for errors or warnings.
+            Cross-reference:
+            - Failed reconciliations in metrics → specific error messages in logs
+            - Slow reconciliation → look for timeout or retry patterns in logs
+            - Pod restarts + high GC → possible OOM, check logs for OutOfMemoryError
+
+            ## Step 5: Summarize findings
+            Provide a clear summary with:
+            1. Operator health assessment
+            2. Reconciliation success rate and performance
+            3. Any resources in unhealthy state
+            4. JVM resource utilization concerns
+            5. Actionable recommendations if issues are found\
+            """.formatted(
+                concernClause,
+                nsArg.isEmpty() ? "" : "namespace='" + namespace + "', ",
+                nsArg.isEmpty() ? "" : "namespace='" + namespace + "', ",
+                nsArg.isEmpty() ? "" : "namespace='" + namespace + "', ");
+
+        return PromptResponse.withMessages(List.of(
+            PromptMessage.withUserRole(instructions)
+        ));
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeStrimziOperatorMetricsPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AnalyzeStrimziOperatorMetricsPrompt.java
@@ -60,43 +60,37 @@ public class AnalyzeStrimziOperatorMetricsPrompt {
         String instructions = """
             You are analyzing metrics for the Strimzi cluster operator.%s
 
-            Use `get_strimzi_operator_metrics` to query each category below. The response \
-            includes an `interpretation` field with metric descriptions and thresholds — \
-            use it to interpret the values.
+            Each `get_strimzi_operator_metrics` response includes an `interpretation` field \
+            with metric descriptions and thresholds — use it to interpret values.
 
             ## Step 1: Reconciliation health
             Call `get_strimzi_operator_metrics(%scategory='reconciliation')`.
-            Critical checks:
+            Use the `interpretation` field for threshold guidance. Key checks:
             - strimzi_reconciliations_failed_total increasing = operator errors, \
             check operator logs for details
-            - strimzi_reconciliations_duration_seconds: divide sum by count for average. \
-            >60s average = slow reconciliation, may indicate resource contention
-            - Compare successful_total + failed_total with total to verify consistency
+            - Divide duration sum by count for average reconciliation time
+            - Compare successful + failed with total to verify consistency
 
             ## Step 2: Managed resources
             Call `get_strimzi_operator_metrics(%scategory='resources')`.
             Look for:
             - strimzi_resources count changes = resources added/removed
-            - strimzi_resource_state: any value != 1 = unhealthy resource that needs attention
-            - Cross-reference unhealthy resources with cluster status using `get_kafka_cluster`
+            - strimzi_resource_state != 1 = unhealthy resource
+            - Cross-reference with `get_kafka_cluster` for details
 
             ## Step 3: Operator JVM health
             Call `get_strimzi_operator_metrics(%scategory='jvm')`.
-            Important: Java normally uses most of its allocated heap. \
-            High heap usage alone is NOT a problem. Only flag JVM memory \
-            as concerning if combined with:
-            - Pod restarts (check with `get_strimzi_operator_pod`)
-            - OOM errors in operator logs
-            - Excessive GC overhead (rapidly increasing GC count)
-            Also watch for rising thread count = possible resource leak.
+            Use the `interpretation` field for JVM guidance. \
+            Cross-reference with `get_strimzi_operator_pod` for restart counts \
+            before flagging memory concerns.
 
-            ## Step 4: Check pod restarts and correlate with logs
+            ## Step 4: Correlate with logs
             Use `get_strimzi_operator_pod` to check for pod restarts.
             Use `get_strimzi_operator_logs` to check for errors or warnings.
             Cross-reference:
-            - Failed reconciliations in metrics → specific error messages in logs
-            - Slow reconciliation → look for timeout or retry patterns in logs
-            - Pod restarts + high GC → possible OOM, check logs for OutOfMemoryError
+            - Failed reconciliations → specific error messages in logs
+            - Slow reconciliation → timeout or retry patterns in logs
+            - Pod restarts + high GC → possible OOM, check for OutOfMemoryError
 
             ## Step 5: Summarize findings
             Provide a clear summary with:

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
@@ -164,26 +164,16 @@ public class DiagnoseClusterIssuePrompt {
 
             ## Step 6: Check cluster metrics [CRITICAL - data availability]
             Use `get_kafka_metrics` with category 'replication' to check replication health.
-            
+
             **STOP AND ESCALATE IF:**
             - offlinepartitionscount > 0 → partitions unavailable (CRITICAL)
             - underreplicatedpartitions > 0 for >5 minutes → data loss risk
-            
-            Look for:
-            - underreplicatedpartitions > 0 → brokers falling behind or overloaded
-            - offlinepartitionscount > 0 → partitions with no leader (unavailable)
-            - maxlag growing → replication lag increasing (check performance next)
-            - leadercount imbalanced → uneven load distribution
-            
-            **If replication issues found, check performance metrics:**
-            Use `get_kafka_metrics` with category 'performance'.
-            - brokerrequesthandleravgidle_percent < 0.3 → broker overloaded
-            - requestqueuetimems increasing → broker can't keep up with load
-            - networkprocessoravgidle_percent < 0.3 → network bottleneck
-            
-            The response includes an `interpretation` field with detailed metric guidance \
-            and thresholds.
-            
+
+            Use the `interpretation` field for per-metric threshold guidance.
+
+            If replication issues found, also call `get_kafka_metrics` with \
+            category 'performance' and use its `interpretation` field for thresholds.
+
             **Correlation patterns:**
             - Replication lag + low broker idle → broker overload (scale or reduce load)
             - Replication lag + normal broker idle → disk I/O bottleneck

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
@@ -17,7 +17,7 @@ import java.util.List;
  *
  * <p>Guides the LLM through a structured diagnostic workflow:
  * check cluster status, node pools, operator logs, pod health,
- * and pod logs to identify root causes.</p>
+ * pod logs, and cluster metrics to identify root causes.</p>
  */
 @Singleton
 public class DiagnoseClusterIssuePrompt {
@@ -36,7 +36,7 @@ public class DiagnoseClusterIssuePrompt {
     @Prompt(
         name = "diagnose-cluster-issue",
         description = "Step-by-step diagnosis of a Kafka cluster issue."
-            + " Guides through status checks, operator logs, and pod inspection."
+            + " Guides through status checks, operator logs, pod inspection, and metrics analysis."
     )
     public PromptResponse diagnoseClusterIssue(
         @PromptArg(
@@ -95,12 +95,22 @@ public class DiagnoseClusterIssuePrompt {
             Look for: OOM kill messages, disk full errors, connection refused, \
             `OutOfMemoryError`, `IOException`, `No space left on device`.
 
-            ## Step 6: Correlate and summarize
-            Correlate the findings from all steps.
+            ## Step 6: Check cluster metrics
+            Use `get_kafka_metrics` with category 'replication' to check replication health.
+            Look for: underreplicatedpartitions > 0, offlinepartitionscount > 0, \
+            growing maxlag.
+            If replication looks healthy, also check category 'performance'.
+            Look for: brokerrequesthandleravgidle_percent < 0.3, \
+            increasing requestqueuetimems.
+            The response includes an `interpretation` field with detailed metric guidance.
+
+            ## Step 7: Correlate and summarize
+            Correlate the findings from all steps, including metrics data.
             Distinguish between:
             - Operator-initiated changes (rolling updates, certificate renewal, configuration changes)
             - Infrastructure failures (OOM, disk full, node issues)
             - Configuration errors (invalid resource specs, missing secrets)
+            - Performance degradation (overloaded brokers, replication lag, network bottlenecks)
 
             Provide a clear summary of the root cause and actionable recommendations.\
             """.formatted(clusterName, nsClause, symptomClause, clusterName);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
@@ -33,6 +33,7 @@ public class DiagnoseClusterIssuePrompt {
      * @param symptom     optional description of the observed symptom
      * @return prompt response with diagnostic instructions
      */
+    @SuppressWarnings("checkstyle:MethodLength")
     @Prompt(
         name = "diagnose-cluster-issue",
         description = "Step-by-step diagnosis of a Kafka cluster issue."
@@ -64,55 +65,180 @@ public class DiagnoseClusterIssuePrompt {
         String instructions = """
             You are diagnosing a Kafka cluster issue for cluster `%s`%s.%s
 
+            **CRITICAL CONTEXT FOR INCIDENT RESPONSE:**
+            - Kafka clusters can experience cascading failures
+            - Data availability issues (offline partitions) are CRITICAL
+            - Pod failures may be symptoms, not root causes
+            - Operator reconciliation issues can prevent recovery
+            
+            **Diagnostic Priority:**
+            1. **CRITICAL**: Data availability (offline partitions, cluster NotReady)
+            2. **HIGH**: Pod health (crashes, OOM, restarts)
+            3. **MEDIUM**: Operator reconciliation (stuck, errors)
+            4. **LOW**: Performance degradation (if cluster is otherwise healthy)
+
             Follow these steps in order. After each step, analyze the results \
-            before proceeding to the next.
+            before proceeding to the next. **Stop and escalate immediately if you find \
+            offline partitions or cluster-wide unavailability.**
 
-            ## Step 1: Check Kafka cluster status
+            ## Step 1: Check Kafka cluster status [CRITICAL - cluster availability]
             Use `get_kafka_cluster` to retrieve the cluster status and conditions.
-            Look for: NotReady conditions, stalled reconciliation, \
-            mismatched observed/expected generation, warning conditions.
+            
+            **STOP AND ESCALATE IF:**
+            - Cluster status is NotReady for >10 minutes (not during rolling update)
+            - Conditions show "KafkaNotReady" or "ZooKeeperNotReady"
+            
+            Look for:
+            - NotReady conditions → cluster unavailable or degraded
+            - Stalled reconciliation (observedGeneration != generation) → operator stuck
+            - Warning conditions → potential issues developing
+            - Recent status changes → correlate with symptom timeline
+            
+            **Expected during normal operations:**
+            - Brief NotReady during rolling updates (2-3 min per broker)
+            - Certificate renewal reconciliations (every 30 days)
 
-            ## Step 2: Check KafkaNodePool statuses
+            ## Step 2: Check KafkaNodePool statuses [HIGH - broker availability]
             Use `list_kafka_node_pools` to list all node pools for this cluster.
             For any pool that looks unhealthy, use `get_kafka_node_pool` for details.
-            Look for: pools with fewer ready replicas than expected, \
-            pools in non-Ready state, role mismatches.
+            
+            Look for:
+            - Pools with fewer ready replicas than expected → brokers down
+            - Pools in non-Ready state → provisioning or configuration issues
+            - Role mismatches (controller vs broker) → KRaft migration issues
+            - Uneven replica distribution → scaling or rebalancing in progress
+            
+            **If multiple pools are unhealthy, this indicates a cluster-wide issue \
+            (infrastructure, operator, or configuration problem).**
 
-            ## Step 3: Check Strimzi operator
+            ## Step 3: Check Strimzi operator [MEDIUM - reconciliation health]
             Use `list_strimzi_operators` to find the operator managing this cluster.
             Use `get_strimzi_operator_logs` to read operator logs.
-            Look for: reconciliation errors, exceptions, warnings related to \
-            `%s`, repeated error patterns.
+            
+            Look for:
+            - Reconciliation errors for `%s` → operator can't manage cluster
+            - Repeated error patterns → persistent configuration or permission issues
+            - Exceptions or stack traces → operator bugs or resource conflicts
+            - "Reconciliation #N failed" → count failures to assess severity
+            
+            **Common operator issues:**
+            - Missing RBAC permissions → check ClusterRole/RoleBinding
+            - Invalid resource specs → check Kafka CR for validation errors
+            - Resource conflicts → check for competing operators or manual changes
+            - Kubernetes API throttling → check operator resource limits
 
-            ## Step 4: Check pod health
+            ## Step 4: Check pod health [HIGH - broker availability]
             Use `get_kafka_cluster_pods` to check all pods for the cluster.
-            Look for: CrashLoopBackOff, Pending pods, high restart counts, \
-            pods not in Running phase, containers not ready.
+            
+            **CRITICAL POD STATES:**
+            - CrashLoopBackOff → pod failing to start (check logs in Step 5)
+            - Pending → resource constraints or scheduling issues
+            - High restart counts (>3 in last hour) → unstable broker
+            - Containers not ready → health checks failing
+            
+            Look for patterns:
+            - All pods unhealthy → cluster-wide issue (infrastructure, config)
+            - Single pod unhealthy → isolated broker issue (disk, memory, network)
+            - Pods restarting sequentially → rolling update in progress (expected)
+            - Pods stuck in Pending → resource exhaustion (CPU, memory, PVCs)
+            
+            **If pods are healthy but cluster is NotReady, issue is likely at \
+            the Kafka application level (check metrics in Step 6).**
 
-            ## Step 5: Read pod logs from unhealthy pods
+            ## Step 5: Read pod logs from unhealthy pods [HIGH - root cause identification]
             For any unhealthy pods found in Step 4, use `get_kafka_cluster_logs` \
             with filter 'errors' to get error logs from broker pods.
-            Look for: OOM kill messages, disk full errors, connection refused, \
-            `OutOfMemoryError`, `IOException`, `No space left on device`.
+            
+            **CRITICAL ERROR PATTERNS:**
+            - "OutOfMemoryError" or "OOM killed" → insufficient heap, increase memory
+            - "No space left on device" → disk full, increase storage or clean up
+            - "Connection refused" or "Unable to connect" → network issues
+            - "IOException" → disk I/O problems or corrupted data
+            - "FATAL" or "ERROR" in startup logs → configuration or dependency issues
+            
+            **Common root causes:**
+            - OOM: Heap too small for workload, increase Xmx or reduce load
+            - Disk full: Log retention too long, increase storage or reduce retention
+            - Network: Firewall rules, DNS issues, or pod network problems
+            - Corruption: Disk failures, need to replace broker and rebuild replicas
 
-            ## Step 6: Check cluster metrics
+            ## Step 6: Check cluster metrics [CRITICAL - data availability]
             Use `get_kafka_metrics` with category 'replication' to check replication health.
-            Look for: underreplicatedpartitions > 0, offlinepartitionscount > 0, \
-            growing maxlag.
-            If replication looks healthy, also check category 'performance'.
-            Look for: brokerrequesthandleravgidle_percent < 0.3, \
-            increasing requestqueuetimems.
-            The response includes an `interpretation` field with detailed metric guidance.
+            
+            **STOP AND ESCALATE IF:**
+            - offlinepartitionscount > 0 → partitions unavailable (CRITICAL)
+            - underreplicatedpartitions > 0 for >5 minutes → data loss risk
+            
+            Look for:
+            - underreplicatedpartitions > 0 → brokers falling behind or overloaded
+            - offlinepartitionscount > 0 → partitions with no leader (unavailable)
+            - maxlag growing → replication lag increasing (check performance next)
+            - leadercount imbalanced → uneven load distribution
+            
+            **If replication issues found, check performance metrics:**
+            Use `get_kafka_metrics` with category 'performance'.
+            - brokerrequesthandleravgidle_percent < 0.3 → broker overloaded
+            - requestqueuetimems increasing → broker can't keep up with load
+            - networkprocessoravgidle_percent < 0.3 → network bottleneck
+            
+            The response includes an `interpretation` field with detailed metric guidance \
+            and thresholds.
+            
+            **Correlation patterns:**
+            - Replication lag + low broker idle → broker overload (scale or reduce load)
+            - Replication lag + normal broker idle → disk I/O bottleneck
+            - Offline partitions + pod crashes → broker failures causing partition unavailability
+            - Offline partitions + healthy pods → controller issues (check operator logs)
 
-            ## Step 7: Correlate and summarize
+            ## Step 7: Correlate and summarize [ROOT CAUSE ANALYSIS]
             Correlate the findings from all steps, including metrics data.
-            Distinguish between:
-            - Operator-initiated changes (rolling updates, certificate renewal, configuration changes)
-            - Infrastructure failures (OOM, disk full, node issues)
-            - Configuration errors (invalid resource specs, missing secrets)
-            - Performance degradation (overloaded brokers, replication lag, network bottlenecks)
+            
+            **Distinguish between issue types:**
+            
+            1. **Operator-initiated changes (EXPECTED):**
+               - Rolling updates → pods restarting sequentially, brief NotReady
+               - Certificate renewal → reconciliation activity, no pod restarts
+               - Configuration changes → reconciliation, possible rolling restart
+               **Action**: Monitor for completion, no intervention needed
+            
+            2. **Infrastructure failures (CRITICAL):**
+               - OOM → increase heap size or reduce load
+               - Disk full → increase storage or reduce retention
+               - Node failures → check Kubernetes node health
+               - Network issues → check pod network, DNS, firewall rules
+               **Action**: Fix infrastructure, may need broker replacement
+            
+            3. **Configuration errors (HIGH):**
+               - Invalid resource specs → fix Kafka CR and reapply
+               - Missing secrets → create required secrets
+               - RBAC issues → fix operator permissions
+               **Action**: Correct configuration, operator will reconcile
+            
+            4. **Performance degradation (MEDIUM):**
+               - Overloaded brokers → scale horizontally or reduce load
+               - Replication lag → check broker capacity and disk I/O
+               - Network bottlenecks → increase network threads or reduce connections
+               **Action**: Capacity planning, scaling, or load reduction
+            
+            5. **Cascading failures (CRITICAL):**
+               - Broker overload → replication lag → offline partitions
+               - GC thrashing → broker overload → replication lag
+               - Controller failure → offline partitions → cluster unavailability
+               **Action**: Address root cause first, then allow system to recover
 
-            Provide a clear summary of the root cause and actionable recommendations.\
+            ## Final Summary
+            Provide a clear summary with:
+            1. **Root cause** (single most likely cause, not a list of symptoms)
+            2. **Severity** (CRITICAL/HIGH/MEDIUM/LOW based on data availability impact)
+            3. **Impact** (what is affected: data availability, performance, stability)
+            4. **Evidence** (specific findings from steps 1-6 that support the diagnosis)
+            5. **Actionable recommendations** (prioritized, specific steps to resolve)
+            6. **Expected recovery time** (how long until cluster is healthy after fix)
+            7. **Prevention** (how to avoid this issue in the future)
+            
+            **Remember:** Symptoms are not root causes. Pod restarts are symptoms; \
+            OOM or disk full are root causes. Offline partitions are symptoms; \
+            broker failures or controller issues are root causes.\
             """.formatted(clusterName, nsClause, symptomClause, clusterName);
 
         return PromptResponse.withMessages(List.of(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
@@ -444,7 +444,7 @@ public class KafkaService {
             .map(listener -> {
                 String bootstrapAddress = null;
                 if (listener.getAddresses() != null && !listener.getAddresses().isEmpty()) {
-                    var addr = listener.getAddresses().getFirst();
+                    GenericKafkaListenerStatusAddresses addr = listener.getAddresses().getFirst();
                     if (addr.getHost() != null && addr.getPort() != null) {
                         bootstrapAddress = String.format("%s:%d", addr.getHost(), addr.getPort());
                     }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
@@ -27,6 +27,7 @@ import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.api.kafka.model.kafka.listener.ListenerAddress;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -444,7 +445,7 @@ public class KafkaService {
             .map(listener -> {
                 String bootstrapAddress = null;
                 if (listener.getAddresses() != null && !listener.getAddresses().isEmpty()) {
-                    GenericKafkaListenerStatusAddresses addr = listener.getAddresses().getFirst();
+                    ListenerAddress addr = listener.getAddresses().getFirst();
                     if (addr.getHost() != null && addr.getPort() != null) {
                         bootstrapAddress = String.format("%s:%d", addr.getHost(), addr.getPort());
                     }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
@@ -11,8 +11,10 @@ import io.streamshub.mcp.common.dto.metrics.PodTarget;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.service.metrics.MetricsQueryService;
 import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.metrics.prometheus.util.PromQLSanitizer;
 import io.streamshub.mcp.strimzi.config.metrics.KafkaMetricCategories;
 import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.util.TimeRangeValidator;
 import io.strimzi.api.ResourceLabels;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -52,6 +54,8 @@ public class KafkaMetricsService {
      * @param category     the metric category (optional, defaults to "replication")
      * @param metricNames  explicit metric names (optional, merged with category)
      * @param rangeMinutes range query duration in minutes (optional, null for instant)
+     * @param startTime    absolute start time in ISO 8601 format (optional, use with endTime)
+     * @param endTime      absolute end time in ISO 8601 format (optional, use with startTime)
      * @param stepSeconds  range query step interval (optional, uses default)
      * @return the metrics response
      */
@@ -61,6 +65,8 @@ public class KafkaMetricsService {
                                                  final String category,
                                                  final String metricNames,
                                                  final Integer rangeMinutes,
+                                                 final String startTime,
+                                                 final String endTime,
                                                  final Integer stepSeconds) {
         String ns = InputUtils.normalizeInput(namespace);
         String name = InputUtils.normalizeInput(clusterName);
@@ -69,6 +75,9 @@ public class KafkaMetricsService {
         if (name == null) {
             throw new ToolCallException("Cluster name is required");
         }
+
+        // Validate time range parameters
+        TimeRangeValidator.validateTimeRangeParameters(rangeMinutes, startTime, endTime);
 
         // Resolve metric names from category + explicit names
         List<String> resolvedMetrics = resolveMetricNames(cat, metricNames);
@@ -107,7 +116,7 @@ public class KafkaMetricsService {
 
         // Query metrics via general service
         List<MetricSample> samples = metricsQueryService.queryMetrics(
-            podTargets, labelMatchers, resolvedMetrics, rangeMinutes, stepSeconds);
+            podTargets, labelMatchers, resolvedMetrics, rangeMinutes, startTime, endTime, stepSeconds);
 
         // Build interpretation from effective categories
         List<String> effectiveCategories = new ArrayList<>(categories);
@@ -141,8 +150,15 @@ public class KafkaMetricsService {
         if (metricNames != null && !metricNames.isBlank()) {
             for (String metric : metricNames.split(",")) {
                 String trimmed = metric.trim();
-                if (!trimmed.isEmpty() && !resolved.contains(trimmed)) {
-                    resolved.add(trimmed);
+                if (!trimmed.isEmpty()) {
+                    try {
+                        String validated = PromQLSanitizer.sanitizeMetricName(trimmed);
+                        if (!resolved.contains(validated)) {
+                            resolved.add(validated);
+                        }
+                    } catch (IllegalArgumentException e) {
+                        LOG.warnf("Invalid metric name '%s': %s", trimmed, e.getMessage());
+                    }
                 }
             }
         }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service.metrics;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+import io.streamshub.mcp.common.dto.metrics.PodTarget;
+import io.streamshub.mcp.common.service.KubernetesResourceService;
+import io.streamshub.mcp.common.service.metrics.MetricsProvider;
+import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.config.metrics.KafkaMetricCategories;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.strimzi.api.ResourceLabels;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Service for retrieving Kafka cluster metrics via pluggable providers.
+ */
+@ApplicationScoped
+public class KafkaMetricsService {
+
+    private static final Logger LOG = Logger.getLogger(KafkaMetricsService.class);
+    private static final String DEFAULT_CATEGORY = "replication";
+    private static final int SECONDS_PER_MINUTE = 60;
+
+    @Inject
+    KubernetesResourceService k8sService;
+
+    @Inject
+    Instance<MetricsProvider> metricsProviderInstance;
+
+    @ConfigProperty(name = "mcp.metrics.provider", defaultValue = "pod-scraping")
+    String providerName;
+
+    @ConfigProperty(name = "mcp.metrics.default-step-seconds", defaultValue = "60")
+    int defaultStepSeconds;
+
+    KafkaMetricsService() {
+        // package-private no-arg constructor for CDI
+    }
+
+    /**
+     * Retrieves metrics for a Kafka cluster.
+     *
+     * @param namespace    the namespace (optional, null for auto-discovery)
+     * @param clusterName  the Kafka cluster name (required)
+     * @param category     the metric category (optional, defaults to "replication")
+     * @param metricNames  explicit metric names (optional, merged with category)
+     * @param rangeMinutes range query duration in minutes (optional, null for instant)
+     * @param stepSeconds  range query step interval (optional, uses default)
+     * @return the metrics response
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public KafkaMetricsResponse getKafkaMetrics(final String namespace,
+                                                 final String clusterName,
+                                                 final String category,
+                                                 final String metricNames,
+                                                 final Integer rangeMinutes,
+                                                 final Integer stepSeconds) {
+        String ns = InputUtils.normalizeInput(namespace);
+        String name = InputUtils.normalizeInput(clusterName);
+        String cat = InputUtils.normalizeInput(category);
+
+        if (name == null) {
+            throw new ToolCallException("Cluster name is required");
+        }
+
+        if (metricsProviderInstance.isUnsatisfied()) {
+            throw new ToolCallException(
+                "No metrics provider configured."
+                    + " Set 'mcp.metrics.provider' to 'streamshub-pod-scraping' or 'streamshub-prometheus'.");
+        }
+
+        // Resolve metric names from category + explicit names
+        List<String> resolvedMetrics = resolveMetricNames(cat, metricNames);
+        List<String> categories = new ArrayList<>();
+        if (cat != null) {
+            categories.add(cat);
+        }
+
+        // Find the Kafka cluster
+        Kafka kafka = findKafkaCluster(ns, name);
+        String resolvedNs = kafka.getMetadata().getNamespace();
+
+        LOG.infof("Getting metrics for cluster '%s' in namespace '%s' (provider=%s)",
+            name, resolvedNs, providerName);
+
+        // Find Kafka pods
+        List<Pod> pods = k8sService.queryResourcesByLabel(
+            Pod.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
+
+        if (pods.isEmpty()) {
+            return KafkaMetricsResponse.empty(name, resolvedNs,
+                String.format("No Kafka pods found for cluster '%s' in namespace '%s'",
+                    name, resolvedNs));
+        }
+
+        // Build query params
+        List<PodTarget> podTargets = pods.stream()
+            .map(pod -> PodTarget.of(
+                pod.getMetadata().getNamespace(),
+                pod.getMetadata().getName()))
+            .toList();
+
+        Map<String, String> labelMatchers = new LinkedHashMap<>();
+        labelMatchers.put("namespace", resolvedNs);
+        labelMatchers.put("strimzi_io_cluster", name);
+
+        MetricsQueryParams params;
+        if (rangeMinutes != null && rangeMinutes > 0) {
+            Instant end = Instant.now();
+            Instant start = end.minusSeconds((long) rangeMinutes * SECONDS_PER_MINUTE);
+            int step = stepSeconds != null ? stepSeconds : defaultStepSeconds;
+            params = MetricsQueryParams.range(resolvedMetrics, labelMatchers, start, end, step);
+        } else {
+            params = MetricsQueryParams.instant(resolvedMetrics, labelMatchers, podTargets);
+        }
+
+        // Query metrics
+        List<MetricSample> samples = metricsProviderInstance.get().queryMetrics(params);
+
+        return KafkaMetricsResponse.of(name, resolvedNs, providerName, categories, samples);
+    }
+
+    private List<String> resolveMetricNames(final String category, final String metricNames) {
+        List<String> resolved = new ArrayList<>();
+
+        String effectiveCategory = category;
+        if (effectiveCategory == null && (metricNames == null || metricNames.isBlank())) {
+            effectiveCategory = DEFAULT_CATEGORY;
+        }
+
+        if (effectiveCategory != null) {
+            List<String> categoryMetrics = KafkaMetricCategories.resolve(effectiveCategory);
+            if (categoryMetrics.isEmpty() && category != null) {
+                throw new ToolCallException(
+                    String.format("Unknown metric category '%s'. Available: %s",
+                        category, KafkaMetricCategories.allCategories()));
+            }
+            resolved.addAll(categoryMetrics);
+        }
+
+        if (metricNames != null && !metricNames.isBlank()) {
+            for (String metric : metricNames.split(",")) {
+                String trimmed = metric.trim();
+                if (!trimmed.isEmpty() && !resolved.contains(trimmed)) {
+                    resolved.add(trimmed);
+                }
+            }
+        }
+
+        return resolved;
+    }
+
+    private Kafka findKafkaCluster(final String namespace, final String name) {
+        Kafka kafka;
+        if (namespace != null) {
+            kafka = k8sService.getResource(Kafka.class, namespace, name);
+        } else {
+            List<Kafka> allClusters = k8sService.queryResourcesInAnyNamespace(Kafka.class);
+            List<Kafka> matching = allClusters.stream()
+                .filter(k -> name.equals(k.getMetadata().getName()))
+                .toList();
+
+            if (matching.size() > 1) {
+                String namespaces = matching.stream()
+                    .map(k -> k.getMetadata().getNamespace())
+                    .distinct()
+                    .collect(Collectors.joining(", "));
+                throw new ToolCallException(
+                    "Multiple clusters named '" + name + "' found in namespaces: "
+                        + namespaces + ". Specify a namespace.");
+            }
+            kafka = matching.isEmpty() ? null : matching.get(0);
+        }
+
+        if (kafka == null) {
+            if (namespace != null) {
+                throw new ToolCallException(
+                    "Kafka cluster '" + name + "' not found in namespace " + namespace);
+            } else {
+                throw new ToolCallException(
+                    "Kafka cluster '" + name + "' not found in any namespace");
+            }
+        }
+
+        return kafka;
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
@@ -11,9 +11,11 @@ import io.streamshub.mcp.common.dto.metrics.PodTarget;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.service.metrics.MetricsQueryService;
 import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.metrics.prometheus.util.PromQLSanitizer;
 import io.streamshub.mcp.strimzi.config.StrimziConstants;
 import io.streamshub.mcp.strimzi.config.metrics.StrimziOperatorMetricCategories;
 import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
+import io.streamshub.mcp.strimzi.util.TimeRangeValidator;
 import io.strimzi.api.ResourceLabels;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -51,6 +53,8 @@ public class StrimziOperatorMetricsService {
      * @param category     the metric category (optional, defaults to "reconciliation")
      * @param metricNames  explicit metric names (optional, merged with category)
      * @param rangeMinutes range query duration in minutes (optional, null for instant)
+     * @param startTime    absolute start time in ISO 8601 format (optional, use with endTime)
+     * @param endTime      absolute end time in ISO 8601 format (optional, use with startTime)
      * @param stepSeconds  range query step interval (optional, uses default)
      * @return the operator metrics response
      */
@@ -60,10 +64,15 @@ public class StrimziOperatorMetricsService {
                                                        final String category,
                                                        final String metricNames,
                                                        final Integer rangeMinutes,
+                                                       final String startTime,
+                                                       final String endTime,
                                                        final Integer stepSeconds) {
         String ns = InputUtils.normalizeInput(namespace);
         String name = InputUtils.normalizeInput(operatorName);
         String cat = InputUtils.normalizeInput(category);
+
+        // Validate time range parameters
+        TimeRangeValidator.validateTimeRangeParameters(rangeMinutes, startTime, endTime);
 
         // Resolve metric names from category + explicit names
         List<String> resolvedMetrics = resolveMetricNames(cat, metricNames);
@@ -92,7 +101,7 @@ public class StrimziOperatorMetricsService {
 
         // Query metrics via general service
         List<MetricSample> samples = metricsQueryService.queryMetrics(
-            podTargets, labelMatchers, resolvedMetrics, rangeMinutes, stepSeconds);
+            podTargets, labelMatchers, resolvedMetrics, rangeMinutes, startTime, endTime, stepSeconds);
 
         // Build interpretation from effective categories
         List<String> effectiveCategories = new ArrayList<>(categories);
@@ -126,8 +135,15 @@ public class StrimziOperatorMetricsService {
         if (metricNames != null && !metricNames.isBlank()) {
             for (String metric : metricNames.split(",")) {
                 String trimmed = metric.trim();
-                if (!trimmed.isEmpty() && !resolved.contains(trimmed)) {
-                    resolved.add(trimmed);
+                if (!trimmed.isEmpty()) {
+                    try {
+                        String validated = PromQLSanitizer.sanitizeMetricName(trimmed);
+                        if (!resolved.contains(validated)) {
+                            resolved.add(validated);
+                        }
+                    } catch (IllegalArgumentException e) {
+                        LOG.warnf("Invalid metric name '%s': %s", trimmed, e.getMessage());
+                    }
                 }
             }
         }
@@ -183,4 +199,5 @@ public class StrimziOperatorMetricsService {
 
         return pods;
     }
+
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
@@ -11,10 +11,10 @@ import io.streamshub.mcp.common.dto.metrics.PodTarget;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.service.metrics.MetricsQueryService;
 import io.streamshub.mcp.common.util.InputUtils;
-import io.streamshub.mcp.strimzi.config.metrics.KafkaMetricCategories;
-import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.config.StrimziConstants;
+import io.streamshub.mcp.strimzi.config.metrics.StrimziOperatorMetricCategories;
+import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
 import io.strimzi.api.ResourceLabels;
-import io.strimzi.api.kafka.model.kafka.Kafka;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -23,16 +23,15 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
- * Service for retrieving Kafka cluster metrics via pluggable providers.
+ * Service for retrieving Strimzi cluster operator metrics via pluggable providers.
  */
 @ApplicationScoped
-public class KafkaMetricsService {
+public class StrimziOperatorMetricsService {
 
-    private static final Logger LOG = Logger.getLogger(KafkaMetricsService.class);
-    private static final String DEFAULT_CATEGORY = "replication";
+    private static final Logger LOG = Logger.getLogger(StrimziOperatorMetricsService.class);
+    private static final String DEFAULT_CATEGORY = "reconciliation";
 
     @Inject
     KubernetesResourceService k8sService;
@@ -40,35 +39,31 @@ public class KafkaMetricsService {
     @Inject
     MetricsQueryService metricsQueryService;
 
-    KafkaMetricsService() {
+    StrimziOperatorMetricsService() {
         // package-private no-arg constructor for CDI
     }
 
     /**
-     * Retrieves metrics for a Kafka cluster.
+     * Retrieves metrics from Strimzi cluster operator pods.
      *
      * @param namespace    the namespace (optional, null for auto-discovery)
-     * @param clusterName  the Kafka cluster name (required)
-     * @param category     the metric category (optional, defaults to "replication")
+     * @param operatorName the operator deployment name (optional, null for any operator)
+     * @param category     the metric category (optional, defaults to "reconciliation")
      * @param metricNames  explicit metric names (optional, merged with category)
      * @param rangeMinutes range query duration in minutes (optional, null for instant)
      * @param stepSeconds  range query step interval (optional, uses default)
-     * @return the metrics response
+     * @return the operator metrics response
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
-    public KafkaMetricsResponse getKafkaMetrics(final String namespace,
-                                                 final String clusterName,
-                                                 final String category,
-                                                 final String metricNames,
-                                                 final Integer rangeMinutes,
-                                                 final Integer stepSeconds) {
+    public StrimziOperatorMetricsResponse getOperatorMetrics(final String namespace,
+                                                       final String operatorName,
+                                                       final String category,
+                                                       final String metricNames,
+                                                       final Integer rangeMinutes,
+                                                       final Integer stepSeconds) {
         String ns = InputUtils.normalizeInput(namespace);
-        String name = InputUtils.normalizeInput(clusterName);
+        String name = InputUtils.normalizeInput(operatorName);
         String cat = InputUtils.normalizeInput(category);
-
-        if (name == null) {
-            throw new ToolCallException("Cluster name is required");
-        }
 
         // Resolve metric names from category + explicit names
         List<String> resolvedMetrics = resolveMetricNames(cat, metricNames);
@@ -77,22 +72,13 @@ public class KafkaMetricsService {
             categories.add(cat);
         }
 
-        // Find the Kafka cluster
-        Kafka kafka = findKafkaCluster(ns, name);
-        String resolvedNs = kafka.getMetadata().getNamespace();
+        // Find operator pods
+        List<Pod> pods = findOperatorPods(ns, name);
+        String resolvedNs = pods.getFirst().getMetadata().getNamespace();
+        String resolvedName = name != null ? name : "cluster-operator";
 
-        LOG.infof("Getting metrics for cluster '%s' in namespace '%s' (provider=%s)",
-            name, resolvedNs, metricsQueryService.providerName());
-
-        // Find Kafka pods
-        List<Pod> pods = k8sService.queryResourcesByLabel(
-            Pod.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
-
-        if (pods.isEmpty()) {
-            return KafkaMetricsResponse.empty(name, resolvedNs,
-                String.format("No Kafka pods found for cluster '%s' in namespace '%s'",
-                    name, resolvedNs));
-        }
+        LOG.infof("Getting metrics for operator '%s' in namespace '%s' (provider=%s)",
+            resolvedName, resolvedNs, metricsQueryService.providerName());
 
         // Build pod targets and label matchers
         List<PodTarget> podTargets = pods.stream()
@@ -103,7 +89,6 @@ public class KafkaMetricsService {
 
         Map<String, String> labelMatchers = new LinkedHashMap<>();
         labelMatchers.put("namespace", resolvedNs);
-        labelMatchers.put("strimzi_io_cluster", name);
 
         // Query metrics via general service
         List<MetricSample> samples = metricsQueryService.queryMetrics(
@@ -114,9 +99,9 @@ public class KafkaMetricsService {
         if (effectiveCategories.isEmpty() && (metricNames == null || metricNames.isBlank())) {
             effectiveCategories.add(DEFAULT_CATEGORY);
         }
-        String interpretation = KafkaMetricCategories.interpretation(effectiveCategories);
+        String interpretation = StrimziOperatorMetricCategories.interpretation(effectiveCategories);
 
-        return KafkaMetricsResponse.of(name, resolvedNs,
+        return StrimziOperatorMetricsResponse.of(resolvedName, resolvedNs,
             metricsQueryService.providerName(), categories, samples, interpretation);
     }
 
@@ -129,11 +114,11 @@ public class KafkaMetricsService {
         }
 
         if (effectiveCategory != null) {
-            List<String> categoryMetrics = KafkaMetricCategories.resolve(effectiveCategory);
+            List<String> categoryMetrics = StrimziOperatorMetricCategories.resolve(effectiveCategory);
             if (categoryMetrics.isEmpty() && category != null) {
                 throw new ToolCallException(
                     String.format("Unknown metric category '%s'. Available: %s",
-                        category, KafkaMetricCategories.allCategories()));
+                        category, StrimziOperatorMetricCategories.allCategories()));
             }
             resolved.addAll(categoryMetrics);
         }
@@ -150,38 +135,52 @@ public class KafkaMetricsService {
         return resolved;
     }
 
-    private Kafka findKafkaCluster(final String namespace, final String name) {
-        Kafka kafka;
-        if (namespace != null) {
-            kafka = k8sService.getResource(Kafka.class, namespace, name);
-        } else {
-            List<Kafka> allClusters = k8sService.queryResourcesInAnyNamespace(Kafka.class);
-            List<Kafka> matching = allClusters.stream()
-                .filter(k -> name.equals(k.getMetadata().getName()))
-                .toList();
+    private List<Pod> findOperatorPods(final String namespace, final String operatorName) {
+        List<Pod> pods;
 
-            if (matching.size() > 1) {
-                String namespaces = matching.stream()
-                    .map(k -> k.getMetadata().getNamespace())
-                    .distinct()
-                    .collect(Collectors.joining(", "));
-                throw new ToolCallException(
-                    "Multiple clusters named '" + name + "' found in namespaces: "
-                        + namespaces + ". Specify a namespace.");
-            }
-            kafka = matching.isEmpty() ? null : matching.get(0);
+        if (namespace != null) {
+            pods = k8sService.queryResourcesByLabel(
+                Pod.class, namespace,
+                ResourceLabels.STRIMZI_KIND_LABEL, StrimziConstants.KindValues.CLUSTER_OPERATOR);
+        } else {
+            pods = k8sService.queryResourcesByLabelInAnyNamespace(
+                Pod.class,
+                ResourceLabels.STRIMZI_KIND_LABEL, StrimziConstants.KindValues.CLUSTER_OPERATOR);
         }
 
-        if (kafka == null) {
-            if (namespace != null) {
+        // Filter by operator name if specified (pod names start with the deployment name)
+        if (operatorName != null) {
+            pods = pods.stream()
+                .filter(pod -> pod.getMetadata().getName().startsWith(operatorName))
+                .toList();
+        }
+
+        if (pods.isEmpty()) {
+            String location = namespace != null
+                ? "in namespace '" + namespace + "'"
+                : "in any namespace";
+
+            if (operatorName != null) {
                 throw new ToolCallException(
-                    "Kafka cluster '" + name + "' not found in namespace " + namespace);
+                    "No Strimzi operator pods found for '" + operatorName + "' " + location);
             } else {
                 throw new ToolCallException(
-                    "Kafka cluster '" + name + "' not found in any namespace");
+                    "No Strimzi operator pods found " + location);
             }
         }
 
-        return kafka;
+        // Verify all pods are in the same namespace
+        List<String> namespaces = pods.stream()
+            .map(pod -> pod.getMetadata().getNamespace())
+            .distinct()
+            .toList();
+
+        if (namespaces.size() > 1) {
+            throw new ToolCallException(
+                "Strimzi operator pods found in multiple namespaces: "
+                    + String.join(", ", namespaces) + ". Please specify a namespace.");
+        }
+
+        return pods;
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
@@ -47,14 +47,8 @@ public class MetricsTools {
      */
     @Tool(
         name = "get_kafka_metrics",
-        description = "Retrieves Prometheus metrics from Kafka cluster pods. "
-            + "Essential for cluster health assessment and incident response. "
-            + "Replication metrics (category='replication') directly impact data availability "
-            + "and should be checked first during incidents. "
-            + "Performance metrics (category='performance') indicate broker capacity and client impact. "
-            + "Supports both relative time ranges (rangeMinutes) and absolute time ranges (startTime/endTime). "
-            + "For incident investigation, use absolute times to analyze specific windows. "
-            + "Returns metric samples by category or explicit metric names with interpretation guides."
+        description = "Retrieves Prometheus metrics from Kafka cluster pods by category or explicit metric names."
+            + " Returns samples with an interpretation guide for thresholds and diagnostics."
     )
     public KafkaMetricsResponse getKafkaMetrics(
         @ToolArg(
@@ -108,12 +102,8 @@ public class MetricsTools {
      */
     @Tool(
         name = "get_strimzi_operator_metrics",
-        description = "Retrieves Prometheus metrics from Strimzi cluster operator pods. "
-            + "Essential for operator health assessment and troubleshooting reconciliation issues. "
-            + "Reconciliation metrics (category='reconciliation') indicate operator performance and failures. "
-            + "Resource metrics (category='resources') show managed resource health. "
-            + "Supports both relative time ranges (rangeMinutes) and absolute time ranges (startTime/endTime). "
-            + "Returns metric samples by category or explicit metric names with interpretation guides."
+        description = "Retrieves Prometheus metrics from Strimzi operator pods by category or explicit metric names."
+            + " Returns samples with an interpretation guide for thresholds and diagnostics."
     )
     public StrimziOperatorMetricsResponse getStrimziOperatorMetrics(
         @ToolArg(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
@@ -40,13 +40,21 @@ public class MetricsTools {
      * @param category     optional metric category
      * @param metricNames  optional explicit metric names
      * @param rangeMinutes optional range duration in minutes
+     * @param startTime    optional absolute start time in ISO 8601 format
+     * @param endTime      optional absolute end time in ISO 8601 format
      * @param stepSeconds  optional range query step in seconds
      * @return the metrics response
      */
     @Tool(
         name = "get_kafka_metrics",
-        description = "Retrieves Prometheus metrics from Kafka cluster pods."
-            + " Returns metric samples by category or explicit metric names."
+        description = "Retrieves Prometheus metrics from Kafka cluster pods. "
+            + "Essential for cluster health assessment and incident response. "
+            + "Replication metrics (category='replication') directly impact data availability "
+            + "and should be checked first during incidents. "
+            + "Performance metrics (category='performance') indicate broker capacity and client impact. "
+            + "Supports both relative time ranges (rangeMinutes) and absolute time ranges (startTime/endTime). "
+            + "For incident investigation, use absolute times to analyze specific windows. "
+            + "Returns metric samples by category or explicit metric names with interpretation guides."
     )
     public KafkaMetricsResponse getKafkaMetrics(
         @ToolArg(
@@ -69,12 +77,20 @@ public class MetricsTools {
             required = false
         ) final Integer rangeMinutes,
         @ToolArg(
+            description = StrimziToolsPrompts.START_TIME_DESC,
+            required = false
+        ) final String startTime,
+        @ToolArg(
+            description = StrimziToolsPrompts.END_TIME_DESC,
+            required = false
+        ) final String endTime,
+        @ToolArg(
             description = StrimziToolsPrompts.STEP_SECONDS_DESC,
             required = false
         ) final Integer stepSeconds
     ) {
         return kafkaMetricsService.getKafkaMetrics(
-            namespace, clusterName, category, metricNames, rangeMinutes, stepSeconds);
+            namespace, clusterName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds);
     }
 
     /**
@@ -85,13 +101,19 @@ public class MetricsTools {
      * @param category     optional metric category
      * @param metricNames  optional explicit metric names
      * @param rangeMinutes optional range duration in minutes
+     * @param startTime    optional absolute start time in ISO 8601 format
+     * @param endTime      optional absolute end time in ISO 8601 format
      * @param stepSeconds  optional range query step in seconds
      * @return the operator metrics response
      */
     @Tool(
         name = "get_strimzi_operator_metrics",
-        description = "Retrieves Prometheus metrics from Strimzi cluster operator pods."
-            + " Returns metric samples by category or explicit metric names."
+        description = "Retrieves Prometheus metrics from Strimzi cluster operator pods. "
+            + "Essential for operator health assessment and troubleshooting reconciliation issues. "
+            + "Reconciliation metrics (category='reconciliation') indicate operator performance and failures. "
+            + "Resource metrics (category='resources') show managed resource health. "
+            + "Supports both relative time ranges (rangeMinutes) and absolute time ranges (startTime/endTime). "
+            + "Returns metric samples by category or explicit metric names with interpretation guides."
     )
     public StrimziOperatorMetricsResponse getStrimziOperatorMetrics(
         @ToolArg(
@@ -115,11 +137,19 @@ public class MetricsTools {
             required = false
         ) final Integer rangeMinutes,
         @ToolArg(
+            description = StrimziToolsPrompts.START_TIME_DESC,
+            required = false
+        ) final String startTime,
+        @ToolArg(
+            description = StrimziToolsPrompts.END_TIME_DESC,
+            required = false
+        ) final String endTime,
+        @ToolArg(
             description = StrimziToolsPrompts.STEP_SECONDS_DESC,
             required = false
         ) final Integer stepSeconds
     ) {
         return strimziOperatorMetricsService.getOperatorMetrics(
-            namespace, operatorName, category, metricNames, rangeMinutes, stepSeconds);
+            namespace, operatorName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
@@ -9,12 +9,14 @@ import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.WrapBusinessError;
 import io.streamshub.mcp.strimzi.config.StrimziToolsPrompts;
 import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
 import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import io.streamshub.mcp.strimzi.service.metrics.StrimziOperatorMetricsService;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 /**
- * MCP tools for Kafka cluster metrics retrieval.
+ * MCP tools for metrics retrieval from Kafka clusters and Strimzi operators.
  */
 @Singleton
 @WrapBusinessError(Exception.class)
@@ -22,6 +24,9 @@ public class MetricsTools {
 
     @Inject
     KafkaMetricsService kafkaMetricsService;
+
+    @Inject
+    StrimziOperatorMetricsService strimziOperatorMetricsService;
 
     MetricsTools() {
         // package-private no-arg constructor for CDI
@@ -70,5 +75,51 @@ public class MetricsTools {
     ) {
         return kafkaMetricsService.getKafkaMetrics(
             namespace, clusterName, category, metricNames, rangeMinutes, stepSeconds);
+    }
+
+    /**
+     * Retrieves metrics from Strimzi cluster operator pods.
+     *
+     * @param operatorName optional operator deployment name
+     * @param namespace    optional namespace
+     * @param category     optional metric category
+     * @param metricNames  optional explicit metric names
+     * @param rangeMinutes optional range duration in minutes
+     * @param stepSeconds  optional range query step in seconds
+     * @return the operator metrics response
+     */
+    @Tool(
+        name = "get_strimzi_operator_metrics",
+        description = "Retrieves Prometheus metrics from Strimzi cluster operator pods."
+            + " Returns metric samples by category or explicit metric names."
+    )
+    public StrimziOperatorMetricsResponse getStrimziOperatorMetrics(
+        @ToolArg(
+            description = StrimziToolsPrompts.OPERATOR_NAME_DESC,
+            required = false
+        ) final String operatorName,
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace,
+        @ToolArg(
+            description = StrimziToolsPrompts.OPERATOR_METRICS_CATEGORY_DESC,
+            required = false
+        ) final String category,
+        @ToolArg(
+            description = StrimziToolsPrompts.METRICS_NAMES_DESC,
+            required = false
+        ) final String metricNames,
+        @ToolArg(
+            description = StrimziToolsPrompts.RANGE_MINUTES_DESC,
+            required = false
+        ) final Integer rangeMinutes,
+        @ToolArg(
+            description = StrimziToolsPrompts.STEP_SECONDS_DESC,
+            required = false
+        ) final Integer stepSeconds
+    ) {
+        return strimziOperatorMetricsService.getOperatorMetrics(
+            namespace, operatorName, category, metricNames, rangeMinutes, stepSeconds);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.tool.metrics;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.WrapBusinessError;
+import io.streamshub.mcp.strimzi.config.StrimziToolsPrompts;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * MCP tools for Kafka cluster metrics retrieval.
+ */
+@Singleton
+@WrapBusinessError(Exception.class)
+public class MetricsTools {
+
+    @Inject
+    KafkaMetricsService kafkaMetricsService;
+
+    MetricsTools() {
+        // package-private no-arg constructor for CDI
+    }
+
+    /**
+     * Retrieves metrics for a Kafka cluster.
+     *
+     * @param clusterName  the Kafka cluster name
+     * @param namespace    optional namespace
+     * @param category     optional metric category
+     * @param metricNames  optional explicit metric names
+     * @param rangeMinutes optional range duration in minutes
+     * @param stepSeconds  optional range query step in seconds
+     * @return the metrics response
+     */
+    @Tool(
+        name = "get_kafka_metrics",
+        description = "Retrieves Prometheus metrics from Kafka cluster pods."
+            + " Returns metric samples by category or explicit metric names."
+    )
+    public KafkaMetricsResponse getKafkaMetrics(
+        @ToolArg(
+            description = StrimziToolsPrompts.CLUSTER_DESC
+        ) final String clusterName,
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace,
+        @ToolArg(
+            description = StrimziToolsPrompts.METRICS_CATEGORY_DESC,
+            required = false
+        ) final String category,
+        @ToolArg(
+            description = StrimziToolsPrompts.METRICS_NAMES_DESC,
+            required = false
+        ) final String metricNames,
+        @ToolArg(
+            description = StrimziToolsPrompts.RANGE_MINUTES_DESC,
+            required = false
+        ) final Integer rangeMinutes,
+        @ToolArg(
+            description = StrimziToolsPrompts.STEP_SECONDS_DESC,
+            required = false
+        ) final Integer stepSeconds
+    ) {
+        return kafkaMetricsService.getKafkaMetrics(
+            namespace, clusterName, category, metricNames, rangeMinutes, stepSeconds);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/util/TimeRangeValidator.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/util/TimeRangeValidator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.util;
+
+import io.quarkiverse.mcp.server.ToolCallException;
+
+/**
+ * Utility class for validating time range parameters in metrics queries.
+ */
+public final class TimeRangeValidator {
+
+    private TimeRangeValidator() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Validates time range parameters to ensure they are used correctly.
+     * <p>
+     * Rules:
+     * <ul>
+     *   <li>Cannot specify both rangeMinutes and absolute time range (startTime/endTime)</li>
+     *   <li>If using absolute time range, both startTime and endTime must be provided</li>
+     * </ul>
+     *
+     * @param rangeMinutes relative time range in minutes (optional)
+     * @param startTime    absolute start time in ISO 8601 format (optional)
+     * @param endTime      absolute end time in ISO 8601 format (optional)
+     * @throws ToolCallException if validation fails
+     */
+    public static void validateTimeRangeParameters(final Integer rangeMinutes,
+                                                    final String startTime,
+                                                    final String endTime) {
+        // Ensure only one time range method is used
+        if (rangeMinutes != null && (startTime != null || endTime != null)) {
+            throw new ToolCallException(
+                "Cannot specify both rangeMinutes and absolute time range (startTime/endTime). "
+                    + "Use rangeMinutes for relative ranges or startTime/endTime for absolute ranges.");
+        }
+
+        // Ensure both startTime and endTime are provided together
+        if (startTime != null && endTime == null || startTime == null && endTime != null) {
+            throw new ToolCallException(
+                "Both startTime and endTime must be specified for absolute time range queries.");
+        }
+    }
+}

--- a/strimzi-mcp/src/main/resources/application.properties
+++ b/strimzi-mcp/src/main/resources/application.properties
@@ -19,6 +19,35 @@ quarkus.kubernetes-client.trust-certs=true
 quarkus.http.port=8080
 mcp.log.tail-lines=200
 
+# =============================================================================
+# Metrics Configuration
+# =============================================================================
+# Metrics provider: "pod-scraping" or "prometheus"
+mcp.metrics.provider=streamshub-pod-scraping
+mcp.metrics.default-step-seconds=60
+
+# Prometheus config (only when provider=prometheus)
+quarkus.rest-client.prometheus.url=http://localhost:9090
+quarkus.rest-client.prometheus.scope=jakarta.inject.Singleton
+mcp.metrics.prometheus.auth-mode=none
+mcp.metrics.prometheus.sa-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
+
+# Basic auth (when auth-mode=basic)
+# quarkus.rest-client.prometheus.username=
+# quarkus.rest-client.prometheus.password=
+
+# Prometheus TLS (uncomment and configure when Prometheus uses TLS)
+# On Kubernetes: mount certs from Secret, set these via env vars or ConfigMap
+# quarkus.rest-client.prometheus.trust-store=/etc/prometheus-tls/ca.crt
+# quarkus.rest-client.prometheus.trust-store-type=PEM
+# mTLS client certificate (when Prometheus requires client cert auth)
+# quarkus.rest-client.prometheus.key-store=/etc/prometheus-tls/client.p12
+# quarkus.rest-client.prometheus.key-store-password=changeit
+# quarkus.rest-client.prometheus.key-store-type=PKCS12
+# quarkus.rest-client.prometheus.verify-host=true
+
+# OAuth2/OIDC: not yet supported — planned for future release
+
 # Logging Configuration
 quarkus.log.category."io.streamshub.mcp.strimzi".level=DEBUG
 quarkus.log.category."io.quarkiverse.mcp".level=INFO

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategoriesTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategoriesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.config.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link KafkaMetricCategories}.
+ */
+class KafkaMetricCategoriesTest {
+
+    KafkaMetricCategoriesTest() {
+    }
+
+    @Test
+    void resolveValidCategoryReturnsMetrics() {
+        List<String> metrics = KafkaMetricCategories.resolve("replication");
+        assertFalse(metrics.isEmpty());
+        assertTrue(metrics.contains("kafka_server_replicamanager_underreplicatedpartitions"));
+    }
+
+    @Test
+    void resolveUnknownCategoryReturnsEmpty() {
+        List<String> metrics = KafkaMetricCategories.resolve("nonexistent");
+        assertTrue(metrics.isEmpty());
+    }
+
+    @Test
+    void resolveNullReturnsEmpty() {
+        List<String> metrics = KafkaMetricCategories.resolve(null);
+        assertTrue(metrics.isEmpty());
+    }
+
+    @Test
+    void resolveIsCaseInsensitive() {
+        List<String> lower = KafkaMetricCategories.resolve("replication");
+        List<String> upper = KafkaMetricCategories.resolve("REPLICATION");
+        List<String> mixed = KafkaMetricCategories.resolve("Replication");
+        assertEquals(lower, upper);
+        assertEquals(lower, mixed);
+    }
+
+    @Test
+    void allCategoriesReturnsFourCategories() {
+        Set<String> categories = KafkaMetricCategories.allCategories();
+        assertEquals(4, categories.size());
+        assertTrue(categories.contains("replication"));
+        assertTrue(categories.contains("throughput"));
+        assertTrue(categories.contains("resources"));
+        assertTrue(categories.contains("performance"));
+    }
+
+    @Test
+    void interpretationWithValidCategoryReturnsGuide() {
+        String interpretation = KafkaMetricCategories.interpretation(List.of("replication"));
+        assertNotNull(interpretation);
+        assertTrue(interpretation.contains("underreplicatedpartitions"));
+    }
+
+    @Test
+    void interpretationWithMultipleCategoriesJoinsThem() {
+        String interpretation = KafkaMetricCategories.interpretation(
+            List.of("replication", "performance"));
+        assertNotNull(interpretation);
+        assertTrue(interpretation.contains("underreplicatedpartitions"));
+        assertTrue(interpretation.contains("brokerrequesthandleravgidle_percent"));
+    }
+
+    @Test
+    void interpretationWithNullReturnsNull() {
+        assertNull(KafkaMetricCategories.interpretation(null));
+    }
+
+    @Test
+    void interpretationWithEmptyListReturnsNull() {
+        assertNull(KafkaMetricCategories.interpretation(List.of()));
+    }
+
+    @Test
+    void interpretationWithUnknownCategoryReturnsNull() {
+        assertNull(KafkaMetricCategories.interpretation(List.of("nonexistent")));
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategoriesTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategoriesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.config.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link StrimziOperatorMetricCategories}.
+ */
+class StrimziOperatorMetricCategoriesTest {
+
+    StrimziOperatorMetricCategoriesTest() {
+    }
+
+    @Test
+    void resolveValidCategoryReturnsMetrics() {
+        List<String> metrics = StrimziOperatorMetricCategories.resolve("reconciliation");
+        assertFalse(metrics.isEmpty());
+        assertTrue(metrics.contains("strimzi_reconciliations_successful_total"));
+    }
+
+    @Test
+    void resolveUnknownCategoryReturnsEmpty() {
+        List<String> metrics = StrimziOperatorMetricCategories.resolve("nonexistent");
+        assertTrue(metrics.isEmpty());
+    }
+
+    @Test
+    void resolveNullReturnsEmpty() {
+        List<String> metrics = StrimziOperatorMetricCategories.resolve(null);
+        assertTrue(metrics.isEmpty());
+    }
+
+    @Test
+    void resolveIsCaseInsensitive() {
+        List<String> lower = StrimziOperatorMetricCategories.resolve("reconciliation");
+        List<String> upper = StrimziOperatorMetricCategories.resolve("RECONCILIATION");
+        assertEquals(lower, upper);
+    }
+
+    @Test
+    void allCategoriesReturnsThreeCategories() {
+        Set<String> categories = StrimziOperatorMetricCategories.allCategories();
+        assertEquals(3, categories.size());
+        assertTrue(categories.contains("reconciliation"));
+        assertTrue(categories.contains("resources"));
+        assertTrue(categories.contains("jvm"));
+    }
+
+    @Test
+    void interpretationWithValidCategoryReturnsGuide() {
+        String interpretation = StrimziOperatorMetricCategories.interpretation(
+            List.of("reconciliation"));
+        assertNotNull(interpretation);
+        assertTrue(interpretation.contains("strimzi_reconciliations_successful_total"));
+    }
+
+    @Test
+    void interpretationWithNullReturnsNull() {
+        assertNull(StrimziOperatorMetricCategories.interpretation(null));
+    }
+
+    @Test
+    void interpretationWithEmptyListReturnsNull() {
+        assertNull(StrimziOperatorMetricCategories.interpretation(List.of()));
+    }
+
+    @Test
+    void interpretationWithUnknownCategoryReturnsNull() {
+        assertNull(StrimziOperatorMetricCategories.interpretation(List.of("nonexistent")));
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponseTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link KafkaMetricsResponse}.
+ */
+class KafkaMetricsResponseTest {
+
+    KafkaMetricsResponseTest() {
+    }
+
+    @Test
+    void ofWithInstantDataPopulatesMetricsNotTimeSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0),
+            MetricSample.of("metric_a", Map.of("pod", "pod-1"), 2.0)
+        );
+
+        KafkaMetricsResponse response = KafkaMetricsResponse.of(
+            "my-cluster", "kafka", "pod-scraping", List.of("replication"), samples, null);
+
+        assertNotNull(response.metrics());
+        assertEquals(2, response.metrics().size());
+        assertNull(response.timeSeries());
+        assertEquals(2, response.sampleCount());
+        assertEquals(1, response.metricCount());
+    }
+
+    @Test
+    void ofWithRangeDataPopulatesTimeSeriesNotMetrics() {
+        Instant now = Instant.now();
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0, now),
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 2.0, now.plusSeconds(60))
+        );
+
+        KafkaMetricsResponse response = KafkaMetricsResponse.of(
+            "my-cluster", "kafka", "prometheus", List.of("throughput"), samples, null);
+
+        assertNull(response.metrics());
+        assertNotNull(response.timeSeries());
+        assertEquals(1, response.timeSeries().size());
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void ofWithEmptySamplesReturnsEmptyMetrics() {
+        KafkaMetricsResponse response = KafkaMetricsResponse.of(
+            "my-cluster", "kafka", "pod-scraping", List.of(), List.of(), null);
+
+        assertNotNull(response.metrics());
+        assertTrue(response.metrics().isEmpty());
+        assertNull(response.timeSeries());
+        assertEquals(0, response.sampleCount());
+        assertEquals(0, response.metricCount());
+    }
+
+    @Test
+    void ofCountsDistinctMetricNames() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of(), 1.0),
+            MetricSample.of("metric_a", Map.of(), 2.0),
+            MetricSample.of("metric_b", Map.of(), 3.0)
+        );
+
+        KafkaMetricsResponse response = KafkaMetricsResponse.of(
+            "my-cluster", "kafka", "pod-scraping", List.of(), samples, null);
+
+        assertEquals(2, response.metricCount());
+        assertEquals(3, response.sampleCount());
+    }
+
+    @Test
+    void ofPassesThroughInterpretation() {
+        KafkaMetricsResponse response = KafkaMetricsResponse.of(
+            "my-cluster", "kafka", "pod-scraping", List.of(), List.of(), "test interpretation");
+
+        assertEquals("test interpretation", response.interpretation());
+    }
+
+    @Test
+    void emptyCreatesResponseWithNoMetrics() {
+        KafkaMetricsResponse response = KafkaMetricsResponse.empty(
+            "my-cluster", "kafka", "No pods found");
+
+        assertEquals("my-cluster", response.clusterName());
+        assertEquals("kafka", response.namespace());
+        assertEquals("No pods found", response.message());
+        assertEquals(0, response.sampleCount());
+        assertEquals(0, response.metricCount());
+        assertNull(response.interpretation());
+        assertNotNull(response.timestamp());
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponseTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponseTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link StrimziOperatorMetricsResponse}.
+ */
+class StrimziOperatorMetricsResponseTest {
+
+    StrimziOperatorMetricsResponseTest() {
+    }
+
+    @Test
+    void ofWithInstantDataPopulatesMetricsNotTimeSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("strimzi_reconciliations_total", Map.of(), 100.0)
+        );
+
+        StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
+            "cluster-operator", "strimzi", "pod-scraping",
+            List.of("reconciliation"), samples, null);
+
+        assertNotNull(response.metrics());
+        assertEquals(1, response.metrics().size());
+        assertNull(response.timeSeries());
+        assertEquals(1, response.sampleCount());
+        assertEquals(1, response.metricCount());
+    }
+
+    @Test
+    void ofWithRangeDataPopulatesTimeSeriesNotMetrics() {
+        Instant now = Instant.now();
+        List<MetricSample> samples = List.of(
+            MetricSample.of("strimzi_reconciliations_total", Map.of(), 100.0, now),
+            MetricSample.of("strimzi_reconciliations_total", Map.of(), 105.0, now.plusSeconds(60))
+        );
+
+        StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
+            "cluster-operator", "strimzi", "prometheus",
+            List.of("reconciliation"), samples, null);
+
+        assertNull(response.metrics());
+        assertNotNull(response.timeSeries());
+        assertEquals(1, response.timeSeries().size());
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void ofWithEmptySamplesReturnsEmptyMetrics() {
+        StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
+            "cluster-operator", "strimzi", "pod-scraping",
+            List.of(), List.of(), null);
+
+        assertNotNull(response.metrics());
+        assertTrue(response.metrics().isEmpty());
+        assertNull(response.timeSeries());
+        assertEquals(0, response.sampleCount());
+    }
+
+    @Test
+    void ofPassesThroughInterpretation() {
+        StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
+            "cluster-operator", "strimzi", "pod-scraping",
+            List.of(), List.of(), "test interpretation");
+
+        assertEquals("test interpretation", response.interpretation());
+    }
+
+    @Test
+    void emptyCreatesResponseWithNoMetrics() {
+        StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.empty(
+            "cluster-operator", "strimzi", "No pods found");
+
+        assertEquals("cluster-operator", response.operatorName());
+        assertEquals("strimzi", response.namespace());
+        assertEquals("No pods found", response.message());
+        assertEquals(0, response.sampleCount());
+        assertNull(response.interpretation());
+        assertNotNull(response.timestamp());
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service.metrics;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
+import io.streamshub.mcp.common.service.KubernetesResourceService;
+import io.streamshub.mcp.common.service.metrics.MetricsProvider;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.strimzi.api.ResourceLabels;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link KafkaMetricsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KafkaMetricsServiceTest {
+
+    KafkaMetricsServiceTest() {
+        // default constructor for checkstyle
+    }
+
+    @Mock
+    KubernetesResourceService k8sService;
+
+    @Mock
+    Instance<MetricsProvider> metricsProviderInstance;
+
+    @Mock
+    MetricsProvider metricsProvider;
+
+    private KafkaMetricsService kafkaMetricsService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        kafkaMetricsService = new KafkaMetricsService();
+        setField(kafkaMetricsService, "k8sService", k8sService);
+        setField(kafkaMetricsService, "metricsProviderInstance", metricsProviderInstance);
+        setField(kafkaMetricsService, "providerName", "pod-scraping");
+        setField(kafkaMetricsService, "defaultStepSeconds", 60);
+
+        when(metricsProviderInstance.isUnsatisfied()).thenReturn(false);
+        when(metricsProviderInstance.get()).thenReturn(metricsProvider);
+    }
+
+    @Test
+    void missingClusterNameThrows() {
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", null, null, null, null, null));
+        assertTrue(ex.getMessage().contains("Cluster name is required"));
+    }
+
+    @Test
+    void clusterNotFoundInNamespaceThrows() {
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("missing")))
+            .thenReturn(null);
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", "missing", null, null, null, null));
+        assertTrue(ex.getMessage().contains("not found in namespace"));
+    }
+
+    @Test
+    void clusterNotFoundInAnyNamespaceThrows() {
+        when(k8sService.queryResourcesInAnyNamespace(Kafka.class))
+            .thenReturn(List.of());
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> kafkaMetricsService.getKafkaMetrics(null, "missing", null, null, null, null));
+        assertTrue(ex.getMessage().contains("not found in any namespace"));
+    }
+
+    @Test
+    void unknownCategoryThrows() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", "my-cluster", "invalid", null, null, null));
+        assertTrue(ex.getMessage().contains("Unknown metric category"));
+    }
+
+    @Test
+    void emptyPodsReturnsEmptyResponse() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of());
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(0, response.sampleCount());
+        assertTrue(response.message().contains("No Kafka pods"));
+    }
+
+    @Test
+    void successfulMetricsRetrieval() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("namespace", "kafka"), 0.0));
+        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null);
+
+        assertNotNull(response);
+        assertEquals("my-cluster", response.clusterName());
+        assertEquals("kafka", response.namespace());
+        assertEquals(1, response.sampleCount());
+        assertEquals(1, response.metricCount());
+    }
+
+    @Test
+    void defaultsToReplicationCategoryWhenNoneSpecified() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+            .thenReturn(List.of());
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals("my-cluster", response.clusterName());
+    }
+
+    @Test
+    void explicitMetricNamesAreAccepted() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+            .thenReturn(List.of());
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", null, "custom_metric_a,custom_metric_b", null, null);
+
+        assertNotNull(response);
+    }
+
+    private Kafka createKafka(final String name, final String namespace) {
+        Kafka kafka = new Kafka();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setName(name);
+        meta.setNamespace(namespace);
+        kafka.setMetadata(meta);
+        return kafka;
+    }
+
+    private Pod createPod(final String name, final String namespace) {
+        Pod pod = new Pod();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setName(name);
+        meta.setNamespace(namespace);
+        pod.setMetadata(meta);
+        return pod;
+    }
+
+    private static void setField(final Object target, final String fieldName,
+                                  final Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
@@ -8,13 +8,11 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
-import io.streamshub.mcp.common.dto.metrics.MetricsQueryParams;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
-import io.streamshub.mcp.common.service.metrics.MetricsProvider;
+import io.streamshub.mcp.common.service.metrics.MetricsQueryService;
 import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
 import io.strimzi.api.ResourceLabels;
 import io.strimzi.api.kafka.model.kafka.Kafka;
-import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,7 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -50,10 +51,7 @@ class KafkaMetricsServiceTest {
     KubernetesResourceService k8sService;
 
     @Mock
-    Instance<MetricsProvider> metricsProviderInstance;
-
-    @Mock
-    MetricsProvider metricsProvider;
+    MetricsQueryService metricsQueryService;
 
     private KafkaMetricsService kafkaMetricsService;
 
@@ -61,12 +59,11 @@ class KafkaMetricsServiceTest {
     void setUp() throws Exception {
         kafkaMetricsService = new KafkaMetricsService();
         setField(kafkaMetricsService, "k8sService", k8sService);
-        setField(kafkaMetricsService, "metricsProviderInstance", metricsProviderInstance);
-        setField(kafkaMetricsService, "providerName", "pod-scraping");
-        setField(kafkaMetricsService, "defaultStepSeconds", 60);
+        setField(kafkaMetricsService, "metricsQueryService", metricsQueryService);
 
-        when(metricsProviderInstance.isUnsatisfied()).thenReturn(false);
-        when(metricsProviderInstance.get()).thenReturn(metricsProvider);
+        when(metricsQueryService.providerName()).thenReturn("pod-scraping");
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), any(), any()))
+            .thenReturn(List.of());
     }
 
     @Test
@@ -138,7 +135,7 @@ class KafkaMetricsServiceTest {
         List<MetricSample> samples = List.of(
             MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
                 Map.of("namespace", "kafka"), 0.0));
-        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull()))
             .thenReturn(samples);
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
@@ -161,8 +158,6 @@ class KafkaMetricsServiceTest {
         when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
             eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
             .thenReturn(List.of(pod));
-        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
-            .thenReturn(List.of());
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
             "kafka", "my-cluster", null, null, null, null);
@@ -181,11 +176,60 @@ class KafkaMetricsServiceTest {
         when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
             eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
             .thenReturn(List.of(pod));
-        when(metricsProvider.queryMetrics(any(MetricsQueryParams.class)))
-            .thenReturn(List.of());
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
             "kafka", "my-cluster", null, "custom_metric_a,custom_metric_b", null, null);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void multipleClustersWithSameNameThrows() {
+        Kafka kafka1 = createKafka("my-cluster", "kafka-a");
+        Kafka kafka2 = createKafka("my-cluster", "kafka-b");
+        when(k8sService.queryResourcesInAnyNamespace(Kafka.class))
+            .thenReturn(List.of(kafka1, kafka2));
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null));
+        assertTrue(ex.getMessage().contains("Multiple clusters"));
+        assertTrue(ex.getMessage().contains("Specify a namespace"));
+    }
+
+    @Test
+    void rangeQueryParametersPassedThrough() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), eq(60), eq(15)))
+            .thenReturn(List.of());
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, 60, 15);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void categoryAndExplicitMetricsMergedWithoutDuplicates() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(k8sService.getResource(eq(Kafka.class), eq("kafka"), eq("my-cluster")))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        // Provide a metric name that's already in the replication category
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication",
+            "kafka_server_replicamanager_underreplicatedpartitions,custom_metric", null, null);
 
         assertNotNull(response);
     }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
@@ -62,14 +62,14 @@ class KafkaMetricsServiceTest {
         setField(kafkaMetricsService, "metricsQueryService", metricsQueryService);
 
         when(metricsQueryService.providerName()).thenReturn("pod-scraping");
-        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), any(), any()))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), any(), any(), any(), any()))
             .thenReturn(List.of());
     }
 
     @Test
     void missingClusterNameThrows() {
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics("kafka", null, null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Cluster name is required"));
     }
 
@@ -79,7 +79,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(null);
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics("kafka", "missing", null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", "missing", null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("not found in namespace"));
     }
 
@@ -89,7 +89,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of());
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics(null, "missing", null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics(null, "missing", null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("not found in any namespace"));
     }
 
@@ -100,7 +100,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(kafka);
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics("kafka", "my-cluster", "invalid", null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", "my-cluster", "invalid", null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Unknown metric category"));
     }
 
@@ -114,7 +114,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of());
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", null, null, null, null);
+            "kafka", "my-cluster", null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals(0, response.sampleCount());
@@ -135,11 +135,11 @@ class KafkaMetricsServiceTest {
         List<MetricSample> samples = List.of(
             MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
                 Map.of("namespace", "kafka"), 0.0));
-        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull()))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
             .thenReturn(samples);
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", "replication", null, null, null);
+            "kafka", "my-cluster", "replication", null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -160,7 +160,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", null, null, null, null);
+            "kafka", "my-cluster", null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -178,7 +178,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", null, "custom_metric_a,custom_metric_b", null, null);
+            "kafka", "my-cluster", null, "custom_metric_a,custom_metric_b", null, null, null, null);
 
         assertNotNull(response);
     }
@@ -191,7 +191,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of(kafka1, kafka2));
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Multiple clusters"));
         assertTrue(ex.getMessage().contains("Specify a namespace"));
     }
@@ -206,11 +206,11 @@ class KafkaMetricsServiceTest {
         when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
             eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
             .thenReturn(List.of(pod));
-        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), eq(60), eq(15)))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), eq(60), isNull(), isNull(), eq(15)))
             .thenReturn(List.of());
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", "replication", null, 60, 15);
+            "kafka", "my-cluster", "replication", null, 60, null, null, 15);
 
         assertNotNull(response);
     }
@@ -229,7 +229,7 @@ class KafkaMetricsServiceTest {
         // Provide a metric name that's already in the replication category
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
             "kafka", "my-cluster", "replication",
-            "kafka_server_replicamanager_underreplicatedpartitions,custom_metric", null, null);
+            "kafka_server_replicamanager_underreplicatedpartitions,custom_metric", null, null, null, null);
 
         assertNotNull(response);
     }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service.metrics;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.service.KubernetesResourceService;
+import io.streamshub.mcp.common.service.metrics.MetricsQueryService;
+import io.streamshub.mcp.strimzi.config.StrimziConstants;
+import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
+import io.strimzi.api.ResourceLabels;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link StrimziOperatorMetricsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StrimziOperatorMetricsServiceTest {
+
+    StrimziOperatorMetricsServiceTest() {
+        // default constructor for checkstyle
+    }
+
+    @Mock
+    KubernetesResourceService k8sService;
+
+    @Mock
+    MetricsQueryService metricsQueryService;
+
+    private StrimziOperatorMetricsService strimziOperatorMetricsService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        strimziOperatorMetricsService = new StrimziOperatorMetricsService();
+        setField(strimziOperatorMetricsService, "k8sService", k8sService);
+        setField(strimziOperatorMetricsService, "metricsQueryService", metricsQueryService);
+
+        when(metricsQueryService.providerName()).thenReturn("pod-scraping");
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), any(), any()))
+            .thenReturn(List.of());
+    }
+
+    @Test
+    void noOperatorPodsFoundInNamespaceThrows() {
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of());
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> strimziOperatorMetricsService.getOperatorMetrics(
+                "kafka-system", null, null, null, null, null));
+        assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
+    }
+
+    @Test
+    void noOperatorPodsFoundInAnyNamespaceThrows() {
+        when(k8sService.queryResourcesByLabelInAnyNamespace(eq(Pod.class),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of());
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> strimziOperatorMetricsService.getOperatorMetrics(
+                null, null, null, null, null, null));
+        assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
+    }
+
+    @Test
+    void namedOperatorNotFoundThrows() {
+        Pod pod = createPod("other-operator-abc123", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod));
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> strimziOperatorMetricsService.getOperatorMetrics(
+                "kafka-system", "strimzi-cluster-operator", null, null, null, null));
+        assertTrue(ex.getMessage().contains("strimzi-cluster-operator"));
+    }
+
+    @Test
+    void unknownCategoryThrows() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod));
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> strimziOperatorMetricsService.getOperatorMetrics(
+                "kafka-system", null, "invalid", null, null, null));
+        assertTrue(ex.getMessage().contains("Unknown metric category"));
+    }
+
+    @Test
+    void successfulMetricsRetrieval() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("strimzi_reconciliations_successful_total",
+                Map.of("namespace", "kafka-system"), 42.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", null, "reconciliation", null, null, null);
+
+        assertNotNull(response);
+        assertEquals("cluster-operator", response.operatorName());
+        assertEquals("kafka-system", response.namespace());
+        assertEquals(1, response.sampleCount());
+        assertEquals(1, response.metricCount());
+    }
+
+    @Test
+    void defaultsToReconciliationCategoryWhenNoneSpecified() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod));
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals("kafka-system", response.namespace());
+    }
+
+    @Test
+    void explicitMetricNamesAreAccepted() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod));
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", null, null, "strimzi_resources,strimzi_resource_state", null, null);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void operatorPodsInMultipleNamespacesThrows() {
+        Pod pod1 = createPod("strimzi-cluster-operator-abc", "ns-a");
+        Pod pod2 = createPod("strimzi-cluster-operator-def", "ns-b");
+        when(k8sService.queryResourcesByLabelInAnyNamespace(eq(Pod.class),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod1, pod2));
+
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> strimziOperatorMetricsService.getOperatorMetrics(
+                null, null, null, null, null, null));
+        assertTrue(ex.getMessage().contains("multiple namespaces"));
+    }
+
+    @Test
+    void namedOperatorFilterMatchesPodNamePrefix() {
+        Pod matchingPod = createPod("my-operator-abc123", "kafka-system");
+        Pod otherPod = createPod("strimzi-cluster-operator-def456", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(matchingPod, otherPod));
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", "my-operator", null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals("my-operator", response.operatorName());
+    }
+
+    @Test
+    void rangeQueryParametersPassedThrough() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
+            eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
+            .thenReturn(List.of(pod));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), eq(30), eq(10)))
+            .thenReturn(List.of());
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", null, "reconciliation", null, 30, 10);
+
+        assertNotNull(response);
+    }
+
+    private Pod createPod(final String name, final String namespace) {
+        Pod pod = new Pod();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setName(name);
+        meta.setNamespace(namespace);
+        pod.setMetadata(meta);
+        return pod;
+    }
+
+    private static void setField(final Object target, final String fieldName,
+                                  final Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsServiceTest.java
@@ -62,7 +62,7 @@ class StrimziOperatorMetricsServiceTest {
         setField(strimziOperatorMetricsService, "metricsQueryService", metricsQueryService);
 
         when(metricsQueryService.providerName()).thenReturn("pod-scraping");
-        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), any(), any()))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), any(), any(), any(), any()))
             .thenReturn(List.of());
     }
 
@@ -74,7 +74,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                "kafka-system", null, null, null, null, null));
+                "kafka-system", null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
     }
 
@@ -86,7 +86,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                null, null, null, null, null, null));
+                null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
     }
 
@@ -99,7 +99,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                "kafka-system", "strimzi-cluster-operator", null, null, null, null));
+                "kafka-system", "strimzi-cluster-operator", null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("strimzi-cluster-operator"));
     }
 
@@ -112,7 +112,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                "kafka-system", null, "invalid", null, null, null));
+                "kafka-system", null, "invalid", null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Unknown metric category"));
     }
 
@@ -126,11 +126,11 @@ class StrimziOperatorMetricsServiceTest {
         List<MetricSample> samples = List.of(
             MetricSample.of("strimzi_reconciliations_successful_total",
                 Map.of("namespace", "kafka-system"), 42.0));
-        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull()))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
             .thenReturn(samples);
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, "reconciliation", null, null, null);
+            "kafka-system", null, "reconciliation", null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("cluster-operator", response.operatorName());
@@ -147,7 +147,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, null, null, null, null);
+            "kafka-system", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("kafka-system", response.namespace());
@@ -161,7 +161,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, null, "strimzi_resources,strimzi_resource_state", null, null);
+            "kafka-system", null, null, "strimzi_resources,strimzi_resource_state", null, null, null, null);
 
         assertNotNull(response);
     }
@@ -176,7 +176,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                null, null, null, null, null, null));
+                null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("multiple namespaces"));
     }
 
@@ -189,7 +189,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(matchingPod, otherPod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", "my-operator", null, null, null, null);
+            "kafka-system", "my-operator", null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-operator", response.operatorName());
@@ -201,11 +201,11 @@ class StrimziOperatorMetricsServiceTest {
         when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka-system"),
             eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
             .thenReturn(List.of(pod));
-        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), eq(30), eq(10)))
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), eq(30), isNull(), isNull(), eq(10)))
             .thenReturn(List.of());
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, "reconciliation", null, 30, 10);
+            "kafka-system", null, "reconciliation", null, 30, null, null, 10);
 
         assertNotNull(response);
     }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpDiscoveryTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpDiscoveryTest.java
@@ -90,6 +90,10 @@ class McpDiscoveryTest {
                     "Prompt 'diagnose-cluster-issue' should be registered");
                 assertNotNull(page.findByName("troubleshoot-connectivity"),
                     "Prompt 'troubleshoot-connectivity' should be registered");
+                assertNotNull(page.findByName("analyze-kafka-metrics"),
+                    "Prompt 'analyze-kafka-metrics' should be registered");
+                assertNotNull(page.findByName("analyze-strimzi-operator-metrics"),
+                    "Prompt 'analyze-strimzi-operator-metrics' should be registered");
             })
             .send()
             .thenAssertResults();
@@ -134,6 +138,46 @@ class McpDiscoveryTest {
                 assertTrue(content.contains("my-cluster"));
                 assertTrue(content.contains("kafka-prod"));
                 assertTrue(content.contains("get_kafka_cluster"));
+            })
+            .send()
+            .thenAssertResults();
+    }
+
+    /**
+     * Verify analyze-kafka-metrics prompt generates correct instructions.
+     */
+    @Test
+    void testPromptGetAnalyzeKafkaMetrics() {
+        client.when()
+            .promptsGet("analyze-kafka-metrics")
+            .withArguments(Map.of("cluster_name", "my-cluster", "namespace", "kafka-prod"))
+            .withAssert(response -> {
+                assertFalse(response.messages().isEmpty());
+                String content = response.messages().getFirst().content().asText().text();
+                assertTrue(content.contains("my-cluster"));
+                assertTrue(content.contains("get_kafka_metrics"));
+                assertTrue(content.contains("replication"));
+                assertTrue(content.contains("throughput"));
+                assertTrue(content.contains("performance"));
+            })
+            .send()
+            .thenAssertResults();
+    }
+
+    /**
+     * Verify analyze-strimzi-operator-metrics prompt generates correct instructions.
+     */
+    @Test
+    void testPromptGetAnalyzeStrimziOperatorMetrics() {
+        client.when()
+            .promptsGet("analyze-strimzi-operator-metrics")
+            .withArguments(Map.of("namespace", "kafka-system"))
+            .withAssert(response -> {
+                assertFalse(response.messages().isEmpty());
+                String content = response.messages().getFirst().content().asText().text();
+                assertTrue(content.contains("kafka-system"));
+                assertTrue(content.contains("get_strimzi_operator_metrics"));
+                assertTrue(content.contains("reconciliation"));
             })
             .send()
             .thenAssertResults();

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpToolsTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpToolsTest.java
@@ -21,11 +21,13 @@ import io.streamshub.mcp.strimzi.dto.ListenerInfo;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
 import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
 import io.streamshub.mcp.strimzi.service.KafkaNodePoolService;
 import io.streamshub.mcp.strimzi.service.KafkaService;
 import io.streamshub.mcp.strimzi.service.KafkaTopicService;
 import io.streamshub.mcp.strimzi.service.StrimziOperatorService;
 import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import io.streamshub.mcp.strimzi.service.metrics.StrimziOperatorMetricsService;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +73,9 @@ class McpToolsTest {
     @InjectMock
     KafkaMetricsService kafkaMetricsService;
 
+    @InjectMock
+    StrimziOperatorMetricsService strimziOperatorMetricsService;
+
     private McpAssured.McpSseTestClient client;
 
     McpToolsTest() {
@@ -108,7 +113,8 @@ class McpToolsTest {
                     "get_strimzi_operator",
                     "get_strimzi_operator_logs",
                     "get_strimzi_operator_pod",
-                    "get_kafka_metrics"
+                    "get_kafka_metrics",
+                    "get_strimzi_operator_metrics"
                 );
 
                 for (String toolName : expectedTools) {
@@ -328,7 +334,7 @@ class McpToolsTest {
 
     @Test
     void testGetStrimziOperatorLogs() {
-        when(operatorService.getOperatorLogs(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(
+        when(operatorService.getOperatorLogs(any(), any(), any())).thenReturn(
             StrimziOperatorLogsResponse.of("kafka-system",
                 "INFO: Operator running normally", List.of("strimzi-operator-abc123"),
                 false, 0, 1, false)
@@ -410,13 +416,29 @@ class McpToolsTest {
     void testGetKafkaMetrics() {
         when(kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null))
             .thenReturn(KafkaMetricsResponse.of("my-cluster", "kafka", "pod-scraping",
-                List.of("replication"), List.of()));
+                List.of("replication"), List.of(), null));
 
         client.when()
             .toolsCall("get_kafka_metrics", Map.of("clusterName", "my-cluster"), response -> {
                 assertFalse(response.isError());
                 String json = response.content().getFirst().asText().text();
                 assertTrue(json.contains("my-cluster"));
+                assertTrue(json.contains("pod-scraping"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetStrimziOperatorMetrics() {
+        when(strimziOperatorMetricsService.getOperatorMetrics(null, null, null, null, null, null))
+            .thenReturn(StrimziOperatorMetricsResponse.of("cluster-operator", "kafka-system",
+                "pod-scraping", List.of("reconciliation"), List.of(), null));
+
+        client.when()
+            .toolsCall("get_strimzi_operator_metrics", Map.of(), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("cluster-operator"));
                 assertTrue(json.contains("pod-scraping"));
             })
             .thenAssertResults();

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpToolsTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpToolsTest.java
@@ -1,0 +1,447 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.tool;
+
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.streamshub.mcp.common.dto.ConditionInfo;
+import io.streamshub.mcp.common.dto.PodSummaryResponse;
+import io.streamshub.mcp.common.dto.ReplicasInfo;
+import io.streamshub.mcp.common.service.PodsService;
+import io.streamshub.mcp.strimzi.dto.KafkaBootstrapResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterPodsResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaNodePoolResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaTopicResponse;
+import io.streamshub.mcp.strimzi.dto.ListenerInfo;
+import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
+import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.service.KafkaNodePoolService;
+import io.streamshub.mcp.strimzi.service.KafkaService;
+import io.streamshub.mcp.strimzi.service.KafkaTopicService;
+import io.streamshub.mcp.strimzi.service.StrimziOperatorService;
+import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * MCP integration tests verifying tool discovery, parameter binding,
+ * response serialization, and error handling through the MCP protocol layer.
+ */
+@QuarkusTest
+class McpToolsTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int testPort;
+
+    @InjectMock
+    KafkaService kafkaService;
+
+    @InjectMock
+    KafkaTopicService topicService;
+
+    @InjectMock
+    KafkaNodePoolService nodePoolService;
+
+    @InjectMock
+    StrimziOperatorService operatorService;
+
+    @InjectMock
+    PodsService podsService;
+
+    @InjectMock
+    KafkaMetricsService kafkaMetricsService;
+
+    private McpAssured.McpSseTestClient client;
+
+    McpToolsTest() {
+    }
+
+    @BeforeEach
+    void setUp() {
+        McpAssured.baseUri = URI.create("http://localhost:" + testPort);
+        client = McpAssured.newConnectedSseClient();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) {
+            client.disconnect();
+        }
+    }
+
+    @Test
+    void testToolDiscovery() {
+        client.when()
+            .toolsList(page -> {
+                List<String> expectedTools = List.of(
+                    "list_kafka_clusters",
+                    "get_kafka_cluster",
+                    "get_kafka_cluster_pods",
+                    "get_kafka_bootstrap_servers",
+                    "get_kafka_cluster_logs",
+                    "list_kafka_topics",
+                    "get_kafka_topic",
+                    "list_kafka_node_pools",
+                    "get_kafka_node_pool",
+                    "get_kafka_node_pool_pods",
+                    "list_strimzi_operators",
+                    "get_strimzi_operator",
+                    "get_strimzi_operator_logs",
+                    "get_strimzi_operator_pod",
+                    "get_kafka_metrics"
+                );
+
+                for (String toolName : expectedTools) {
+                    assertNotNull(page.findByName(toolName), "Tool '" + toolName + "' should be registered");
+                }
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testListKafkaClusters() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            new KafkaClusterResponse("my-cluster", "kafka", "Kafka", "4.2.0",
+                "Ready",
+                List.of(new ConditionInfo("Ready", "True", null, null, null)),
+                List.of(new ListenerInfo("plain", "internal",
+                    "my-cluster-kafka-bootstrap.kafka.svc:9092"),
+                    new ListenerInfo("tls", "internal",
+                    "my-cluster-kafka-bootstrap.kafka.svc:9093")),
+                new ReplicasInfo(3, 3),
+                "jbod", "100Gi",
+                false, true, false, Instant.parse("2025-01-01T00:00:00Z"), 60L, "strimzi")
+        ));
+
+        client.when()
+            .toolsCall("list_kafka_clusters", Map.of(), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("my-cluster"));
+                assertTrue(json.contains("kafka"));
+                assertTrue(json.contains("Ready"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaCluster() {
+        when(kafkaService.getCluster(null, "my-cluster")).thenReturn(
+            new KafkaClusterResponse("my-cluster", "kafka", "Kafka", "4.2.0",
+                "Ready",
+                List.of(new ConditionInfo("Ready", "True", null, null, null)),
+                List.of(new ListenerInfo("plain", "internal",
+                    "my-cluster-kafka-bootstrap.kafka.svc:9092")),
+                new ReplicasInfo(3, 3),
+                "jbod", "100Gi",
+                false, true, false, Instant.parse("2025-01-01T00:00:00Z"), 60L, "strimzi")
+        );
+
+        client.when()
+            .toolsCall("get_kafka_cluster", Map.of("clusterName", "my-cluster"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("my-cluster"));
+                assertTrue(json.contains("4.2.0"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaClusterPods() {
+        PodSummaryResponse podSummary = PodSummaryResponse.of("kafka", List.of(
+            PodSummaryResponse.PodInfo.summary("my-cluster-kafka-0", "Running", true, "kafka", 0, 120)
+        ));
+        when(kafkaService.getClusterPods(null, "my-cluster")).thenReturn(
+            KafkaClusterPodsResponse.of("my-cluster", "kafka", podSummary)
+        );
+
+        client.when()
+            .toolsCall("get_kafka_cluster_pods", Map.of("clusterName", "my-cluster"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("my-cluster-kafka-0"));
+                assertTrue(json.contains("Running"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaBootstrapServers() {
+        when(kafkaService.getBootstrapServers(null, "my-cluster")).thenReturn(
+            KafkaBootstrapResponse.of("kafka", "my-cluster", List.of(
+                new KafkaBootstrapResponse.BootstrapServerInfo(
+                    "my-cluster-kafka-bootstrap.kafka.svc", 9092, "plain", "internal",
+                    "my-cluster-kafka-bootstrap.kafka.svc:9092")
+            ))
+        );
+
+        client.when()
+            .toolsCall("get_kafka_bootstrap_servers", Map.of("clusterName", "my-cluster"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("my-cluster-kafka-bootstrap"));
+                assertTrue(json.contains("9092"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testListKafkaTopics() {
+        when(topicService.listTopics(null, "my-cluster")).thenReturn(List.of(
+            new KafkaTopicResponse("user-events", "my-cluster", 12, 3, "Ready")
+        ));
+
+        client.when()
+            .toolsCall("list_kafka_topics", Map.of("clusterName", "my-cluster"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("user-events"));
+                assertTrue(json.contains("my-cluster"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaTopic() {
+        when(topicService.getTopic(null, "my-cluster", "user-events")).thenReturn(
+            new KafkaTopicResponse("user-events", "my-cluster", 12, 3, "Ready")
+        );
+
+        client.when()
+            .toolsCall("get_kafka_topic",
+                Map.of("clusterName", "my-cluster", "topicName", "user-events"), response -> {
+                    assertFalse(response.isError());
+                    String json = response.content().getFirst().asText().text();
+                    assertTrue(json.contains("user-events"));
+                    assertTrue(json.contains("12"));
+                })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testListKafkaNodePools() {
+        when(nodePoolService.listNodePools(null, "my-cluster")).thenReturn(List.of(
+            new KafkaNodePoolResponse("broker", "kafka", "my-cluster",
+                List.of("broker"), 3, "jbod", "100Gi")
+        ));
+
+        client.when()
+            .toolsCall("list_kafka_node_pools", Map.of("clusterName", "my-cluster"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("broker"));
+                assertTrue(json.contains("my-cluster"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaNodePool() {
+        when(nodePoolService.getNodePool(null, "my-cluster", "broker")).thenReturn(
+            new KafkaNodePoolResponse("broker", "kafka", "my-cluster",
+                List.of("broker"), 3, "jbod", "100Gi")
+        );
+
+        client.when()
+            .toolsCall("get_kafka_node_pool",
+                Map.of("clusterName", "my-cluster", "nodePoolName", "broker"), response -> {
+                    assertFalse(response.isError());
+                    String json = response.content().getFirst().asText().text();
+                    assertTrue(json.contains("broker"));
+                    assertTrue(json.contains("100Gi"));
+                })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaNodePoolPods() {
+        when(nodePoolService.getNodePoolPods(null, "my-cluster", "broker")).thenReturn(List.of(
+            PodSummaryResponse.PodInfo.summary("my-cluster-broker-0", "Running", true, "kafka", 0, 60)
+        ));
+
+        client.when()
+            .toolsCall("get_kafka_node_pool_pods",
+                Map.of("clusterName", "my-cluster", "nodePoolName", "broker"), response -> {
+                    assertFalse(response.isError());
+                    String json = response.content().getFirst().asText().text();
+                    assertTrue(json.contains("my-cluster-broker-0"));
+                    assertTrue(json.contains("Running"));
+                })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testListStrimziOperators() {
+        when(operatorService.listOperators(null)).thenReturn(List.of(
+            StrimziOperatorResponse.of("strimzi-cluster-operator", "kafka-system",
+                true, 1, 1, "0.51.0", "quay.io/strimzi/operator:0.50.0", "48.5", "HEALTHY")
+        ));
+
+        client.when()
+            .toolsCall("list_strimzi_operators", Map.of(), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("strimzi-cluster-operator"));
+                assertTrue(json.contains("HEALTHY"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetStrimziOperator() {
+        when(operatorService.getOperator(null, "strimzi-cluster-operator")).thenReturn(
+            StrimziOperatorResponse.of("strimzi-cluster-operator", "kafka-system",
+                true, 1, 1, "0.51.0", "quay.io/strimzi/operator:0.50.0", "48.5", "HEALTHY")
+        );
+
+        client.when()
+            .toolsCall("get_strimzi_operator",
+                Map.of("operatorName", "strimzi-cluster-operator"), response -> {
+                    assertFalse(response.isError());
+                    String json = response.content().getFirst().asText().text();
+                    assertTrue(json.contains("strimzi-cluster-operator"));
+                    assertTrue(json.contains("0.51.0"));
+                })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetStrimziOperatorLogs() {
+        when(operatorService.getOperatorLogs(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(
+            StrimziOperatorLogsResponse.of("kafka-system",
+                "INFO: Operator running normally", List.of("strimzi-operator-abc123"),
+                false, 0, 1, false)
+        );
+
+        client.when()
+            .toolsCall("get_strimzi_operator_logs", Map.of(), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("Operator running normally"));
+                assertTrue(json.contains("strimzi-operator-abc123"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetStrimziOperatorPod() {
+        when(podsService.describePod("kafka-system", "strimzi-operator-abc123", null)).thenReturn(
+            PodSummaryResponse.of("kafka-system", List.of(
+                PodSummaryResponse.PodInfo.summary(
+                    "strimzi-operator-abc123", "Running", true, "operator", 0, 120)
+            ))
+        );
+
+        client.when()
+            .toolsCall("get_strimzi_operator_pod",
+                Map.of("namespace", "kafka-system", "podName", "strimzi-operator-abc123"), response -> {
+                    assertFalse(response.isError());
+                    String json = response.content().getFirst().asText().text();
+                    assertTrue(json.contains("strimzi-operator-abc123"));
+                    assertTrue(json.contains("Running"));
+                })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testToolCallExceptionWrappedAsError() {
+        when(kafkaService.getCluster(any(), eq("nonexistent"))).thenThrow(
+            new ToolCallException("Kafka cluster 'nonexistent' not found in any namespace")
+        );
+
+        client.when()
+            .toolsCall("get_kafka_cluster", Map.of("clusterName", "nonexistent"), response -> {
+                assertTrue(response.isError());
+                String text = response.content().getFirst().asText().text();
+                assertTrue(text.contains("not found"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGenericExceptionWrappedAsError() {
+        when(kafkaService.listClusters(any())).thenThrow(
+            new RuntimeException("Connection refused")
+        );
+
+        client.when()
+            .toolsCall("list_kafka_clusters", Map.of(), response -> {
+                assertTrue(response.isError());
+                String text = response.content().getFirst().asText().text();
+                assertTrue(text.contains("Connection refused"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testEmptyListResult() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of());
+
+        client.when()
+            .toolsCall("list_kafka_clusters", Map.of(), response -> {
+                assertFalse(response.isError());
+                assertTrue(response.content().isEmpty());
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testGetKafkaMetrics() {
+        when(kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null))
+            .thenReturn(KafkaMetricsResponse.of("my-cluster", "kafka", "pod-scraping",
+                List.of("replication"), List.of()));
+
+        client.when()
+            .toolsCall("get_kafka_metrics", Map.of("clusterName", "my-cluster"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("my-cluster"));
+                assertTrue(json.contains("pod-scraping"));
+            })
+            .thenAssertResults();
+    }
+
+    @Test
+    void testNamespaceParameterPassedThrough() {
+        when(kafkaService.listClusters("production")).thenReturn(List.of(
+            new KafkaClusterResponse("prod-cluster", "production", "Kafka", "4.2.0",
+                "Ready",
+                List.of(new ConditionInfo("Ready", "True", null, null, null)),
+                List.of(new ListenerInfo("tls", "internal",
+                    "prod-cluster-kafka-bootstrap.production.svc:9093")),
+                new ReplicasInfo(3, 3),
+                "jbod", "100Gi",
+                false, true, true, Instant.parse("2025-01-01T00:00:00Z"), 120L, "strimzi")
+        ));
+
+        client.when()
+            .toolsCall("list_kafka_clusters", Map.of("namespace", "production"), response -> {
+                assertFalse(response.isError());
+                String json = response.content().getFirst().asText().text();
+                assertTrue(json.contains("prod-cluster"));
+                assertTrue(json.contains("production"));
+            })
+            .thenAssertResults();
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/MetricsToolsTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/MetricsToolsTest.java
@@ -414,7 +414,7 @@ class MetricsToolsTest {
 
     @Test
     void testGetKafkaMetrics() {
-        when(kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null))
+        when(kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null, null, null))
             .thenReturn(KafkaMetricsResponse.of("my-cluster", "kafka", "pod-scraping",
                 List.of("replication"), List.of(), null));
 
@@ -430,7 +430,7 @@ class MetricsToolsTest {
 
     @Test
     void testGetStrimziOperatorMetrics() {
-        when(strimziOperatorMetricsService.getOperatorMetrics(null, null, null, null, null, null))
+        when(strimziOperatorMetricsService.getOperatorMetrics(null, null, null, null, null, null, null, null))
             .thenReturn(StrimziOperatorMetricsResponse.of("cluster-operator", "kafka-system",
                 "pod-scraping", List.of("reconciliation"), List.of(), null));
 

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/MetricsToolsTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/MetricsToolsTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
  * response serialization, and error handling through the MCP protocol layer.
  */
 @QuarkusTest
-class McpToolsTest {
+class MetricsToolsTest {
 
     @ConfigProperty(name = "quarkus.http.test-port")
     int testPort;
@@ -78,7 +78,7 @@ class McpToolsTest {
 
     private McpAssured.McpSseTestClient client;
 
-    McpToolsTest() {
+    MetricsToolsTest() {
     }
 
     @BeforeEach


### PR DESCRIPTION
This PR implements modules for scraping metrics directly from pods and via Prometheus.

Users can define which provider can be used via `mcp.metrics.provider` configuration. Allowed values are `streamshub-pod-scraping` and `streamshub-prometheus`.

Prometheus implementation is currently tested with prometheus instance installed within OCP clusters. Plan si to test also others and document usage of it properly. 

The PR is in draft because it needs more testing and docs.