### PR TITLE
Unify prometheus and loki plugins configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Checkstyle runs during compile phase. Fix all violations before committing.
 ```
 io.streamshub.mcp.common.
 ├── config/         → KubernetesConstants (labels, conditions, phases, health status)
-├── dto/            → PodSummaryResponse, PodLogsResult, LogCollectionOptions (generic pod DTOs)
+├── dto/            → PodSummaryResponse, PodLogsResult, LogCollectionParams (generic pod DTOs)
 │   └── metrics/    → MetricSample, PodTarget, MetricsQueryParams
 ├── readiness/   → KubernetesConnectionReadinessCheck (health check for kube API)
 ├──service/        → KubernetesResourceService, PodsService, DeploymentService, CompletionHelper
@@ -132,7 +132,7 @@ public KafkaClusterLogsResponse getKafkaClusterLogs(
     final Cancellation cancellation // check if client cancelled mid-operation
 ) {
     // Build options with callbacks
-    LogCollectionOptions options = LogCollectionOptions.builder(...)
+    LogCollectionParams options = LogCollectionParams.builder(...)
         .notifier(mcpLog::info)
         .cancelCheck(cancellation::skipProcessingIfCancelled)
         .progressCallback(...)

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>

--- a/common/src/main/java/io/streamshub/mcp/common/auth/AbstractAuthFilter.java
+++ b/common/src/main/java/io/streamshub/mcp/common/auth/AbstractAuthFilter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.auth;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import org.jboss.logging.Logger;
+
+import java.util.Locale;
+
+/**
+ * Base JAX-RS client request filter that adds authentication headers to outgoing API calls.
+ * Supports service account token, explicit bearer token, basic auth, and no-auth modes.
+ * Basic auth and mTLS are handled natively by Quarkus REST client properties.
+ *
+ * <p>Subclasses provide the provider-specific configuration and can add
+ * extra headers (e.g. tenant ID) via {@link #addProviderSpecificHeaders}.</p>
+ */
+public abstract class AbstractAuthFilter implements ClientRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(AbstractAuthFilter.class);
+
+    /**
+     * Returns the authentication configuration for this provider.
+     *
+     * @return the auth config
+     */
+    protected abstract AuthConfig authConfig();
+
+    /**
+     * Returns a human-readable provider name used in warning messages (e.g. "Loki", "Prometheus").
+     *
+     * @return the provider name
+     */
+    protected abstract String providerName();
+
+    /**
+     * Returns the full configuration property name for the bearer token,
+     * used in warning messages when the token is missing (e.g. "mcp.log.loki.bearer-token").
+     *
+     * @return the bearer token property name
+     */
+    protected abstract String bearerTokenPropertyName();
+
+    /**
+     * Hook for subclasses to add provider-specific headers (e.g. tenant ID).
+     * Default implementation does nothing.
+     *
+     * @param requestContext the outgoing request context
+     */
+    protected void addProviderSpecificHeaders(final ClientRequestContext requestContext) {
+        // no-op by default
+    }
+
+    @Override
+    public void filter(final ClientRequestContext requestContext) {
+        addProviderSpecificHeaders(requestContext);
+        addAuthentication(requestContext);
+    }
+
+    private void addAuthentication(final ClientRequestContext requestContext) {
+        String authMode = authConfig().authMode().toLowerCase(Locale.ROOT);
+
+        switch (authMode) {
+            case AuthHelper.AUTH_MODE_SA_TOKEN:
+                AuthHelper.readServiceAccountToken(authConfig().saTokenPath())
+                    .ifPresent(token -> requestContext.getHeaders()
+                        .putSingle("Authorization", "Bearer " + token));
+                break;
+            case AuthHelper.AUTH_MODE_BEARER_TOKEN:
+                AuthHelper.validateBearerToken(authConfig().bearerToken(), bearerTokenPropertyName())
+                    .ifPresent(token -> requestContext.getHeaders()
+                        .putSingle("Authorization", "Bearer " + token));
+                break;
+            case AuthHelper.AUTH_MODE_BASIC:
+                break;
+            case AuthHelper.AUTH_MODE_NONE:
+                break;
+            default:
+                LOG.warnf("Unknown %s auth mode: '%s'. No authentication applied.",
+                    providerName(), authMode);
+                break;
+        }
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/auth/AuthConfig.java
+++ b/common/src/main/java/io/streamshub/mcp/common/auth/AuthConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.auth;
+
+import java.util.Optional;
+
+/**
+ * Common authentication configuration contract for external service providers.
+ * Implemented by provider-specific {@code @ConfigMapping} interfaces
+ * (e.g. {@code LokiConfig}, {@code PrometheusConfig}).
+ */
+public interface AuthConfig {
+
+    /**
+     * Authentication mode: {@code none}, {@code bearer-token}, {@code sa-token}, or {@code basic}.
+     *
+     * @return the auth mode
+     */
+    String authMode();
+
+    /**
+     * Bearer token for {@code bearer-token} authentication.
+     *
+     * @return the bearer token, if configured
+     */
+    Optional<String> bearerToken();
+
+    /**
+     * Path to the service account token file for {@code sa-token} authentication.
+     *
+     * @return the token file path
+     */
+    String saTokenPath();
+}

--- a/common/src/main/java/io/streamshub/mcp/common/dto/LogCollectionParams.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/LogCollectionParams.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
  * Options for log collection from Kubernetes pods.
  *
  * <p>Encapsulates filtering, pagination, and callback parameters
- * for {@link io.streamshub.mcp.common.service.PodsService#collectLogs}.</p>
+ * for {@link io.streamshub.mcp.common.service.log.LogCollectionService#collectLogs}.</p>
  *
  * @param filter           optional filter: "errors", "warnings", or a regex pattern
  * @param keywords         optional list of keywords to match lines against (case-insensitive)
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
  * @param cancelCheck      optional callback invoked before each pod; should throw to abort
  * @param progressCallback optional callback receiving (completedPods, totalPods) after each pod
  */
-public record LogCollectionOptions(
+public record LogCollectionParams(
     String filter,
     List<String> keywords,
     Integer sinceSeconds,
@@ -43,9 +43,9 @@ public record LogCollectionOptions(
      * @param previous     if true, retrieve previous container logs
      * @return log collection options with no keywords or callbacks
      */
-    public static LogCollectionOptions of(final String filter, final Integer sinceSeconds,
-                                          final int tailLines, final Boolean previous) {
-        return new LogCollectionOptions(filter, null, sinceSeconds, tailLines, previous, null, null, null);
+    public static LogCollectionParams of(final String filter, final Integer sinceSeconds,
+                                         final int tailLines, final Boolean previous) {
+        return new LogCollectionParams(filter, null, sinceSeconds, tailLines, previous, null, null, null);
     }
 
     /**
@@ -59,7 +59,7 @@ public record LogCollectionOptions(
     }
 
     /**
-     * Builder for constructing {@link LogCollectionOptions} instances.
+     * Builder for constructing {@link LogCollectionParams} instances.
      */
     public static final class Builder {
 
@@ -158,8 +158,8 @@ public record LogCollectionOptions(
          *
          * @return the constructed options
          */
-        public LogCollectionOptions build() {
-            return new LogCollectionOptions(filter, keywords, sinceSeconds, tailLines,
+        public LogCollectionParams build() {
+            return new LogCollectionParams(filter, keywords, sinceSeconds, tailLines,
                 previous, notifier, cancelCheck, progressCallback);
         }
     }

--- a/common/src/main/java/io/streamshub/mcp/common/service/log/LogCollectionService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/log/LogCollectionService.java
@@ -5,7 +5,7 @@
 package io.streamshub.mcp.common.service.log;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -63,12 +63,12 @@ public class LogCollectionService {
      *
      * @param namespace the namespace of the pods
      * @param pods      the list of pods to collect logs from
-     * @param options   log collection options (filter, keywords, pagination, callbacks)
+     * @param options   log collection params (filter, keywords, pagination, callbacks)
      * @return the aggregated, filtered, and deduplicated log result
      */
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public PodLogsResult collectLogs(final String namespace, final List<Pod> pods,
-                                     final LogCollectionOptions options) {
+                                     final LogCollectionParams options) {
         List<String> podNames = pods.stream()
             .map(pod -> pod.getMetadata().getName())
             .toList();

--- a/common/src/test/java/io/streamshub/mcp/common/auth/AbstractAuthFilterTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/auth/AbstractAuthFilterTest.java
@@ -2,9 +2,8 @@
  * Copyright StreamsHub authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.streamshub.mcp.metrics.prometheus.service;
+package io.streamshub.mcp.common.auth;
 
-import io.streamshub.mcp.metrics.prometheus.config.PrometheusConfig;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -24,42 +23,36 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link PrometheusAuthFilter}.
- * Core authentication logic is tested in
- * {@link io.streamshub.mcp.common.auth.AbstractAuthFilterTest}.
+ * Tests for {@link AbstractAuthFilter} shared authentication logic.
  */
-class PrometheusAuthFilterTest {
+class AbstractAuthFilterTest {
 
     @Mock
     private ClientRequestContext requestContext;
 
     @Mock
-    private PrometheusConfig config;
+    private AuthConfig authConfig;
 
     private MultivaluedMap<String, Object> headers;
-    private PrometheusAuthFilter filter;
+    private TestAuthFilter filter;
 
     @TempDir
     Path tempDir;
 
-    PrometheusAuthFilterTest() {
+    AbstractAuthFilterTest() {
     }
 
     @BeforeEach
-    void setUp() throws ReflectiveOperationException {
+    void setUp() {
         MockitoAnnotations.openMocks(this);
         headers = new MultivaluedHashMap<>();
         when(requestContext.getHeaders()).thenReturn(headers);
-
-        filter = new PrometheusAuthFilter();
-        java.lang.reflect.Field configField = PrometheusAuthFilter.class.getDeclaredField("config");
-        configField.setAccessible(true);
-        configField.set(filter, config);
+        filter = new TestAuthFilter(authConfig);
     }
 
     @Test
     void noAuthModeDoesNotAddHeaders() throws IOException {
-        when(config.authMode()).thenReturn("none");
+        when(authConfig.authMode()).thenReturn("none");
 
         filter.filter(requestContext);
 
@@ -68,7 +61,7 @@ class PrometheusAuthFilterTest {
 
     @Test
     void basicAuthModeDoesNotAddHeaders() throws IOException {
-        when(config.authMode()).thenReturn("basic");
+        when(authConfig.authMode()).thenReturn("basic");
 
         filter.filter(requestContext);
 
@@ -77,8 +70,8 @@ class PrometheusAuthFilterTest {
 
     @Test
     void bearerTokenModeAddsAuthorizationHeader() throws IOException {
-        when(config.authMode()).thenReturn("bearer-token");
-        when(config.bearerToken()).thenReturn(Optional.of("test-token-123"));
+        when(authConfig.authMode()).thenReturn("bearer-token");
+        when(authConfig.bearerToken()).thenReturn(Optional.of("test-token-123"));
 
         filter.filter(requestContext);
 
@@ -87,8 +80,8 @@ class PrometheusAuthFilterTest {
 
     @Test
     void bearerTokenModeTrimsToken() throws IOException {
-        when(config.authMode()).thenReturn("bearer-token");
-        when(config.bearerToken()).thenReturn(Optional.of("  test-token-456  "));
+        when(authConfig.authMode()).thenReturn("bearer-token");
+        when(authConfig.bearerToken()).thenReturn(Optional.of("  test-token-456  "));
 
         filter.filter(requestContext);
 
@@ -97,8 +90,8 @@ class PrometheusAuthFilterTest {
 
     @Test
     void bearerTokenModeWithoutTokenDoesNotAddHeader() throws IOException {
-        when(config.authMode()).thenReturn("bearer-token");
-        when(config.bearerToken()).thenReturn(Optional.empty());
+        when(authConfig.authMode()).thenReturn("bearer-token");
+        when(authConfig.bearerToken()).thenReturn(Optional.empty());
 
         filter.filter(requestContext);
 
@@ -107,8 +100,8 @@ class PrometheusAuthFilterTest {
 
     @Test
     void bearerTokenModeWithBlankTokenDoesNotAddHeader() throws IOException {
-        when(config.authMode()).thenReturn("bearer-token");
-        when(config.bearerToken()).thenReturn(Optional.of("   "));
+        when(authConfig.authMode()).thenReturn("bearer-token");
+        when(authConfig.bearerToken()).thenReturn(Optional.of("   "));
 
         filter.filter(requestContext);
 
@@ -120,8 +113,8 @@ class PrometheusAuthFilterTest {
         Path tokenFile = tempDir.resolve("token");
         Files.writeString(tokenFile, "sa-token-content");
 
-        when(config.authMode()).thenReturn("sa-token");
-        when(config.saTokenPath()).thenReturn(tokenFile.toString());
+        when(authConfig.authMode()).thenReturn("sa-token");
+        when(authConfig.saTokenPath()).thenReturn(tokenFile.toString());
 
         filter.filter(requestContext);
 
@@ -133,8 +126,8 @@ class PrometheusAuthFilterTest {
         Path tokenFile = tempDir.resolve("token");
         Files.writeString(tokenFile, "  sa-token-with-whitespace  \n");
 
-        when(config.authMode()).thenReturn("sa-token");
-        when(config.saTokenPath()).thenReturn(tokenFile.toString());
+        when(authConfig.authMode()).thenReturn("sa-token");
+        when(authConfig.saTokenPath()).thenReturn(tokenFile.toString());
 
         filter.filter(requestContext);
 
@@ -143,8 +136,8 @@ class PrometheusAuthFilterTest {
 
     @Test
     void serviceAccountTokenModeWithMissingFileDoesNotAddHeader() throws IOException {
-        when(config.authMode()).thenReturn("sa-token");
-        when(config.saTokenPath()).thenReturn("/nonexistent/token");
+        when(authConfig.authMode()).thenReturn("sa-token");
+        when(authConfig.saTokenPath()).thenReturn("/nonexistent/token");
 
         filter.filter(requestContext);
 
@@ -153,7 +146,7 @@ class PrometheusAuthFilterTest {
 
     @Test
     void unknownAuthModeDoesNotAddHeader() throws IOException {
-        when(config.authMode()).thenReturn("unknown-mode");
+        when(authConfig.authMode()).thenReturn("unknown-mode");
 
         filter.filter(requestContext);
 
@@ -162,11 +155,38 @@ class PrometheusAuthFilterTest {
 
     @Test
     void authModeIsCaseInsensitive() throws IOException {
-        when(config.authMode()).thenReturn("BEARER-TOKEN");
-        when(config.bearerToken()).thenReturn(Optional.of("test-token"));
+        when(authConfig.authMode()).thenReturn("BEARER-TOKEN");
+        when(authConfig.bearerToken()).thenReturn(Optional.of("test-token"));
 
         filter.filter(requestContext);
 
         assertEquals("Bearer test-token", headers.getFirst("Authorization"));
+    }
+
+    /**
+     * Concrete test subclass of {@link AbstractAuthFilter}.
+     */
+    private static class TestAuthFilter extends AbstractAuthFilter {
+
+        private final AuthConfig config;
+
+        TestAuthFilter(final AuthConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        protected AuthConfig authConfig() {
+            return config;
+        }
+
+        @Override
+        protected String providerName() {
+            return "Test";
+        }
+
+        @Override
+        protected String bearerTokenPropertyName() {
+            return "test.bearer-token";
+        }
     }
 }

--- a/common/src/test/java/io/streamshub/mcp/common/service/log/LogCollectionServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/log/LogCollectionServiceTest.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -46,7 +46,7 @@ class LogCollectionServiceTest {
             throw new RuntimeException("Cancelled");
         };
 
-        LogCollectionOptions options = LogCollectionOptions.builder(100)
+        LogCollectionParams options = LogCollectionParams.builder(100)
             .cancelCheck(cancelCheck)
             .build();
 
@@ -62,7 +62,7 @@ class LogCollectionServiceTest {
 
         List<int[]> progressCalls = new ArrayList<>();
 
-        LogCollectionOptions options = LogCollectionOptions.builder(100)
+        LogCollectionParams options = LogCollectionParams.builder(100)
             .progressCallback((completed, total) -> progressCalls.add(new int[]{completed, total}))
             .build();
 
@@ -81,7 +81,7 @@ class LogCollectionServiceTest {
 
         List<String> notifications = new ArrayList<>();
 
-        LogCollectionOptions options = LogCollectionOptions.builder(100)
+        LogCollectionParams options = LogCollectionParams.builder(100)
             .notifier(notifications::add)
             .build();
 
@@ -93,7 +93,7 @@ class LogCollectionServiceTest {
 
     @Test
     void testCollectLogsEmptyPodList() {
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 100, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 100, null);
         PodLogsResult result = logCollectionService.collectLogs("kafka", List.of(), options);
 
         assertNotNull(result);

--- a/dev/manifests/loki/lokistack.yaml
+++ b/dev/manifests/loki/lokistack.yaml
@@ -28,6 +28,6 @@ spec:
     secret:
       name: logging-loki-s3
       type: s3
-  storageClassName: rook-ceph-block
+  storageClassName: standard-csi
   tenants:
     mode: openshift-logging

--- a/dev/manifests/loki/s3-storage.yaml
+++ b/dev/manifests/loki/s3-storage.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: seaweedfs
-          image: chrislusf/seaweedfs:latest
+          image: mirror.gcr.io/chrislusf/seaweedfs:latest
           args:
             - server
             - -s3
@@ -128,7 +128,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: create-bucket
-          image: curlimages/curl:latest
+          image: mirror.gcr.io/curlimages/curl:latest
           command:
             - /bin/sh
             - -c

--- a/dev/scripts/setup-loki.sh
+++ b/dev/scripts/setup-loki.sh
@@ -66,42 +66,53 @@ wait_for_crd() {
 deploy() {
     check_prerequisites
 
-    # Check loki-operator channel (pick latest stable, don't trust defaultChannel)
-    local channel
-    channel=$(kubectl get packagemanifest loki-operator -n openshift-marketplace \
-        -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' 2>/dev/null \
-        | grep '^stable-' | sort -V | tail -1)
-    if [ -z "$channel" ]; then
-        log_error "loki-operator not found in openshift-marketplace."
-        log_error "Ensure the OperatorHub catalog sources are available."
-        exit 1
-    fi
-    log_success "Found loki-operator (channel: $channel)"
-
-    # Update channel in manifest if different
-    sed -i.bak "s/channel: stable-.*/channel: $channel/" "$MANIFESTS_DIR/loki-operator.yaml"
-    rm -f "$MANIFESTS_DIR/loki-operator.yaml.bak"
-
     # Check for available StorageClass
     local sc
-    sc=$(kubectl get storageclass -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    sc=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null | awk '{print $1}' || echo "")
     if [ -n "$sc" ]; then
         log_info "Using StorageClass: $sc"
         sed -i.bak "s/storageClassName: .*/storageClassName: $sc/" "$MANIFESTS_DIR/lokistack.yaml"
         rm -f "$MANIFESTS_DIR/lokistack.yaml.bak"
     fi
 
-    # Phase 1: Namespace + Operator
-    log_info "Phase 1: Installing Loki Operator..."
+    # Ensure namespaces exist
     kubectl apply -f "$MANIFESTS_DIR/namespace.yaml"
     kubectl create namespace "$OPERATOR_NS" --dry-run=client -o yaml | kubectl apply -f -
-    kubectl apply -f "$MANIFESTS_DIR/loki-operator.yaml"
+
+    # Check if loki-operator is already installed
+    local existing_csv
+    existing_csv=$(kubectl get csv -n "$OPERATOR_NS" -o name 2>/dev/null | grep loki || echo "")
+
+    if [ -n "$existing_csv" ]; then
+        log_success "Loki Operator already installed ($existing_csv)"
+    else
+        # Discover loki-operator channel (pick latest stable, don't trust defaultChannel)
+        local channel
+        channel=$(kubectl get packagemanifest loki-operator -n openshift-marketplace \
+            -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' 2>/dev/null \
+            | grep '^stable-' | sort -V | tail -1)
+        if [ -z "$channel" ]; then
+            log_error "loki-operator not found in openshift-marketplace."
+            log_error "Ensure the OperatorHub catalog sources are available."
+            exit 1
+        fi
+        log_success "Found loki-operator (channel: $channel)"
+
+        # Update channel in manifest if different
+        sed -i.bak "s/channel: stable-.*/channel: $channel/" "$MANIFESTS_DIR/loki-operator.yaml"
+        rm -f "$MANIFESTS_DIR/loki-operator.yaml.bak"
+
+        # Phase 1: Install Loki Operator
+        log_info "Phase 1: Installing Loki Operator..."
+        kubectl apply -f "$MANIFESTS_DIR/loki-operator.yaml"
+    fi
 
     # Phase 2: Wait for LokiStack CRD
     wait_for_crd "lokistacks.loki.grafana.com" 300
 
     # Phase 3: SeaweedFS + LokiStack
     log_info "Phase 3: Deploying SeaweedFS storage..."
+    kubectl delete job seaweedfs-create-bucket -n "$LOKI_NS" --ignore-not-found 2>/dev/null || true
     kubectl apply -f "$MANIFESTS_DIR/s3-storage.yaml"
 
     log_info "Waiting for SeaweedFS to be ready..."

--- a/loki-log-provider/src/main/java/io/streamshub/mcp/loki/config/LokiConfig.java
+++ b/loki-log-provider/src/main/java/io/streamshub/mcp/loki/config/LokiConfig.java
@@ -7,6 +7,7 @@ package io.streamshub.mcp.loki.config;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import io.streamshub.mcp.common.auth.AuthConfig;
 
 import java.util.Optional;
 
@@ -18,13 +19,14 @@ import java.util.Optional;
  * Quarkus REST client properties under {@code quarkus.rest-client.loki.*}.</p>
  */
 @ConfigMapping(prefix = "mcp.log.loki")
-public interface LokiConfig {
+public interface LokiConfig extends AuthConfig {
 
     /**
      * Authentication mode: {@code none}, {@code bearer-token}, {@code sa-token}, or {@code basic}.
      *
      * @return the auth mode
      */
+    @Override
     @WithName("auth-mode")
     @WithDefault("none")
     String authMode();
@@ -34,6 +36,7 @@ public interface LokiConfig {
      *
      * @return the bearer token, if configured
      */
+    @Override
     @WithName("bearer-token")
     Optional<String> bearerToken();
 
@@ -42,6 +45,7 @@ public interface LokiConfig {
      *
      * @return the token file path
      */
+    @Override
     @WithName("sa-token-path")
     @WithDefault("/var/run/secrets/kubernetes.io/serviceaccount/token")
     String saTokenPath();

--- a/loki-log-provider/src/main/java/io/streamshub/mcp/loki/service/LokiAuthFilter.java
+++ b/loki-log-provider/src/main/java/io/streamshub/mcp/loki/service/LokiAuthFilter.java
@@ -4,14 +4,11 @@
  */
 package io.streamshub.mcp.loki.service;
 
-import io.streamshub.mcp.common.auth.AuthHelper;
+import io.streamshub.mcp.common.auth.AbstractAuthFilter;
+import io.streamshub.mcp.common.auth.AuthConfig;
 import io.streamshub.mcp.loki.config.LokiConfig;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.ClientRequestContext;
-import jakarta.ws.rs.client.ClientRequestFilter;
-import org.jboss.logging.Logger;
-
-import java.util.Locale;
 
 /**
  * JAX-RS client request filter that adds authentication and tenant ID to Loki API calls.
@@ -21,9 +18,7 @@ import java.util.Locale;
  * <p>Registered on {@link LokiClient} via {@code @RegisterProvider},
  * so it only applies to Loki API calls.</p>
  */
-public class LokiAuthFilter implements ClientRequestFilter {
-
-    private static final Logger LOG = Logger.getLogger(LokiAuthFilter.class);
+public class LokiAuthFilter extends AbstractAuthFilter {
 
     @Inject
     LokiConfig config;
@@ -32,38 +27,24 @@ public class LokiAuthFilter implements ClientRequestFilter {
     }
 
     @Override
-    public void filter(final ClientRequestContext requestContext) {
-        addTenantId(requestContext);
-        addAuthentication(requestContext);
+    protected AuthConfig authConfig() {
+        return config;
     }
 
-    private void addTenantId(final ClientRequestContext requestContext) {
+    @Override
+    protected String providerName() {
+        return "Loki";
+    }
+
+    @Override
+    protected String bearerTokenPropertyName() {
+        return "mcp.log.loki.bearer-token";
+    }
+
+    @Override
+    protected void addProviderSpecificHeaders(final ClientRequestContext requestContext) {
         config.tenantId()
             .filter(id -> !id.isBlank())
             .ifPresent(id -> requestContext.getHeaders().putSingle("X-Scope-OrgID", id.trim()));
-    }
-
-    private void addAuthentication(final ClientRequestContext requestContext) {
-        String authMode = config.authMode().toLowerCase(Locale.ROOT);
-
-        switch (authMode) {
-            case AuthHelper.AUTH_MODE_SA_TOKEN:
-                AuthHelper.readServiceAccountToken(config.saTokenPath())
-                    .ifPresent(token -> requestContext.getHeaders()
-                        .putSingle("Authorization", "Bearer " + token));
-                break;
-            case AuthHelper.AUTH_MODE_BEARER_TOKEN:
-                AuthHelper.validateBearerToken(config.bearerToken(), "mcp.log.loki.bearer-token")
-                    .ifPresent(token -> requestContext.getHeaders()
-                        .putSingle("Authorization", "Bearer " + token));
-                break;
-            case AuthHelper.AUTH_MODE_BASIC:
-                break;
-            case AuthHelper.AUTH_MODE_NONE:
-                break;
-            default:
-                LOG.warnf("Unknown Loki auth mode: '%s'. No authentication applied.", authMode);
-                break;
-        }
     }
 }

--- a/loki-log-provider/src/test/java/io/streamshub/mcp/loki/service/LokiAuthFilterTest.java
+++ b/loki-log-provider/src/test/java/io/streamshub/mcp/loki/service/LokiAuthFilterTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.loki.service;
+
+import io.streamshub.mcp.loki.config.LokiConfig;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link LokiAuthFilter} Loki-specific header behavior.
+ * Core authentication logic is tested in
+ * {@link io.streamshub.mcp.common.auth.AbstractAuthFilterTest}.
+ */
+class LokiAuthFilterTest {
+
+    @Mock
+    private ClientRequestContext requestContext;
+
+    @Mock
+    private LokiConfig config;
+
+    private MultivaluedMap<String, Object> headers;
+    private LokiAuthFilter filter;
+
+    LokiAuthFilterTest() {
+    }
+
+    @BeforeEach
+    void setUp() throws ReflectiveOperationException {
+        MockitoAnnotations.openMocks(this);
+        headers = new MultivaluedHashMap<>();
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        when(config.authMode()).thenReturn("none");
+        when(config.saTokenPath()).thenReturn("/var/run/secrets/kubernetes.io/serviceaccount/token");
+        when(config.bearerToken()).thenReturn(Optional.empty());
+
+        filter = new LokiAuthFilter();
+        java.lang.reflect.Field configField = LokiAuthFilter.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(filter, config);
+    }
+
+    @Test
+    void tenantIdHeaderIsAddedWhenConfigured() throws IOException {
+        when(config.tenantId()).thenReturn(Optional.of("my-tenant"));
+
+        filter.filter(requestContext);
+
+        assertEquals("my-tenant", headers.getFirst("X-Scope-OrgID"));
+    }
+
+    @Test
+    void tenantIdHeaderIsNotAddedWhenEmpty() throws IOException {
+        when(config.tenantId()).thenReturn(Optional.empty());
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("X-Scope-OrgID"));
+    }
+
+    @Test
+    void tenantIdHeaderIsNotAddedWhenBlank() throws IOException {
+        when(config.tenantId()).thenReturn(Optional.of("   "));
+
+        filter.filter(requestContext);
+
+        assertNull(headers.getFirst("X-Scope-OrgID"));
+    }
+
+    @Test
+    void tenantIdHeaderIsTrimmed() throws IOException {
+        when(config.tenantId()).thenReturn(Optional.of("  my-tenant  "));
+
+        filter.filter(requestContext);
+
+        assertEquals("my-tenant", headers.getFirst("X-Scope-OrgID"));
+    }
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/config/PrometheusConfig.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/config/PrometheusConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.metrics.prometheus.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+import io.streamshub.mcp.common.auth.AuthConfig;
+
+import java.util.Optional;
+
+/**
+ * Configuration for the Prometheus metrics provider.
+ *
+ * <p>Maps to properties under {@code mcp.metrics.prometheus.*}.
+ * Connection settings (URL, TLS) are configured via standard
+ * Quarkus REST client properties under {@code quarkus.rest-client.prometheus.*}.</p>
+ */
+@ConfigMapping(prefix = "mcp.metrics.prometheus")
+public interface PrometheusConfig extends AuthConfig {
+
+    /**
+     * Authentication mode: {@code none}, {@code bearer-token}, {@code sa-token}, or {@code basic}.
+     *
+     * @return the auth mode
+     */
+    @Override
+    @WithName("auth-mode")
+    @WithDefault("none")
+    String authMode();
+
+    /**
+     * Bearer token for {@code bearer-token} authentication.
+     *
+     * @return the bearer token, if configured
+     */
+    @Override
+    @WithName("bearer-token")
+    Optional<String> bearerToken();
+
+    /**
+     * Path to the service account token file for {@code sa-token} authentication.
+     *
+     * @return the token file path
+     */
+    @Override
+    @WithName("sa-token-path")
+    @WithDefault("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    String saTokenPath();
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusAuthFilter.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusAuthFilter.java
@@ -4,67 +4,40 @@
  */
 package io.streamshub.mcp.metrics.prometheus.service;
 
-import io.streamshub.mcp.common.auth.AuthHelper;
-import jakarta.ws.rs.client.ClientRequestContext;
-import jakarta.ws.rs.client.ClientRequestFilter;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
-
-import java.io.IOException;
-import java.util.Locale;
+import io.streamshub.mcp.common.auth.AbstractAuthFilter;
+import io.streamshub.mcp.common.auth.AuthConfig;
+import io.streamshub.mcp.metrics.prometheus.config.PrometheusConfig;
+import jakarta.inject.Inject;
 
 /**
  * JAX-RS client request filter that adds authentication to Prometheus API calls.
- * Supports service account token, explicit bearer token, and no-auth modes.
+ * Supports service account token, explicit bearer token, basic auth, and no-auth modes.
  * Basic auth and mTLS are handled natively by Quarkus REST client properties.
  *
  * <p>Registered on {@link PrometheusClient} via {@code @RegisterProvider},
  * so it only applies to Prometheus API calls.</p>
  */
-public class PrometheusAuthFilter implements ClientRequestFilter {
+public class PrometheusAuthFilter extends AbstractAuthFilter {
 
-    private static final Logger LOG = Logger.getLogger(PrometheusAuthFilter.class);
-
-    private static final String AUTH_MODE_KEY = "mcp.metrics.prometheus.auth-mode";
-    private static final String BEARER_TOKEN_KEY = "mcp.metrics.prometheus.bearer-token";
-    private static final String SA_TOKEN_PATH_KEY = "mcp.metrics.prometheus.sa-token-path";
+    @Inject
+    PrometheusConfig config;
 
     PrometheusAuthFilter() {
         // package-private no-arg constructor for CDI
     }
 
     @Override
-    public void filter(final ClientRequestContext requestContext) throws IOException {
-        String authMode = ConfigProvider.getConfig()
-            .getOptionalValue(AUTH_MODE_KEY, String.class)
-            .orElse("none")
-            .toLowerCase(Locale.ROOT);
+    protected AuthConfig authConfig() {
+        return config;
+    }
 
-        switch (authMode) {
-            case AuthHelper.AUTH_MODE_SA_TOKEN:
-                String tokenPath = ConfigProvider.getConfig()
-                    .getOptionalValue(SA_TOKEN_PATH_KEY, String.class)
-                    .orElse(AuthHelper.DEFAULT_SA_TOKEN_PATH);
-                AuthHelper.readServiceAccountToken(tokenPath)
-                    .ifPresent(token -> requestContext.getHeaders()
-                        .putSingle("Authorization", "Bearer " + token));
-                break;
-            case AuthHelper.AUTH_MODE_BEARER_TOKEN:
-                AuthHelper.validateBearerToken(
-                        ConfigProvider.getConfig().getOptionalValue(BEARER_TOKEN_KEY, String.class),
-                        BEARER_TOKEN_KEY)
-                    .ifPresent(token -> requestContext.getHeaders()
-                        .putSingle("Authorization", "Bearer " + token));
-                break;
-            case AuthHelper.AUTH_MODE_BASIC:
-                // Basic auth is handled by Quarkus REST client properties:
-                // quarkus.rest-client.prometheus.username / password
-                break;
-            case AuthHelper.AUTH_MODE_NONE:
-                break;
-            default:
-                LOG.warnf("Unknown Prometheus auth mode: '%s'. No authentication applied.", authMode);
-                break;
-        }
+    @Override
+    protected String providerName() {
+        return "Prometheus";
+    }
+
+    @Override
+    protected String bearerTokenPropertyName() {
+        return "mcp.metrics.prometheus.bearer-token";
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.streamshub.mcp.common.config.KubernetesConstants;
 import io.streamshub.mcp.common.dto.ConditionInfo;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import io.streamshub.mcp.common.dto.PodSummaryResponse;
 import io.streamshub.mcp.common.dto.ReplicasInfo;
@@ -195,7 +195,7 @@ public class KafkaService {
      * @return the cluster logs response
      */
     public KafkaClusterLogsResponse getClusterLogs(final String namespace, final String clusterName,
-                                                   final LogCollectionOptions options) {
+                                                   final LogCollectionParams options) {
         String ns = InputUtils.normalizeInput(namespace);
         String normalizedName = InputUtils.normalizeInput(clusterName);
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/StrimziOperatorService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/StrimziOperatorService.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.streamshub.mcp.common.config.KubernetesConstants;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import io.streamshub.mcp.common.service.DeploymentService;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
@@ -112,7 +112,7 @@ public class StrimziOperatorService {
      * @return the operator logs response
      */
     public StrimziOperatorLogsResponse getOperatorLogs(final String namespace, final String operatorName,
-                                                        final LogCollectionOptions options) {
+                                                        final LogCollectionParams options) {
         String ns = InputUtils.normalizeInput(namespace);
 
         LOG.infof("Getting operator logs (namespace=%s, name=%s, filter=%s, tailLines=%s, previous=%s)",

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTools.java
@@ -10,7 +10,7 @@ import io.quarkiverse.mcp.server.Progress;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.WrapBusinessError;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.guardrail.Guarded;
 import io.streamshub.mcp.strimzi.config.StrimziToolsPrompts;
 import io.streamshub.mcp.strimzi.dto.KafkaBootstrapResponse;
@@ -228,7 +228,7 @@ public class KafkaTools {
         final Progress progress,
         final Cancellation cancellation
     ) {
-        LogCollectionOptions options = LogCollectionOptions.builder(
+        LogCollectionParams options = LogCollectionParams.builder(
                 tailLines != null ? tailLines : defaultTailLines)
             .filter(filter)
             .keywords(keywords)

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/StrimziOperatorTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/StrimziOperatorTools.java
@@ -10,7 +10,7 @@ import io.quarkiverse.mcp.server.Progress;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.WrapBusinessError;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodSummaryResponse;
 import io.streamshub.mcp.common.guardrail.Guarded;
 import io.streamshub.mcp.common.service.PodsService;
@@ -138,7 +138,7 @@ public class StrimziOperatorTools {
         final Progress progress,
         final Cancellation cancellation
     ) {
-        LogCollectionOptions options = LogCollectionOptions.builder(
+        LogCollectionParams options = LogCollectionParams.builder(
                 tailLines != null ? tailLines : defaultTailLines)
             .filter(filter)
             .keywords(keywords)

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaLogCollectionTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaLogCollectionTest.java
@@ -7,7 +7,7 @@ package io.streamshub.mcp.strimzi.service;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.service.log.LogCollectionService;
@@ -68,7 +68,7 @@ class KafkaLogCollectionTest {
 
     @Test
     void testMissingClusterNameThrows() {
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 200, null);
 
         assertThrows(ToolCallException.class,
             () -> kafkaService.getClusterLogs("kafka", null, options));
@@ -82,7 +82,7 @@ class KafkaLogCollectionTest {
             eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
             .thenReturn(List.of());
 
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 200, null);
 
         KafkaClusterLogsResponse response = kafkaService.getClusterLogs("kafka", "my-cluster", options);
 
@@ -108,7 +108,7 @@ class KafkaLogCollectionTest {
         when(logCollectionService.collectLogs(eq("kafka"), any(), any()))
             .thenReturn(logsResult);
 
-        LogCollectionOptions options = LogCollectionOptions.of("errors", null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of("errors", null, 200, null);
 
         KafkaClusterLogsResponse response = kafkaService.getClusterLogs("kafka", "my-cluster", options);
 
@@ -140,7 +140,7 @@ class KafkaLogCollectionTest {
         when(logCollectionService.collectLogs(eq("kafka"), any(), any()))
             .thenReturn(logsResult);
 
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 200, null);
 
         KafkaClusterLogsResponse response = kafkaService.getClusterLogs("kafka", "my-cluster", options);
 
@@ -165,7 +165,7 @@ class KafkaLogCollectionTest {
         when(logCollectionService.collectLogs(eq("kafka"), any(), any()))
             .thenReturn(logsResult);
 
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 200, null);
 
         KafkaClusterLogsResponse response = kafkaService.getClusterLogs("kafka", "my-cluster", options);
 
@@ -183,7 +183,7 @@ class KafkaLogCollectionTest {
         when(logCollectionService.collectLogs(any(), any(), any()))
             .thenReturn(new PodLogsResult(List.of(), "", 0, 0, 0, false));
 
-        LogCollectionOptions options = LogCollectionOptions.builder(100)
+        LogCollectionParams options = LogCollectionParams.builder(100)
             .filter("errors")
             .sinceSeconds(300)
             .previous(true)

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/OperatorLogCollectionTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/OperatorLogCollectionTest.java
@@ -6,7 +6,7 @@ package io.streamshub.mcp.strimzi.service;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import io.streamshub.mcp.common.service.DeploymentService;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
@@ -73,7 +73,7 @@ class OperatorLogCollectionTest {
             eq(ResourceLabels.STRIMZI_KIND_LABEL), eq(StrimziConstants.KindValues.CLUSTER_OPERATOR)))
             .thenReturn(List.of());
 
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 200, null);
 
         StrimziOperatorLogsResponse response = operatorService.getOperatorLogs("strimzi", null, options);
 
@@ -98,7 +98,7 @@ class OperatorLogCollectionTest {
         when(logCollectionService.collectLogs(eq("strimzi"), any(), any()))
             .thenReturn(logsResult);
 
-        LogCollectionOptions options = LogCollectionOptions.of(null, null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of(null, null, 200, null);
 
         StrimziOperatorLogsResponse response = operatorService.getOperatorLogs("strimzi", null, options);
 
@@ -127,7 +127,7 @@ class OperatorLogCollectionTest {
         when(logCollectionService.collectLogs(eq("strimzi"), any(), any()))
             .thenReturn(logsResult);
 
-        LogCollectionOptions options = LogCollectionOptions.of("errors", null, 200, null);
+        LogCollectionParams options = LogCollectionParams.of("errors", null, 200, null);
 
         StrimziOperatorLogsResponse response = operatorService.getOperatorLogs("strimzi", null, options);
 
@@ -146,7 +146,7 @@ class OperatorLogCollectionTest {
         when(logCollectionService.collectLogs(any(), any(), any()))
             .thenReturn(new PodLogsResult(List.of(), "", 0, 0, 0, false));
 
-        LogCollectionOptions options = LogCollectionOptions.builder(50)
+        LogCollectionParams options = LogCollectionParams.builder(50)
             .filter("warnings")
             .sinceSeconds(600)
             .previous(true)

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/StrimziOperatorServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/StrimziOperatorServiceTest.java
@@ -17,7 +17,7 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.streamshub.mcp.common.dto.LogCollectionOptions;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
 import jakarta.inject.Inject;
@@ -66,7 +66,7 @@ class StrimziOperatorServiceTest {
         setupEmptyPodResponses("kafka-system");
 
         StrimziOperatorLogsResponse result = operatorService.getOperatorLogs(
-            "kafka-system", null, LogCollectionOptions.of(null, null, 200, null));
+            "kafka-system", null, LogCollectionParams.of(null, null, 200, null));
 
         assertNotNull(result);
         assertEquals("kafka-system", result.namespace());
@@ -79,9 +79,9 @@ class StrimziOperatorServiceTest {
         setupEmptyPodResponses("kafka");
 
         StrimziOperatorLogsResponse result1 = operatorService.getOperatorLogs(
-            "  KAFKA  ", null, LogCollectionOptions.of(null, null, 200, null));
+            "  KAFKA  ", null, LogCollectionParams.of(null, null, 200, null));
         StrimziOperatorLogsResponse result2 = operatorService.getOperatorLogs(
-            "kafka", null, LogCollectionOptions.of(null, null, 200, null));
+            "kafka", null, LogCollectionParams.of(null, null, 200, null));
 
         assertEquals("kafka", result1.namespace());
         assertEquals("kafka", result2.namespace());


### PR DESCRIPTION
This PR unifies auth config and class names for Loki and Prometheus plugins we have.

It also fixes the script for loki config to be re-executable when it fails.