### PR TITLE
Diagnostic tools with sampling end elicitation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,10 @@ io.streamshub.mcp.common.
 ├── config/         → KubernetesConstants (labels, conditions, phases, health status)
 ├── dto/            → PodSummaryResponse, PodLogsResult, LogCollectionParams (generic pod DTOs)
 │   └── metrics/    → MetricSample, PodTarget, MetricsQueryParams
-├── readiness/   → KubernetesConnectionReadinessCheck (health check for kube API)
-├──service/        → KubernetesResourceService, PodsService, DeploymentService, CompletionHelper
+├── readiness/      → KubernetesConnectionReadinessCheck (health check for kube API)
+├── service/        → KubernetesResourceService, PodsService, DeploymentService, CompletionHelper,
+│   │                 DiagnosticHelper (shared MCP framework utilities for diagnostic tools)
+│   ├── log/        → LogCollectionService, LogCollectorProvider, KubernetesLogProvider
 │   └── metrics/    → MetricsProvider (interface), PodScrapingMetricsProvider, MetricsQueryService
 └── util/           → InputUtils
     └── metrics/    → PrometheusTextParser
@@ -49,13 +51,24 @@ io.streamshub.mcp.metrics.prometheus.
 ```
 io.streamshub.mcp.strimzi.
 ├── tool/              → MCP tool definitions (thin wrappers, no logic)
+│                        KafkaTools, KafkaTopicTools, KafkaNodePoolTools,
+│                        StrimziOperatorTools, StrimziEventsTools, MetricsTools,
+│                        DiagnosticTools (composite diagnostic tools)
 ├── service/           → Business logic (KafkaService, KafkaTopicService, KafkaNodePoolService,
-│                        StrimziOperatorService, CompletionService)
-├── dto/               → Strimzi response records (10 DTOs)
-├── prompt/            → MCP prompt templates (DiagnoseClusterIssuePrompt, TroubleshootConnectivityPrompt)
+│                        StrimziOperatorService, StrimziEventsService, CompletionService)
+│                        Diagnostic orchestrators: KafkaClusterDiagnosticService,
+│                        KafkaConnectivityDiagnosticService, KafkaMetricsDiagnosticService,
+│                        OperatorMetricsDiagnosticService
+├── dto/               → Strimzi response records and diagnostic reports
+├── prompt/            → MCP prompt templates (DiagnoseClusterIssuePrompt, TroubleshootConnectivityPrompt,
+│                        AnalyzeKafkaMetricsPrompt, AnalyzeStrimziOperatorMetricsPrompt)
 ├── resource/          → ResourceSubscriptionManager (Kubernetes watches → MCP notifications)
 ├── resource/template/ → MCP resource templates and completions (5 templates)
-└── config/            → StrimziConstants (labels, resource URIs), StrimziToolsPrompts
+├── config/            → StrimziConstants (labels, resource URIs), StrimziToolsPrompts
+│   └── metrics/       → KafkaMetricCategories, KafkaExporterMetricCategories,
+│                        StrimziOperatorMetricCategories (category constants + metric name mappings)
+└── util/              → NamespaceElicitationHelper (Strimzi-specific namespace disambiguation),
+                         MetricNameResolver, TimeRangeValidator
 ```
 
 ### Layer rules
@@ -70,6 +83,12 @@ io.streamshub.mcp.strimzi.
 - **Metrics providers** implement `MetricsProvider` interface. Selected via `@LookupIfProperty` on `mcp.metrics.provider`.
   Domain services use `MetricsQueryService` (in common/) to query metrics — it handles provider lookup,
   query param construction, and delegation. Do not inject `Instance<MetricsProvider>` directly in domain services.
+- **Diagnostic services** orchestrate multi-step workflows by calling existing domain services.
+  They use `DiagnosticHelper` (common/) for MCP framework interactions and `NamespaceElicitationHelper`
+  (strimzi-mcp) for Strimzi-specific namespace disambiguation. Individual step failures don't abort the workflow.
+- **Metric category constants** are defined as public `static final String` fields in each `*MetricCategories` class
+  (e.g., `KafkaMetricCategories.REPLICATION`). Use these constants instead of string literals when referencing
+  metric categories in services, diagnostic tools, or prompts.
 
 ## MCP Tool Pattern
 
@@ -140,6 +159,98 @@ public KafkaClusterLogsResponse getKafkaClusterLogs(
     return kafkaService.getClusterLogs(namespace, clusterName, options);
 }
 ```
+
+## Composite Diagnostic Tool Pattern
+
+Composite diagnostic tools orchestrate multi-step workflows in a single tool call.
+They complement prompt templates: prompts are client-driven (LLM calls tools one by one),
+composite tools are server-driven (server gathers all data internally).
+
+```java
+@Singleton
+@Guarded
+@WrapBusinessError(Exception.class)
+public class DiagnosticTools {
+
+    @Inject
+    KafkaClusterDiagnosticService clusterDiagnosticService;
+
+    @Tool(name = "diagnose_kafka_cluster", description = "...")
+    public KafkaClusterDiagnosticReport diagnoseKafkaCluster(
+        @ToolArg(description = StrimziToolsPrompts.CLUSTER_DESC) final String clusterName,
+        @ToolArg(description = StrimziToolsPrompts.NS_DESC, required = false) final String namespace,
+        final Sampling sampling,       // LLM-guided selective investigation
+        final Elicitation elicitation,  // namespace disambiguation
+        final McpLog mcpLog,
+        final Progress progress,
+        final Cancellation cancellation
+    ) {
+        return clusterDiagnosticService.diagnose(...);
+    }
+}
+```
+
+### Diagnostic service structure (3-phase workflow)
+
+1. **Phase 1 — Initial data gathering**: Always runs. Gathers cluster status, node pools, pods.
+   If namespace is ambiguous and Elicitation is supported, asks the user to choose.
+2. **Phase 2 — Deep investigation**: If Sampling is supported, sends Phase 1 results to LLM
+   and asks which areas need deeper investigation. If not supported, investigates all areas.
+3. **Phase 3 — Analysis**: If Sampling is supported, sends all gathered data to LLM for
+   root cause analysis. If not supported, returns raw data without analysis.
+
+### Key behaviors
+
+- **Graceful degradation**: Works without Sampling/Elicitation support (gathers everything, returns raw data)
+- **Step failure resilience**: Individual step failures are recorded in `stepsFailed`, workflow continues
+- **Progress tracking**: Reports progress via `DiagnosticHelper.sendProgress()`
+- **Cancellation**: Checks `DiagnosticHelper.checkCancellation()` between steps
+- **No duplication**: Calls existing domain services (KafkaService, StrimziOperatorService, etc.)
+- **Configurable token limits**: `mcp.sampling.triage-max-tokens` and `mcp.sampling.analysis-max-tokens`
+
+### DiagnosticHelper (common module)
+
+Shared MCP framework utilities in `common/src/.../service/DiagnosticHelper.java`:
+- `sendClientNotification(McpLog, String)` — log-level notification to MCP client
+- `sendProgress(Progress, step, totalSteps, label)` — progress update to MCP client
+- `checkCancellation(Cancellation)` — abort if client cancelled
+- `putIfNotNull(Map, String, Object)` — conditional map insertion
+- `elicitSelection(Elicitation, message, propertyName, description, options)` — generic single-select Elicitation
+- `extractSamplingText(SamplingResponse)` — safe text extraction from Sampling response
+- `MAP_TYPE_REF` — reusable `TypeReference<Map<String, Object>>` for JSON parsing
+
+### NamespaceElicitationHelper (strimzi module)
+
+Strimzi-specific namespace disambiguation in `strimzi-mcp/src/.../util/NamespaceElicitationHelper.java`:
+- `isMultipleNamespacesError(ToolCallException)` — checks for Strimzi multi-namespace error
+- `parseNamespacesFromError(String)` — extracts namespace list from Strimzi error message
+- `elicitNamespace(ToolCallException, Elicitation, context)` — combines parsing + `DiagnosticHelper.elicitSelection`
+
+### Diagnostic report DTOs
+
+Compose existing DTOs into a single report. Follow the naming pattern `Kafka*DiagnosticReport`:
+- `KafkaClusterDiagnosticReport` — cluster, node pools, pods, operator, logs, events, metrics
+- `KafkaConnectivityDiagnosticReport` — cluster, bootstrap servers, certificates, pods, logs
+- `KafkaMetricsDiagnosticReport` — cluster, pods, replication/performance/resource/throughput metrics
+- `OperatorMetricsDiagnosticReport` — operator, reconciliation/resource/JVM metrics, logs
+
+### Adding a new composite diagnostic tool
+
+1. Create the report DTO in `strimzi-mcp/src/.../strimzi/dto/`
+2. Create the diagnostic service in `strimzi-mcp/src/.../strimzi/service/` following the 3-phase pattern
+3. Add the `@Tool` method to `DiagnosticTools`
+4. Add the tool name to `McpDiscoveryTest.testToolDiscovery()` expected list
+5. Create a service test in `strimzi-mcp/src/test/.../strimzi/service/`
+6. Run `mvn compile && mvn test`
+
+### Logging in diagnostic services
+
+Use specific resource names in log messages and client notifications:
+- "Checked Kafka cluster status" (not "Checked cluster status")
+- "Found 3 KafkaNodePools" (not "Found 3 node pools")
+- "Checked Strimzi operator 'name' status: HEALTHY" (not "Checked operator status")
+- "Collected Kafka cluster logs" (not "Collected cluster logs")
+- "Failed to gather Kafka related events" (not "Failed to gather events")
 
 ## MCP Prompt Template Pattern
 
@@ -386,6 +497,13 @@ Service tests (one per domain service):
 - `strimzi-mcp/src/test/java/.../service/KafkaServiceTest.java`
 - `strimzi-mcp/src/test/java/.../service/KafkaTopicServiceTest.java`
 - `strimzi-mcp/src/test/java/.../service/StrimziOperatorServiceTest.java`
+- `strimzi-mcp/src/test/java/.../service/StrimziEventsServiceTest.java`
+
+Diagnostic service tests (one per diagnostic service):
+- `strimzi-mcp/src/test/java/.../service/KafkaClusterDiagnosticServiceTest.java`
+- `strimzi-mcp/src/test/java/.../service/KafkaConnectivityDiagnosticServiceTest.java`
+- `strimzi-mcp/src/test/java/.../service/KafkaMetricsDiagnosticServiceTest.java`
+- `strimzi-mcp/src/test/java/.../service/OperatorMetricsDiagnosticServiceTest.java`
 
 Tool tests (one per tools class):
 - `strimzi-mcp/src/test/java/.../tool/KafkaToolsTest.java`

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -15,6 +15,10 @@
             <artifactId>quarkus-kubernetes-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/common/src/main/java/io/streamshub/mcp/common/service/DiagnosticHelper.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/DiagnosticHelper.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ElicitationRequest;
+import io.quarkiverse.mcp.server.ElicitationResponse;
+import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.ToolCallException;
+import org.jboss.logging.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Shared utilities for diagnostic service implementations.
+ *
+ * <p>Provides common helpers for MCP framework interactions (notifications,
+ * progress, cancellation), namespace disambiguation via Elicitation,
+ * and Sampling response parsing.</p>
+ */
+public final class DiagnosticHelper {
+
+    private static final Logger LOG = Logger.getLogger(DiagnosticHelper.class);
+    private static final Pattern NAMESPACES_PATTERN = Pattern.compile("namespaces: (.+)\\. Please");
+
+    /**
+     * Reusable type reference for deserializing JSON maps from Sampling responses.
+     */
+    public static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() { };
+
+    private DiagnosticHelper() {
+    }
+
+    /**
+     * Send a log-level notification to the MCP client.
+     *
+     * @param mcpLog  the MCP log (may be null)
+     * @param message the notification message
+     */
+    public static void sendClientNotification(final McpLog mcpLog, final String message) {
+        if (mcpLog != null) {
+            mcpLog.info(message);
+        }
+    }
+
+    /**
+     * Send a progress update to the MCP client.
+     *
+     * @param progress   the MCP progress (may be null)
+     * @param step       the current step number
+     * @param totalSteps the total number of steps
+     * @param label      the diagnostic label (e.g., "Diagnostic", "Connectivity diagnostic")
+     */
+    public static void sendProgress(final Progress progress, final int step,
+                                     final int totalSteps, final String label) {
+        if (progress != null && progress.token().isPresent()) {
+            progress.notificationBuilder()
+                .setProgress(step)
+                .setTotal(totalSteps)
+                .setMessage(String.format("%s step %d/%d", label, step, totalSteps))
+                .build()
+                .sendAndForget();
+        }
+    }
+
+    /**
+     * Check if the MCP client has cancelled the operation.
+     *
+     * @param cancellation the MCP cancellation (may be null)
+     */
+    public static void checkCancellation(final Cancellation cancellation) {
+        if (cancellation != null) {
+            cancellation.skipProcessingIfCancelled();
+        }
+    }
+
+    /**
+     * Put a value into a map only if it is not null.
+     *
+     * @param map   the target map
+     * @param key   the key
+     * @param value the value (skipped if null)
+     */
+    public static void putIfNotNull(final Map<String, Object> map, final String key,
+                                     final Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
+    /**
+     * Check if a {@link ToolCallException} indicates multiple resources
+     * found in different namespaces.
+     *
+     * @param e the exception
+     * @return true if the error is a multi-namespace ambiguity
+     */
+    public static boolean isMultipleNamespacesError(final ToolCallException e) {
+        return e.getMessage() != null && e.getMessage().contains("Multiple clusters named");
+    }
+
+    /**
+     * Ask the user to select a namespace via MCP Elicitation when a resource
+     * exists in multiple namespaces.
+     *
+     * @param error       the original ambiguity error
+     * @param elicitation the MCP Elicitation interface
+     * @param context     descriptive context for the prompt (e.g., "diagnosed", "checked for connectivity")
+     * @return the selected namespace, or throws the original error
+     */
+    public static String elicitNamespace(final ToolCallException error,
+                                          final Elicitation elicitation,
+                                          final String context) {
+        List<String> namespaces = parseNamespacesFromError(error.getMessage());
+        if (namespaces.isEmpty()) {
+            throw error;
+        }
+
+        try {
+            ElicitationResponse response = elicitation.requestBuilder()
+                .setMessage("The cluster exists in multiple namespaces. Which namespace should be "
+                    + context + "?")
+                .addSchemaProperty("namespace",
+                    ElicitationRequest.SingleSelectEnumSchema.builder(namespaces)
+                        .setDescription("Select the namespace")
+                        .setRequired(true)
+                        .build())
+                .build()
+                .sendAndAwait();
+
+            if (response.actionAccepted()) {
+                return response.content().getString("namespace");
+            }
+        } catch (Exception e) {
+            LOG.warnf("Elicitation failed: %s", e.getMessage());
+        }
+
+        throw error;
+    }
+
+    /**
+     * Parse namespace names from a "Multiple clusters named 'x' found in namespaces: a, b" error.
+     *
+     * @param message the error message
+     * @return list of namespace names
+     */
+    public static List<String> parseNamespacesFromError(final String message) {
+        if (message == null) {
+            return List.of();
+        }
+        Matcher matcher = NAMESPACES_PATTERN.matcher(message);
+        if (matcher.find()) {
+            return Arrays.stream(matcher.group(1).split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        }
+        return List.of();
+    }
+
+    /**
+     * Safely extract text content from a Sampling response.
+     *
+     * @param response the Sampling response
+     * @return the text content, or null if the response structure is invalid
+     */
+    public static String extractSamplingText(final SamplingResponse response) {
+        if (response == null || response.content() == null) {
+            return null;
+        }
+        return response.content().asText().text();
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/service/DiagnosticHelper.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/DiagnosticHelper.java
@@ -12,26 +12,21 @@ import io.quarkiverse.mcp.server.ElicitationResponse;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.Progress;
 import io.quarkiverse.mcp.server.SamplingResponse;
-import io.quarkiverse.mcp.server.ToolCallException;
 import org.jboss.logging.Logger;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Shared utilities for diagnostic service implementations.
  *
  * <p>Provides common helpers for MCP framework interactions (notifications,
- * progress, cancellation), namespace disambiguation via Elicitation,
- * and Sampling response parsing.</p>
+ * progress, cancellation, elicitation) and Sampling response parsing.
+ * All methods are generic and reusable across MCP server modules.</p>
  */
 public final class DiagnosticHelper {
 
     private static final Logger LOG = Logger.getLogger(DiagnosticHelper.class);
-    private static final Pattern NAMESPACES_PATTERN = Pattern.compile("namespaces: (.+)\\. Please");
 
     /**
      * Reusable type reference for deserializing JSON maps from Sampling responses.
@@ -99,73 +94,41 @@ public final class DiagnosticHelper {
     }
 
     /**
-     * Check if a {@link ToolCallException} indicates multiple resources
-     * found in different namespaces.
+     * Ask the user to select a single value from a list via MCP Elicitation.
      *
-     * @param e the exception
-     * @return true if the error is a multi-namespace ambiguity
-     */
-    public static boolean isMultipleNamespacesError(final ToolCallException e) {
-        return e.getMessage() != null && e.getMessage().contains("Multiple clusters named");
-    }
-
-    /**
-     * Ask the user to select a namespace via MCP Elicitation when a resource
-     * exists in multiple namespaces.
+     * <p>This is a generic Elicitation wrapper usable for any disambiguation
+     * (namespace selection, cluster selection, etc.).</p>
      *
-     * @param error       the original ambiguity error
-     * @param elicitation the MCP Elicitation interface
-     * @param context     descriptive context for the prompt (e.g., "diagnosed", "checked for connectivity")
-     * @return the selected namespace, or throws the original error
+     * @param elicitation  the MCP Elicitation interface
+     * @param message      the prompt message shown to the user
+     * @param propertyName the schema property name (e.g., "namespace")
+     * @param description  the property description
+     * @param options      the list of options to choose from
+     * @return the selected value, or null if the user declined or elicitation failed
      */
-    public static String elicitNamespace(final ToolCallException error,
-                                          final Elicitation elicitation,
-                                          final String context) {
-        List<String> namespaces = parseNamespacesFromError(error.getMessage());
-        if (namespaces.isEmpty()) {
-            throw error;
-        }
-
+    public static String elicitSelection(final Elicitation elicitation,
+                                          final String message,
+                                          final String propertyName,
+                                          final String description,
+                                          final List<String> options) {
         try {
             ElicitationResponse response = elicitation.requestBuilder()
-                .setMessage("The cluster exists in multiple namespaces. Which namespace should be "
-                    + context + "?")
-                .addSchemaProperty("namespace",
-                    ElicitationRequest.SingleSelectEnumSchema.builder(namespaces)
-                        .setDescription("Select the namespace")
+                .setMessage(message)
+                .addSchemaProperty(propertyName,
+                    ElicitationRequest.SingleSelectEnumSchema.builder(options)
+                        .setDescription(description)
                         .setRequired(true)
                         .build())
                 .build()
                 .sendAndAwait();
 
             if (response.actionAccepted()) {
-                return response.content().getString("namespace");
+                return response.content().getString(propertyName);
             }
         } catch (Exception e) {
             LOG.warnf("Elicitation failed: %s", e.getMessage());
         }
-
-        throw error;
-    }
-
-    /**
-     * Parse namespace names from a "Multiple clusters named 'x' found in namespaces: a, b" error.
-     *
-     * @param message the error message
-     * @return list of namespace names
-     */
-    public static List<String> parseNamespacesFromError(final String message) {
-        if (message == null) {
-            return List.of();
-        }
-        Matcher matcher = NAMESPACES_PATTERN.matcher(message);
-        if (matcher.find()) {
-            return Arrays.stream(matcher.group(1).split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
-        }
-        return List.of();
+        return null;
     }
 
     /**

--- a/common/src/main/java/io/streamshub/mcp/common/service/log/KubernetesLogProvider.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/log/KubernetesLogProvider.java
@@ -4,10 +4,14 @@
  */
 package io.streamshub.mcp.common.service.log;
 
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 import java.util.List;
 
@@ -24,6 +28,8 @@ import java.util.List;
 @LookupIfProperty(name = "mcp.log.provider", stringValue = "streamshub-kubernetes", lookupIfMissing = true)
 public class KubernetesLogProvider implements LogCollectorProvider {
 
+    private static final Logger LOG = Logger.getLogger(KubernetesLogProvider.class);
+
     @Inject
     KubernetesClient kubernetesClient;
 
@@ -36,27 +42,75 @@ public class KubernetesLogProvider implements LogCollectorProvider {
                             final Boolean previous, final String filter,
                             final List<String> keywords,
                             final String startTime, final String endTime) {
-        var podResource = kubernetesClient.pods()
+        PodResource podResource = kubernetesClient.pods()
             .inNamespace(namespace)
             .withName(podName);
 
-        String rawLogs;
+        List<String> containerNames = getContainerNames(podResource);
+
+        if (containerNames.size() <= 1) {
+            String rawLogs = fetchContainerLogs(podResource, null,
+                tailLines, sinceSeconds, previous, startTime);
+            return LogFilterUtils.applyFilters(rawLogs, filter, keywords);
+        }
+
+        // Multi-container pod: fetch logs from each container
+        int perContainerLines = Math.max(1, tailLines / containerNames.size());
+        StringBuilder combined = new StringBuilder();
+        for (String container : containerNames) {
+            String containerLogs = fetchContainerLogs(podResource, container,
+                perContainerLines, sinceSeconds, previous, startTime);
+            String filtered = LogFilterUtils.applyFilters(containerLogs, filter, keywords);
+            if (filtered != null && !filtered.isEmpty()) {
+                combined.append("--- container: ").append(container).append(" ---\n");
+                combined.append(filtered).append("\n");
+            }
+        }
+        return combined.isEmpty() ? null : combined.toString();
+    }
+
+    private List<String> getContainerNames(final PodResource podResource) {
+        try {
+            Pod pod = podResource.get();
+            if (pod != null && pod.getSpec() != null && pod.getSpec().getContainers() != null) {
+                List<String> names = pod.getSpec().getContainers().stream()
+                    .map(Container::getName)
+                    .toList();
+                if (!names.isEmpty()) {
+                    return names;
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugf("Could not list containers for pod: %s", e.getMessage());
+        }
+        return List.of();
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private String fetchContainerLogs(final PodResource podResource,
+                                       final String containerName,
+                                       final int tailLines,
+                                       final Integer sinceSeconds,
+                                       final Boolean previous,
+                                       final String startTime) {
+        var resource = containerName != null
+            ? podResource.inContainer(containerName)
+            : podResource;
+
         if (Boolean.TRUE.equals(previous)) {
-            rawLogs = podResource.terminated()
+            return resource.terminated()
                 .tailingLines(tailLines + 1)
                 .getLog();
         } else if (startTime != null) {
-            rawLogs = podResource.sinceTime(startTime)
+            return resource.sinceTime(startTime)
                 .tailingLines(tailLines + 1)
                 .getLog();
         } else if (sinceSeconds != null) {
-            rawLogs = podResource.sinceSeconds(sinceSeconds)
+            return resource.sinceSeconds(sinceSeconds)
                 .tailingLines(tailLines + 1)
                 .getLog();
         } else {
-            rawLogs = podResource.tailingLines(tailLines + 1).getLog();
+            return resource.tailingLines(tailLines + 1).getLog();
         }
-
-        return LogFilterUtils.applyFilters(rawLogs, filter, keywords);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkiverse.mcp</groupId>
+                <artifactId>quarkus-mcp-server-core</artifactId>
+                <version>${quarkus.mcp.server.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.mcp</groupId>
                 <artifactId>quarkus-mcp-server-http</artifactId>
                 <version>${quarkus.mcp.server.version}</version>
             </dependency>

--- a/strimzi-mcp/README.md
+++ b/strimzi-mcp/README.md
@@ -75,8 +75,21 @@ MCP prompt templates encode Strimzi domain knowledge and guide LLMs through stru
 |--------|-----------|-------------|
 | `diagnose-cluster-issue` | `cluster_name` (required), `namespace`, `symptom` | Step-by-step cluster diagnosis: checks status, node pools, operator logs, pod health, and correlates findings to identify root causes. |
 | `troubleshoot-connectivity` | `cluster_name` (required), `namespace`, `listener_name` | Connectivity troubleshooting: checks listeners, bootstrap addresses, listener accessibility by type, and pod health. |
+| `analyze-kafka-metrics` | `cluster_name` (required), `namespace`, `concern` | Metrics analysis: guides through replication, throughput, performance, and resource metrics with cascading failure pattern recognition. |
+| `analyze-strimzi-operator-metrics` | `namespace`, `concern` | Operator metrics analysis: guides through reconciliation, resource, and JVM metrics with operator log correlation. |
 
 **How they work**: The MCP client discovers available prompts, the user selects one and fills in the parameters, and the client injects the structured instructions into the LLM conversation. The LLM then follows the steps, calling the MCP tools automatically.
+
+### Diagnostic Tools
+
+Diagnostic tools are composite tools that run multi-step workflows in a single call, using **Sampling** for LLM-guided triage and analysis, and **Elicitation** for user disambiguation. They fall back to gathering all data when the client does not support Sampling.
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `diagnose_kafka_cluster` | `clusterName` (required), `namespace`, `symptom`, `sinceMinutes` | Gathers cluster status, node pools, pods, operator logs, cluster logs, events, and metrics. Uses Sampling to triage which areas need deep investigation. |
+| `diagnose_kafka_connectivity` | `clusterName` (required), `namespace`, `listenerName` | Checks listeners, bootstrap addresses, TLS certificates, authentication, pod health, and connection-related logs. |
+| `diagnose_kafka_metrics` | `clusterName` (required), `namespace`, `concern` | Gathers cluster status and pod health, then selectively queries replication, performance, resource, and throughput metrics. |
+| `diagnose_operator_metrics` | `namespace`, `operatorName`, `clusterName`, `concern` | Gathers operator status, then selectively queries reconciliation, resource, and JVM metrics along with operator logs. |
 
 ## Resource Templates
 
@@ -270,4 +283,4 @@ kubectl get crd | grep strimzi
 
 ## License
 
-Apache 2.0
+[Apache License 2.0](../LICENSE)

--- a/strimzi-mcp/install/003-ClusterRole.yaml
+++ b/strimzi-mcp/install/003-ClusterRole.yaml
@@ -20,10 +20,18 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]
-  # Pods, logs, and services
+  # Pods and services
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "services"]
+    resources: ["pods", "services"]
     verbs: ["get", "list"]
+  # Pod logs (get only, no list)
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Events (list only, used with field selectors)
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list"]
   # ConfigMaps (logging overrides, external configuration references)
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -164,6 +164,20 @@ public final class StrimziToolsPrompts {
             + " Omit for all available events.";
 
     /**
+     * Concern parameter description for metrics diagnostic tools.
+     */
+    public static final String CONCERN_DESC =
+        "Specific concern to investigate, e.g. 'high latency',"
+            + " 'replication lag', 'slow reconciliation'. Omit if unknown.";
+
+    /**
+     * Symptom parameter description for diagnostic tools.
+     */
+    public static final String SYMPTOM_DESC =
+        "Observed symptom, e.g. 'NotReady for 15 minutes'"
+            + " or 'pods restarting'. Omit if unknown.";
+
+    /**
      * Common instruction for prompt templates to handle tool call failures gracefully.
      */
     public static final String ERROR_HANDLING_INSTRUCTION =

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaExporterMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaExporterMetricCategories.java
@@ -16,13 +16,28 @@ import java.util.stream.Collectors;
  */
 public final class KafkaExporterMetricCategories {
 
+    /**
+     * Consumer group lag category (offset, lag, lag seconds).
+     */
+    public static final String CONSUMER_LAG = "consumer_lag";
+
+    /**
+     * Topic partition category (offsets, ISR, under-replicated, replicas).
+     */
+    public static final String PARTITIONS = "partitions";
+
+    /**
+     * JVM and system resource category (heap, GC, CPU, threads).
+     */
+    public static final String RESOURCES = "resources";
+
     private static final Map<String, List<String>> CATEGORIES = Map.of(
-        "consumer_lag", List.of(
+        CONSUMER_LAG, List.of(
             "kafka_consumergroup_current_offset",
             "kafka_consumergroup_lag",
             "kafka_consumergroup_lag_seconds"
         ),
-        "partitions", List.of(
+        PARTITIONS, List.of(
             "kafka_topic_partitions",
             "kafka_topic_partition_current_offset",
             "kafka_topic_partition_oldest_offset",
@@ -30,7 +45,7 @@ public final class KafkaExporterMetricCategories {
             "kafka_topic_partition_under_replicated_partition",
             "kafka_topic_partition_replicas"
         ),
-        "resources", List.of(
+        RESOURCES, List.of(
             "jvm_memory_used_bytes",
             "jvm_memory_max_bytes",
             "jvm_gc_collection_seconds_count",
@@ -41,7 +56,7 @@ public final class KafkaExporterMetricCategories {
     );
 
     private static final Map<String, String> DESCRIPTIONS = Map.of(
-        "consumer_lag",
+        CONSUMER_LAG,
             "**[HIGH - CONSUMER GROUP LAG]**\n\n"
                 + "kafka_consumergroup_lag: Number of messages a consumer group is behind the latest offset. "
                 + "**THRESHOLDS**: 0 = fully caught up, <1000 = healthy, 1000-10000 = monitor, "
@@ -51,7 +66,7 @@ public final class KafkaExporterMetricCategories {
                 + "to catch up. >60s = significant delay, >300s = investigate consumer health.\n\n"
                 + "kafka_consumergroup_current_offset: Current committed offset per consumer group/partition. "
                 + "Stalled offset = consumer is stuck or dead. Compare with partition end offset to calculate lag.",
-        "partitions",
+        PARTITIONS,
             "**[HIGH - PARTITION HEALTH]**\n\n"
                 + "kafka_topic_partition_under_replicated_partition: Partitions where ISR count < replica count. "
                 + "Should be 0. >0 means replicas are lagging — check broker health and disk I/O. "
@@ -67,7 +82,7 @@ public final class KafkaExporterMetricCategories {
                 + "Gap between oldest and current = retained data volume. "
                 + "Oldest offset advancing = log segments being cleaned/compacted.\n\n"
                 + "kafka_topic_partitions: Number of partitions per topic.",
-        "resources",
+        RESOURCES,
             MetricsDescriptions.jvmDescription("get_kafka_cluster_pods",
                 "exporter scraping failures or missing metrics")
     );

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
@@ -16,8 +16,28 @@ import java.util.stream.Collectors;
  */
 public final class KafkaMetricCategories {
 
+    /**
+     * Replication health category (under-replicated partitions, offline partitions, ISR lag).
+     */
+    public static final String REPLICATION = "replication";
+
+    /**
+     * Throughput category (bytes in/out, messages in, produce/fetch requests).
+     */
+    public static final String THROUGHPUT = "throughput";
+
+    /**
+     * JVM and system resource category (heap, GC, CPU, threads).
+     */
+    public static final String RESOURCES = "resources";
+
+    /**
+     * Request performance category (handler idle, queue times, network processor idle).
+     */
+    public static final String PERFORMANCE = "performance";
+
     private static final Map<String, List<String>> CATEGORIES = Map.of(
-        "replication", List.of(
+        REPLICATION, List.of(
             "kafka_server_replicamanager_underreplicatedpartitions",
             "kafka_server_replicamanager_leadercount",
             "kafka_server_replicamanager_partitioncount",
@@ -25,14 +45,14 @@ public final class KafkaMetricCategories {
             "kafka_controller_kafkacontroller_offlinepartitionscount",
             "kafka_server_replicafetchermanager_maxlag"
         ),
-        "throughput", List.of(
+        THROUGHPUT, List.of(
             "kafka_server_brokertopicmetrics_messagesin_total",
             "kafka_server_brokertopicmetrics_bytesin_total",
             "kafka_server_brokertopicmetrics_bytesout_total",
             "kafka_server_brokertopicmetrics_totalproducerequests_total",
             "kafka_server_brokertopicmetrics_totalfetchrequests_total"
         ),
-        "resources", List.of(
+        RESOURCES, List.of(
             "jvm_memory_used_bytes",
             "jvm_memory_max_bytes",
             "jvm_gc_collection_seconds_count",
@@ -40,7 +60,7 @@ public final class KafkaMetricCategories {
             "process_cpu_seconds_total",
             "jvm_threads_current"
         ),
-        "performance", List.of(
+        PERFORMANCE, List.of(
             "kafka_network_requestmetrics_totaltimems",
             "kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent",
             "kafka_network_requestmetrics_requestqueuetimems",
@@ -50,7 +70,7 @@ public final class KafkaMetricCategories {
     );
 
     private static final Map<String, String> DESCRIPTIONS = Map.of(
-        "replication",
+        REPLICATION,
             "**[CRITICAL - CLUSTER AVAILABILITY]**\n\n"
                 + "kafka_server_replicamanager_underreplicatedpartitions: Partitions with fewer in-sync "
                 + "replicas than configured. Should be 0. >0 means data loss risk. "
@@ -72,7 +92,7 @@ public final class KafkaMetricCategories {
                 + "Should be balanced across brokers.\n\n"
                 + "kafka_server_replicamanager_offlinereplicacount: Replicas that are offline. "
                 + "Should be 0. >0 = broker or disk issues. Check pod status and logs.",
-        "throughput",
+        THROUGHPUT,
             "kafka_server_brokertopicmetrics_messagesin_total: Cumulative messages received. "
                 + "Rate of change = messages/sec. Sudden drops = producer issues.\n"
                 + "kafka_server_brokertopicmetrics_bytesin_total: Cumulative bytes received. "
@@ -83,10 +103,10 @@ public final class KafkaMetricCategories {
                 + "Rate = produce request throughput.\n"
                 + "kafka_server_brokertopicmetrics_totalfetchrequests_total: Total fetch requests. "
                 + "Includes consumer and follower fetches.",
-        "resources",
+        RESOURCES,
             MetricsDescriptions.jvmDescription("get_kafka_cluster_pods",
                 "performance degradation or pod restarts"),
-        "performance",
+        PERFORMANCE,
             "**[HIGH - BROKER CAPACITY]**\n\n"
                 + "kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent: "
                 + "Request handler thread idle ratio. **CRITICAL THRESHOLDS**: "

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
@@ -16,19 +16,34 @@ import java.util.stream.Collectors;
  */
 public final class StrimziOperatorMetricCategories {
 
+    /**
+     * Reconciliation category (successful, failed, total, duration).
+     */
+    public static final String RECONCILIATION = "reconciliation";
+
+    /**
+     * Strimzi resource state category.
+     */
+    public static final String RESOURCES = "resources";
+
+    /**
+     * JVM metrics category (heap, GC, CPU, threads).
+     */
+    public static final String JVM = "jvm";
+
     private static final Map<String, List<String>> CATEGORIES = Map.of(
-        "reconciliation", List.of(
+        RECONCILIATION, List.of(
             "strimzi_reconciliations_successful_total",
             "strimzi_reconciliations_failed_total",
             "strimzi_reconciliations_total",
             "strimzi_reconciliations_duration_seconds_sum",
             "strimzi_reconciliations_duration_seconds_count"
         ),
-        "resources", List.of(
+        RESOURCES, List.of(
             "strimzi_resources",
             "strimzi_resource_state"
         ),
-        "jvm", List.of(
+        JVM, List.of(
             "jvm_memory_used_bytes",
             "jvm_memory_max_bytes",
             "jvm_gc_collection_seconds_count",
@@ -39,7 +54,7 @@ public final class StrimziOperatorMetricCategories {
     );
 
     private static final Map<String, String> DESCRIPTIONS = Map.of(
-        "reconciliation",
+        RECONCILIATION,
             "**[HIGH - OPERATOR HEALTH]**\n\n"
                 + "strimzi_reconciliations_successful_total: Cumulative count of successful reconciliations. "
                 + "Should increase steadily. Flat line = no reconciliation activity (check if expected).\n\n"
@@ -54,7 +69,7 @@ public final class StrimziOperatorMetricCategories {
                 + "Divide sum by count for average. **THRESHOLDS**: <30s = good, 30-60s = acceptable, "
                 + ">60s = slow (may indicate resource contention, complex configurations, or K8s API slowness). "
                 + "Increasing trend = operator struggling to keep up.",
-        "resources",
+        RESOURCES,
             "**[HIGH - RESOURCE MANAGEMENT]**\n\n"
                 + "strimzi_resources: Count of Strimzi custom resources (Kafka, KafkaTopic, KafkaUser, etc.) "
                 + "managed by the operator. Sudden changes = resources added/removed. "
@@ -64,7 +79,7 @@ public final class StrimziOperatorMetricCategories {
                 + "1 = healthy/ready, 0 = unhealthy/not ready. "
                 + "**IMMEDIATE ACTION**: Any value != 1 indicates a resource that needs attention. "
                 + "Check resource status with get_kafka_cluster or get_kafka_topics.",
-        "jvm",
+        JVM,
             MetricsDescriptions.jvmDescription("get_strimzi_operator_pod",
                 "slow reconciliations or pod restarts")
     );

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/KafkaClusterDiagnosticReport.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/KafkaClusterDiagnosticReport.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Consolidated diagnostic report from a multi-step Kafka cluster investigation.
+ * Composes existing DTOs from individual tool responses into a single result.
+ *
+ * <p>Each field corresponds to one diagnostic step. Fields are null when the
+ * step was skipped (Sampling-guided selective investigation) or failed
+ * (recorded in {@code stepsFailed}).</p>
+ *
+ * @param cluster        Kafka cluster status and conditions
+ * @param nodePools      KafkaNodePool summaries for the cluster
+ * @param pods           pod health summaries (phase, restarts, termination reasons)
+ * @param operator       Strimzi operator deployment status
+ * @param operatorLogs   operator pod logs filtered for errors
+ * @param clusterLogs    Kafka broker pod logs filtered for errors
+ * @param events         Kubernetes events for the cluster and related resources
+ * @param metrics        replication metrics from Kafka broker pods
+ * @param analysis       LLM-generated root cause analysis via Sampling, or null
+ * @param stepsCompleted diagnostic steps that completed successfully
+ * @param stepsFailed    diagnostic steps that failed with error descriptions
+ * @param timestamp      when this report was generated
+ * @param message        human-readable summary of the diagnostic run
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KafkaClusterDiagnosticReport(
+    @JsonProperty("cluster") KafkaClusterResponse cluster,
+    @JsonProperty("node_pools") List<KafkaNodePoolResponse> nodePools,
+    @JsonProperty("pods") KafkaClusterPodsResponse pods,
+    @JsonProperty("operator") StrimziOperatorResponse operator,
+    @JsonProperty("operator_logs") StrimziOperatorLogsResponse operatorLogs,
+    @JsonProperty("cluster_logs") KafkaClusterLogsResponse clusterLogs,
+    @JsonProperty("events") StrimziEventsResponse events,
+    @JsonProperty("metrics") KafkaMetricsResponse metrics,
+    @JsonProperty("analysis") String analysis,
+    @JsonProperty("steps_completed") List<String> stepsCompleted,
+    @JsonProperty("steps_failed") List<String> stepsFailed,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("message") String message
+) {
+
+    /**
+     * Creates a diagnostic report with gathered data and step tracking.
+     *
+     * @param cluster        cluster status response
+     * @param nodePools      node pool responses
+     * @param pods           pod health response
+     * @param operator       operator status response
+     * @param operatorLogs   operator logs response
+     * @param clusterLogs    cluster logs response
+     * @param events         events response
+     * @param metrics        metrics response
+     * @param analysis       LLM analysis text or null
+     * @param stepsCompleted steps that succeeded
+     * @param stepsFailed    steps that failed with reasons
+     * @return a new diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public static KafkaClusterDiagnosticReport of(KafkaClusterResponse cluster,
+                                                  List<KafkaNodePoolResponse> nodePools,
+                                                  KafkaClusterPodsResponse pods,
+                                                  StrimziOperatorResponse operator,
+                                                  StrimziOperatorLogsResponse operatorLogs,
+                                                  KafkaClusterLogsResponse clusterLogs,
+                                                  StrimziEventsResponse events,
+                                                  KafkaMetricsResponse metrics,
+                                                  String analysis,
+                                                  List<String> stepsCompleted,
+                                                  List<String> stepsFailed) {
+        int completed = stepsCompleted != null ? stepsCompleted.size() : 0;
+        int failed = stepsFailed != null ? stepsFailed.size() : 0;
+        String clusterName = cluster != null ? cluster.name() : "unknown";
+
+        String msg;
+        if (failed == 0) {
+            msg = String.format("Diagnostic completed for cluster '%s': %d steps succeeded",
+                clusterName, completed);
+        } else {
+            msg = String.format("Diagnostic completed for cluster '%s': %d steps succeeded, %d steps failed",
+                clusterName, completed, failed);
+        }
+
+        return new KafkaClusterDiagnosticReport(cluster, nodePools, pods, operator, operatorLogs,
+            clusterLogs, events, metrics, analysis, stepsCompleted, stepsFailed,
+            Instant.now(), msg);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/KafkaConnectivityDiagnosticReport.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/KafkaConnectivityDiagnosticReport.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Consolidated connectivity diagnostic report from a multi-step investigation.
+ * Composes existing DTOs covering listeners, TLS certificates, authentication,
+ * pod health, and connection-related logs.
+ *
+ * <p>Each field corresponds to one diagnostic step. Fields are null when the
+ * step was skipped (Sampling-guided selective investigation) or failed
+ * (recorded in {@code stepsFailed}).</p>
+ *
+ * @param cluster          Kafka cluster status and conditions
+ * @param bootstrapServers listener addresses, types, and ports
+ * @param certificates     TLS certificate metadata and listener authentication
+ * @param pods             pod health summaries (phase, restarts, termination reasons)
+ * @param clusterLogs      Kafka pod logs filtered for connectivity errors
+ * @param analysis         LLM-generated connectivity analysis via Sampling, or null
+ * @param stepsCompleted   diagnostic steps that completed successfully
+ * @param stepsFailed      diagnostic steps that failed with error descriptions
+ * @param timestamp        when this report was generated
+ * @param message          human-readable summary of the diagnostic run
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KafkaConnectivityDiagnosticReport(
+    @JsonProperty("cluster") KafkaClusterResponse cluster,
+    @JsonProperty("bootstrap_servers") KafkaBootstrapResponse bootstrapServers,
+    @JsonProperty("certificates") KafkaCertificateResponse certificates,
+    @JsonProperty("pods") KafkaClusterPodsResponse pods,
+    @JsonProperty("cluster_logs") KafkaClusterLogsResponse clusterLogs,
+    @JsonProperty("analysis") String analysis,
+    @JsonProperty("steps_completed") List<String> stepsCompleted,
+    @JsonProperty("steps_failed") List<String> stepsFailed,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("message") String message
+) {
+
+    /**
+     * Creates a connectivity diagnostic report with gathered data and step tracking.
+     *
+     * @param cluster          cluster status response
+     * @param bootstrapServers bootstrap server addresses
+     * @param certificates     certificate and authentication response
+     * @param pods             pod health response
+     * @param clusterLogs      cluster logs response
+     * @param analysis         LLM analysis text or null
+     * @param stepsCompleted   steps that succeeded
+     * @param stepsFailed      steps that failed with reasons
+     * @return a new connectivity diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public static KafkaConnectivityDiagnosticReport of(KafkaClusterResponse cluster,
+                                                       KafkaBootstrapResponse bootstrapServers,
+                                                       KafkaCertificateResponse certificates,
+                                                       KafkaClusterPodsResponse pods,
+                                                       KafkaClusterLogsResponse clusterLogs,
+                                                       String analysis,
+                                                       List<String> stepsCompleted,
+                                                       List<String> stepsFailed) {
+        int completed = stepsCompleted != null ? stepsCompleted.size() : 0;
+        int failed = stepsFailed != null ? stepsFailed.size() : 0;
+        String clusterName = cluster != null ? cluster.name() : "unknown";
+
+        String msg;
+        if (failed == 0) {
+            msg = String.format("Connectivity diagnostic completed for cluster '%s': %d steps succeeded",
+                clusterName, completed);
+        } else {
+            msg = String.format(
+                "Connectivity diagnostic completed for cluster '%s': %d steps succeeded, %d steps failed",
+                clusterName, completed, failed);
+        }
+
+        return new KafkaConnectivityDiagnosticReport(cluster, bootstrapServers, certificates,
+            pods, clusterLogs, analysis, stepsCompleted, stepsFailed, Instant.now(), msg);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/KafkaMetricsDiagnosticReport.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/KafkaMetricsDiagnosticReport.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Consolidated diagnostic report from a multi-step Kafka metrics analysis.
+ * Composes cluster status, pod health, and metrics from each category
+ * into a single result for LLM-driven diagnosis.
+ *
+ * <p>Each field corresponds to one diagnostic step. Fields are null when the
+ * step was skipped (Sampling-guided selective investigation) or failed
+ * (recorded in {@code stepsFailed}).</p>
+ *
+ * @param cluster            Kafka cluster status and conditions
+ * @param pods               pod health summaries (phase, restarts, termination reasons)
+ * @param replicationMetrics replication metrics (under-replicated partitions, offline partitions, ISR)
+ * @param performanceMetrics performance metrics (request handler idle, network processor idle, queue times)
+ * @param resourceMetrics    resource metrics (JVM heap, GC, CPU, open file descriptors)
+ * @param throughputMetrics  throughput metrics (bytes in/out, messages in per broker)
+ * @param analysis           LLM-generated metrics analysis via Sampling, or null
+ * @param stepsCompleted     diagnostic steps that completed successfully
+ * @param stepsFailed        diagnostic steps that failed with error descriptions
+ * @param timestamp          when this report was generated
+ * @param message            human-readable summary of the diagnostic run
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KafkaMetricsDiagnosticReport(
+    @JsonProperty("cluster") KafkaClusterResponse cluster,
+    @JsonProperty("pods") KafkaClusterPodsResponse pods,
+    @JsonProperty("replication_metrics") KafkaMetricsResponse replicationMetrics,
+    @JsonProperty("performance_metrics") KafkaMetricsResponse performanceMetrics,
+    @JsonProperty("resource_metrics") KafkaMetricsResponse resourceMetrics,
+    @JsonProperty("throughput_metrics") KafkaMetricsResponse throughputMetrics,
+    @JsonProperty("analysis") String analysis,
+    @JsonProperty("steps_completed") List<String> stepsCompleted,
+    @JsonProperty("steps_failed") List<String> stepsFailed,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("message") String message
+) {
+
+    /**
+     * Creates a metrics diagnostic report with gathered data and step tracking.
+     *
+     * @param cluster            cluster status response
+     * @param pods               pod health response
+     * @param replicationMetrics replication metrics response
+     * @param performanceMetrics performance metrics response
+     * @param resourceMetrics    resource metrics response
+     * @param throughputMetrics  throughput metrics response
+     * @param analysis           LLM analysis text or null
+     * @param stepsCompleted     steps that succeeded
+     * @param stepsFailed        steps that failed with reasons
+     * @return a new metrics diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public static KafkaMetricsDiagnosticReport of(KafkaClusterResponse cluster,
+                                                  KafkaClusterPodsResponse pods,
+                                                  KafkaMetricsResponse replicationMetrics,
+                                                  KafkaMetricsResponse performanceMetrics,
+                                                  KafkaMetricsResponse resourceMetrics,
+                                                  KafkaMetricsResponse throughputMetrics,
+                                                  String analysis,
+                                                  List<String> stepsCompleted,
+                                                  List<String> stepsFailed) {
+        int completed = stepsCompleted != null ? stepsCompleted.size() : 0;
+        int failed = stepsFailed != null ? stepsFailed.size() : 0;
+        String clusterName = cluster != null ? cluster.name() : "unknown";
+
+        String msg;
+        if (failed == 0) {
+            msg = String.format("Metrics diagnostic completed for cluster '%s': %d steps succeeded",
+                clusterName, completed);
+        } else {
+            msg = String.format(
+                "Metrics diagnostic completed for cluster '%s': %d steps succeeded, %d steps failed",
+                clusterName, completed, failed);
+        }
+
+        return new KafkaMetricsDiagnosticReport(cluster, pods,
+            replicationMetrics, performanceMetrics, resourceMetrics, throughputMetrics,
+            analysis, stepsCompleted, stepsFailed, Instant.now(), msg);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/OperatorMetricsDiagnosticReport.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/OperatorMetricsDiagnosticReport.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Consolidated diagnostic report from a multi-step Strimzi operator metrics analysis.
+ * Composes operator status with metrics from each category and operator logs
+ * into a single result for LLM-driven diagnosis.
+ *
+ * <p>Each field corresponds to one diagnostic step. Fields are null when the
+ * step was skipped (Sampling-guided selective investigation) or failed
+ * (recorded in {@code stepsFailed}).</p>
+ *
+ * @param operator              Strimzi operator deployment status
+ * @param reconciliationMetrics reconciliation metrics (success/failure rates, durations)
+ * @param resourceMetrics       resource metrics (managed resource counts and states)
+ * @param jvmMetrics            JVM metrics (heap, GC, threads)
+ * @param operatorLogs          operator pod logs filtered for errors
+ * @param analysis              LLM-generated operator metrics analysis via Sampling, or null
+ * @param stepsCompleted        diagnostic steps that completed successfully
+ * @param stepsFailed           diagnostic steps that failed with error descriptions
+ * @param timestamp             when this report was generated
+ * @param message               human-readable summary of the diagnostic run
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record OperatorMetricsDiagnosticReport(
+    @JsonProperty("operator") StrimziOperatorResponse operator,
+    @JsonProperty("reconciliation_metrics") StrimziOperatorMetricsResponse reconciliationMetrics,
+    @JsonProperty("resource_metrics") StrimziOperatorMetricsResponse resourceMetrics,
+    @JsonProperty("jvm_metrics") StrimziOperatorMetricsResponse jvmMetrics,
+    @JsonProperty("operator_logs") StrimziOperatorLogsResponse operatorLogs,
+    @JsonProperty("analysis") String analysis,
+    @JsonProperty("steps_completed") List<String> stepsCompleted,
+    @JsonProperty("steps_failed") List<String> stepsFailed,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("message") String message
+) {
+
+    /**
+     * Creates an operator metrics diagnostic report with gathered data and step tracking.
+     *
+     * @param operator              operator status response
+     * @param reconciliationMetrics reconciliation metrics response
+     * @param resourceMetrics       resource metrics response
+     * @param jvmMetrics            JVM metrics response
+     * @param operatorLogs          operator logs response
+     * @param analysis              LLM analysis text or null
+     * @param stepsCompleted        steps that succeeded
+     * @param stepsFailed           steps that failed with reasons
+     * @return a new operator metrics diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public static OperatorMetricsDiagnosticReport of(StrimziOperatorResponse operator,
+                                                     StrimziOperatorMetricsResponse reconciliationMetrics,
+                                                     StrimziOperatorMetricsResponse resourceMetrics,
+                                                     StrimziOperatorMetricsResponse jvmMetrics,
+                                                     StrimziOperatorLogsResponse operatorLogs,
+                                                     String analysis,
+                                                     List<String> stepsCompleted,
+                                                     List<String> stepsFailed) {
+        String operatorName = operator != null ? operator.name() : "unknown";
+        int completed = stepsCompleted != null ? stepsCompleted.size() : 0;
+        int failed = stepsFailed != null ? stepsFailed.size() : 0;
+
+        String msg;
+        if (failed == 0) {
+            msg = String.format(
+                "Operator metrics diagnostic completed for '%s': %d steps succeeded",
+                operatorName, completed);
+        } else {
+            msg = String.format(
+                "Operator metrics diagnostic completed for '%s': %d steps succeeded, %d steps failed",
+                operatorName, completed, failed);
+        }
+
+        return new OperatorMetricsDiagnosticReport(operator,
+            reconciliationMetrics, resourceMetrics, jvmMetrics, operatorLogs,
+            analysis, stepsCompleted, stepsFailed, Instant.now(), msg);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
@@ -26,6 +26,7 @@ import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
 import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
 import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import io.streamshub.mcp.strimzi.util.NamespaceElicitationHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -216,9 +217,9 @@ public class KafkaClusterDiagnosticService {
             DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka cluster status: " + result.readiness());
             return result;
         } catch (ToolCallException e) {
-            if (DiagnosticHelper.isMultipleNamespacesError(e)
+            if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
                     && elicitation != null && elicitation.isSupported()) {
-                String resolved = DiagnosticHelper.elicitNamespace(e, elicitation, "diagnosed");
+                String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "diagnosed");
                 return gatherClusterStatus(resolved, clusterName, null,
                     completed, mcpLog);
             }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
@@ -51,9 +51,8 @@ public class KafkaClusterDiagnosticService {
 
     private static final Logger LOG = Logger.getLogger(KafkaClusterDiagnosticService.class);
     private static final int SECONDS_PER_MINUTE = 60;
-    private static final int TRIAGE_MAX_TOKENS = 200;
-    private static final int ANALYSIS_MAX_TOKENS = 1500;
     private static final int TOTAL_STEPS = 7;
+    private static final String DIAGNOSTIC_LABEL = "Kafka cluster diagnostic";
 
     private static final String STEP_CLUSTER_STATUS = "cluster_status";
     private static final String STEP_NODE_POOLS = "node_pools";
@@ -84,6 +83,12 @@ public class KafkaClusterDiagnosticService {
 
     @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
     int defaultTailLines;
+
+    @ConfigProperty(name = "mcp.sampling.triage-max-tokens", defaultValue = "200")
+    int triageMaxTokens;
+
+    @ConfigProperty(name = "mcp.sampling.analysis-max-tokens", defaultValue = "1500")
+    int analysisMaxTokens;
 
     KafkaClusterDiagnosticService() {
     }
@@ -135,7 +140,7 @@ public class KafkaClusterDiagnosticService {
         // === Phase 1: Initial data gathering ===
         KafkaClusterResponse cluster = gatherClusterStatus(
             ns, name, elicitation, completed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         // Resolve namespace from cluster response for subsequent calls
@@ -143,12 +148,12 @@ public class KafkaClusterDiagnosticService {
 
         List<KafkaNodePoolResponse> nodePools = gatherNodePools(
             resolvedNs, name, completed, failed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         KafkaClusterPodsResponse pods = gatherClusterPods(
             resolvedNs, name, completed, failed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         // === Phase 2: Deep investigation ===
@@ -161,7 +166,7 @@ public class KafkaClusterDiagnosticService {
             operator = gatherOperatorStatus(resolvedNs, completed, failed, mcpLog);
             operatorLogs = gatherOperatorLogs(
                 resolvedNs, sinceMinutes, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -169,7 +174,7 @@ public class KafkaClusterDiagnosticService {
         if (areas.clusterLogs) {
             clusterLogs = gatherClusterLogs(
                 resolvedNs, name, sinceMinutes, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -177,7 +182,7 @@ public class KafkaClusterDiagnosticService {
         if (areas.events) {
             events = gatherEvents(
                 resolvedNs, name, sinceMinutes, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -185,7 +190,7 @@ public class KafkaClusterDiagnosticService {
         if (areas.metrics) {
             metrics = gatherMetrics(
                 resolvedNs, name, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -208,7 +213,7 @@ public class KafkaClusterDiagnosticService {
         try {
             KafkaClusterResponse result = kafkaService.getCluster(namespace, clusterName);
             completed.add(STEP_CLUSTER_STATUS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked cluster status: " + result.readiness());
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka cluster status: " + result.readiness());
             return result;
         } catch (ToolCallException e) {
             if (DiagnosticHelper.isMultipleNamespacesError(e)
@@ -229,10 +234,10 @@ public class KafkaClusterDiagnosticService {
         try {
             List<KafkaNodePoolResponse> result = nodePoolService.listNodePools(namespace, clusterName);
             completed.add(STEP_NODE_POOLS);
-            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d node pools", result.size()));
+            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d KafkaNodePools", result.size()));
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather node pools: %s", e.getMessage());
+            LOG.warnf("Failed to gather KafkaNodePools: %s", e.getMessage());
             failed.add(STEP_NODE_POOLS + ": " + e.getMessage());
             return List.of();
         }
@@ -246,10 +251,10 @@ public class KafkaClusterDiagnosticService {
         try {
             KafkaClusterPodsResponse result = kafkaService.getClusterPods(namespace, clusterName);
             completed.add(STEP_POD_HEALTH);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked pod health");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka pod health");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather pod health: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka pod health: %s", e.getMessage());
             failed.add(STEP_POD_HEALTH + ": " + e.getMessage());
             return null;
         }
@@ -265,12 +270,14 @@ public class KafkaClusterDiagnosticService {
             List<StrimziOperatorResponse> operators = operatorService.listOperators(namespace);
             if (!operators.isEmpty()) {
                 completed.add(STEP_OPERATOR_STATUS);
-                DiagnosticHelper.sendClientNotification(mcpLog, "Checked operator status: " + operators.getFirst().status());
-                return operators.getFirst();
+                StrimziOperatorResponse op = operators.getFirst();
+                DiagnosticHelper.sendClientNotification(mcpLog,
+                    String.format("Checked Strimzi operator '%s' status: %s", op.name(), op.status()));
+                return op;
             }
             return null;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather operator status: %s", e.getMessage());
+            LOG.warnf("Failed to gather Strimzi operator status: %s", e.getMessage());
             failed.add(STEP_OPERATOR_STATUS + ": " + e.getMessage());
             return null;
         }
@@ -285,10 +292,10 @@ public class KafkaClusterDiagnosticService {
             StrimziOperatorLogsResponse result = operatorService.getOperatorLogs(
                 namespace, null, buildErrorLogParams(sinceMinutes));
             completed.add(STEP_OPERATOR_LOGS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Collected operator logs");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected Strimzi operator logs");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather operator logs: %s", e.getMessage());
+            LOG.warnf("Failed to gather Strimzi operator logs: %s", e.getMessage());
             failed.add(STEP_OPERATOR_LOGS + ": " + e.getMessage());
             return null;
         }
@@ -304,10 +311,10 @@ public class KafkaClusterDiagnosticService {
             KafkaClusterLogsResponse result = kafkaService.getClusterLogs(
                 namespace, clusterName, buildErrorLogParams(sinceMinutes));
             completed.add(STEP_CLUSTER_LOGS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Collected cluster logs");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected Kafka cluster logs");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather cluster logs: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka cluster logs: %s", e.getMessage());
             failed.add(STEP_CLUSTER_LOGS + ": " + e.getMessage());
             return null;
         }
@@ -326,7 +333,7 @@ public class KafkaClusterDiagnosticService {
             DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d events", result.totalEvents()));
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather events: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka related events: %s", e.getMessage());
             failed.add(STEP_EVENTS + ": " + e.getMessage());
             return null;
         }
@@ -341,10 +348,10 @@ public class KafkaClusterDiagnosticService {
             KafkaMetricsResponse result = kafkaMetricsService.getKafkaMetrics(
                 namespace, clusterName, "replication", null, null, null, null, null);
             completed.add(STEP_METRICS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Retrieved replication metrics");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Retrieved Kafka replication metrics");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather metrics: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka metrics: %s", e.getMessage());
             failed.add(STEP_METRICS + ": " + e.getMessage());
             return null;
         }
@@ -368,7 +375,7 @@ public class KafkaClusterDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(summaryJson))
-                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .setMaxTokens(triageMaxTokens)
                 .build()
                 .sendAndAwait();
 
@@ -403,7 +410,7 @@ public class KafkaClusterDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(dataJson))
-                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .setMaxTokens(analysisMaxTokens)
                 .build()
                 .sendAndAwait();
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterDiagnosticReport;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterLogsResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterPodsResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaNodePoolResponse;
+import io.streamshub.mcp.strimzi.dto.StrimziEventsResponse;
+import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
+import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Orchestrates a multistep diagnostic workflow for Kafka clusters.
+ *
+ * <p>Gathers data from multiple services in a single operation, optionally
+ * using MCP Sampling to get LLM analysis of intermediate results and
+ * Elicitation to resolve ambiguous inputs (e.g., multiple namespaces).</p>
+ *
+ * <p>Individual step failures do not abort the workflow. Failed steps are
+ * recorded and the report includes all data that was successfully gathered.</p>
+ */
+@ApplicationScoped
+public class KafkaClusterDiagnosticService {
+
+    private static final Logger LOG = Logger.getLogger(KafkaClusterDiagnosticService.class);
+    private static final int SECONDS_PER_MINUTE = 60;
+    private static final int TRIAGE_MAX_TOKENS = 200;
+    private static final int ANALYSIS_MAX_TOKENS = 1500;
+    private static final int TOTAL_STEPS = 7;
+
+    private static final String STEP_CLUSTER_STATUS = "cluster_status";
+    private static final String STEP_NODE_POOLS = "node_pools";
+    private static final String STEP_POD_HEALTH = "pod_health";
+    private static final String STEP_OPERATOR_STATUS = "operator_status";
+    private static final String STEP_OPERATOR_LOGS = "operator_logs";
+    private static final String STEP_CLUSTER_LOGS = "cluster_logs";
+    private static final String STEP_EVENTS = "events";
+    private static final String STEP_METRICS = "metrics";
+
+    @Inject
+    KafkaService kafkaService;
+
+    @Inject
+    KafkaNodePoolService nodePoolService;
+
+    @Inject
+    StrimziOperatorService operatorService;
+
+    @Inject
+    StrimziEventsService eventsService;
+
+    @Inject
+    KafkaMetricsService kafkaMetricsService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
+    int defaultTailLines;
+
+    KafkaClusterDiagnosticService() {
+    }
+
+    /**
+     * Run a multistep diagnostic workflow for a Kafka cluster.
+     *
+     * <p>Phase 1 gathers cluster status, node pools, and pod health.
+     * Phase 2 uses Sampling (if supported) to decide which areas need
+     * deeper investigation, then gathers operator logs, cluster logs,
+     * events, and/or metrics. Phase 3 uses Sampling to produce a
+     * root cause analysis.</p>
+     *
+     * @param namespace    optional namespace (elicited if ambiguous)
+     * @param clusterName  the Kafka cluster name
+     * @param symptom      optional symptom description for context
+     * @param sinceMinutes optional time window for logs and events
+     * @param sampling     MCP Sampling for LLM analysis (may be unsupported)
+     * @param elicitation  MCP Elicitation for user input (may be unsupported)
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public KafkaClusterDiagnosticReport diagnose(final String namespace,
+                                                 final String clusterName,
+                                                 final String symptom,
+                                                 final Integer sinceMinutes,
+                                                 final Sampling sampling,
+                                                 final Elicitation elicitation,
+                                                 final McpLog mcpLog,
+                                                 final Progress progress,
+                                                 final Cancellation cancellation) {
+        String ns = InputUtils.normalizeInput(namespace);
+        String name = InputUtils.normalizeInput(clusterName);
+
+        if (name == null) {
+            throw new ToolCallException("Cluster name is required");
+        }
+
+        LOG.infof("Starting diagnostic for cluster=%s (namespace=%s, symptom=%s)",
+            name, ns != null ? ns : "auto", symptom);
+
+        List<String> completed = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        int stepIndex = 0;
+
+        // === Phase 1: Initial data gathering ===
+        KafkaClusterResponse cluster = gatherClusterStatus(
+            ns, name, elicitation, completed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        // Resolve namespace from cluster response for subsequent calls
+        String resolvedNs = cluster.namespace();
+
+        List<KafkaNodePoolResponse> nodePools = gatherNodePools(
+            resolvedNs, name, completed, failed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        KafkaClusterPodsResponse pods = gatherClusterPods(
+            resolvedNs, name, completed, failed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        // === Phase 2: Deep investigation ===
+        InvestigationAreas areas = decideInvestigationAreas(
+            sampling, cluster, nodePools, pods, symptom);
+
+        StrimziOperatorResponse operator = null;
+        StrimziOperatorLogsResponse operatorLogs = null;
+        if (areas.operatorLogs) {
+            operator = gatherOperatorStatus(resolvedNs, completed, failed, mcpLog);
+            operatorLogs = gatherOperatorLogs(
+                resolvedNs, sinceMinutes, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        KafkaClusterLogsResponse clusterLogs = null;
+        if (areas.clusterLogs) {
+            clusterLogs = gatherClusterLogs(
+                resolvedNs, name, sinceMinutes, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        StrimziEventsResponse events = null;
+        if (areas.events) {
+            events = gatherEvents(
+                resolvedNs, name, sinceMinutes, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        KafkaMetricsResponse metrics = null;
+        if (areas.metrics) {
+            metrics = gatherMetrics(
+                resolvedNs, name, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        // === Phase 3: Final analysis ===
+        String analysis = produceAnalysis(sampling, cluster, nodePools, pods,
+            operator, operatorLogs, clusterLogs, events, metrics, symptom);
+
+        return KafkaClusterDiagnosticReport.of(cluster, nodePools, pods, operator,
+            operatorLogs, clusterLogs, events, metrics, analysis,
+            completed, failed.isEmpty() ? null : failed);
+    }
+
+    // ---- Phase 1: Initial data gathering ----
+
+    private KafkaClusterResponse gatherClusterStatus(final String namespace,
+                                                     final String clusterName,
+                                                     final Elicitation elicitation,
+                                                     final List<String> completed,
+                                                     final McpLog mcpLog) {
+        try {
+            KafkaClusterResponse result = kafkaService.getCluster(namespace, clusterName);
+            completed.add(STEP_CLUSTER_STATUS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked cluster status: " + result.readiness());
+            return result;
+        } catch (ToolCallException e) {
+            if (DiagnosticHelper.isMultipleNamespacesError(e)
+                    && elicitation != null && elicitation.isSupported()) {
+                String resolved = DiagnosticHelper.elicitNamespace(e, elicitation, "diagnosed");
+                return gatherClusterStatus(resolved, clusterName, null,
+                    completed, mcpLog);
+            }
+            throw e;
+        }
+    }
+
+    private List<KafkaNodePoolResponse> gatherNodePools(final String namespace,
+                                                        final String clusterName,
+                                                        final List<String> completed,
+                                                        final List<String> failed,
+                                                        final McpLog mcpLog) {
+        try {
+            List<KafkaNodePoolResponse> result = nodePoolService.listNodePools(namespace, clusterName);
+            completed.add(STEP_NODE_POOLS);
+            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d node pools", result.size()));
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather node pools: %s", e.getMessage());
+            failed.add(STEP_NODE_POOLS + ": " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    private KafkaClusterPodsResponse gatherClusterPods(final String namespace,
+                                                       final String clusterName,
+                                                       final List<String> completed,
+                                                       final List<String> failed,
+                                                       final McpLog mcpLog) {
+        try {
+            KafkaClusterPodsResponse result = kafkaService.getClusterPods(namespace, clusterName);
+            completed.add(STEP_POD_HEALTH);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked pod health");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather pod health: %s", e.getMessage());
+            failed.add(STEP_POD_HEALTH + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Phase 2: Deep investigation ----
+
+    private StrimziOperatorResponse gatherOperatorStatus(final String namespace,
+                                                         final List<String> completed,
+                                                         final List<String> failed,
+                                                         final McpLog mcpLog) {
+        try {
+            List<StrimziOperatorResponse> operators = operatorService.listOperators(namespace);
+            if (!operators.isEmpty()) {
+                completed.add(STEP_OPERATOR_STATUS);
+                DiagnosticHelper.sendClientNotification(mcpLog, "Checked operator status: " + operators.getFirst().status());
+                return operators.getFirst();
+            }
+            return null;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather operator status: %s", e.getMessage());
+            failed.add(STEP_OPERATOR_STATUS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private StrimziOperatorLogsResponse gatherOperatorLogs(final String namespace,
+                                                           final Integer sinceMinutes,
+                                                           final List<String> completed,
+                                                           final List<String> failed,
+                                                           final McpLog mcpLog) {
+        try {
+            StrimziOperatorLogsResponse result = operatorService.getOperatorLogs(
+                namespace, null, buildErrorLogParams(sinceMinutes));
+            completed.add(STEP_OPERATOR_LOGS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected operator logs");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather operator logs: %s", e.getMessage());
+            failed.add(STEP_OPERATOR_LOGS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private KafkaClusterLogsResponse gatherClusterLogs(final String namespace,
+                                                       final String clusterName,
+                                                       final Integer sinceMinutes,
+                                                       final List<String> completed,
+                                                       final List<String> failed,
+                                                       final McpLog mcpLog) {
+        try {
+            KafkaClusterLogsResponse result = kafkaService.getClusterLogs(
+                namespace, clusterName, buildErrorLogParams(sinceMinutes));
+            completed.add(STEP_CLUSTER_LOGS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected cluster logs");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather cluster logs: %s", e.getMessage());
+            failed.add(STEP_CLUSTER_LOGS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private StrimziEventsResponse gatherEvents(final String namespace,
+                                               final String clusterName,
+                                               final Integer sinceMinutes,
+                                               final List<String> completed,
+                                               final List<String> failed,
+                                               final McpLog mcpLog) {
+        try {
+            StrimziEventsResponse result = eventsService.getClusterEvents(
+                namespace, clusterName, sinceMinutes);
+            completed.add(STEP_EVENTS);
+            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d events", result.totalEvents()));
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather events: %s", e.getMessage());
+            failed.add(STEP_EVENTS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private KafkaMetricsResponse gatherMetrics(final String namespace,
+                                               final String clusterName,
+                                               final List<String> completed,
+                                               final List<String> failed,
+                                               final McpLog mcpLog) {
+        try {
+            KafkaMetricsResponse result = kafkaMetricsService.getKafkaMetrics(
+                namespace, clusterName, "replication", null, null, null, null, null);
+            completed.add(STEP_METRICS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Retrieved replication metrics");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather metrics: %s", e.getMessage());
+            failed.add(STEP_METRICS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Sampling: triage and analysis ----
+
+    private InvestigationAreas decideInvestigationAreas(final Sampling sampling,
+                                                        final KafkaClusterResponse cluster,
+                                                        final List<KafkaNodePoolResponse> nodePools,
+                                                        final KafkaClusterPodsResponse pods,
+                                                        final String symptom) {
+        if (sampling == null || !sampling.isSupported()) {
+            return InvestigationAreas.all();
+        }
+
+        try {
+            Map<String, Object> summary = buildPhase1Summary(cluster, nodePools, pods, symptom);
+            String summaryJson = objectMapper.writeValueAsString(summary);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(summaryJson))
+                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return parseInvestigationAreas(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling triage failed, investigating all areas: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private String produceAnalysis(final Sampling sampling,
+                                   final KafkaClusterResponse cluster,
+                                   final List<KafkaNodePoolResponse> nodePools,
+                                   final KafkaClusterPodsResponse pods,
+                                   final StrimziOperatorResponse operator,
+                                   final StrimziOperatorLogsResponse operatorLogs,
+                                   final KafkaClusterLogsResponse clusterLogs,
+                                   final StrimziEventsResponse events,
+                                   final KafkaMetricsResponse metrics,
+                                   final String symptom) {
+        if (sampling == null || !sampling.isSupported()) {
+            return null;
+        }
+
+        try {
+            Map<String, Object> fullData = buildFullSummary(
+                cluster, nodePools, pods, operator, operatorLogs,
+                clusterLogs, events, metrics, symptom);
+            String dataJson = objectMapper.writeValueAsString(fullData);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(dataJson))
+                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return DiagnosticHelper.extractSamplingText(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling analysis failed: %s", e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Helpers ----
+
+    private LogCollectionParams buildErrorLogParams(final Integer sinceMinutes) {
+        return LogCollectionParams.builder(defaultTailLines)
+            .filter("errors")
+            .sinceSeconds(sinceMinutes != null ? sinceMinutes * SECONDS_PER_MINUTE : null)
+            .build();
+    }
+
+    private Map<String, Object> buildPhase1Summary(final KafkaClusterResponse cluster,
+                                                   final List<KafkaNodePoolResponse> nodePools,
+                                                   final KafkaClusterPodsResponse pods,
+                                                   final String symptom) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        if (symptom != null) {
+            summary.put("symptom", symptom);
+        }
+        summary.put("cluster_readiness", cluster.readiness());
+        if (cluster.replicas() != null) {
+            summary.put("expected_replicas", cluster.replicas().expected());
+            summary.put("ready_replicas", cluster.replicas().ready());
+        }
+        summary.put("node_pool_count", nodePools.size());
+        if (pods != null) {
+            summary.put("pods", pods);
+        }
+        return summary;
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private Map<String, Object> buildFullSummary(final KafkaClusterResponse cluster,
+                                                 final List<KafkaNodePoolResponse> nodePools,
+                                                 final KafkaClusterPodsResponse pods,
+                                                 final StrimziOperatorResponse operator,
+                                                 final StrimziOperatorLogsResponse operatorLogs,
+                                                 final KafkaClusterLogsResponse clusterLogs,
+                                                 final StrimziEventsResponse events,
+                                                 final KafkaMetricsResponse metrics,
+                                                 final String symptom) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        if (symptom != null) {
+            data.put("symptom", symptom);
+        }
+        DiagnosticHelper.putIfNotNull(data, STEP_CLUSTER_STATUS, cluster);
+        DiagnosticHelper.putIfNotNull(data, STEP_NODE_POOLS, nodePools);
+        DiagnosticHelper.putIfNotNull(data, STEP_POD_HEALTH, pods);
+        DiagnosticHelper.putIfNotNull(data, STEP_OPERATOR_STATUS, operator);
+        DiagnosticHelper.putIfNotNull(data, STEP_OPERATOR_LOGS, operatorLogs);
+        DiagnosticHelper.putIfNotNull(data, STEP_CLUSTER_LOGS, clusterLogs);
+        DiagnosticHelper.putIfNotNull(data, STEP_EVENTS, events);
+        DiagnosticHelper.putIfNotNull(data, STEP_METRICS, metrics);
+        return data;
+    }
+
+    private InvestigationAreas parseInvestigationAreas(final SamplingResponse response) {
+        try {
+            String text = DiagnosticHelper.extractSamplingText(response);
+            Map<String, Object> parsed = objectMapper.readValue(text, DiagnosticHelper.MAP_TYPE_REF);
+            return new InvestigationAreas(
+                Boolean.TRUE.equals(parsed.get(STEP_OPERATOR_LOGS)),
+                Boolean.TRUE.equals(parsed.get(STEP_CLUSTER_LOGS)),
+                Boolean.TRUE.equals(parsed.get(STEP_EVENTS)),
+                Boolean.TRUE.equals(parsed.get(STEP_METRICS))
+            );
+        } catch (Exception e) {
+            LOG.debugf("Could not parse triage response, investigating all: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    /**
+     * Flags indicating which investigation areas the LLM recommended.
+     *
+     * @param operatorLogs whether to gather operator logs
+     * @param clusterLogs  whether to gather cluster logs
+     * @param events       whether to gather Kubernetes events
+     * @param metrics      whether to gather replication metrics
+     */
+    record InvestigationAreas(boolean operatorLogs, boolean clusterLogs,
+                              boolean events, boolean metrics) {
+
+        /**
+         * Returns areas with all flags set to true (fallback when Sampling is unavailable).
+         *
+         * @return investigation areas with all flags enabled
+         */
+        static InvestigationAreas all() {
+            return new InvestigationAreas(true, true, true, true);
+        }
+    }
+
+    // ---- Sampling system prompts ----
+
+    static final String TRIAGE_SYSTEM_PROMPT = """
+        You are a Kafka infrastructure diagnostics assistant. \
+        Analyze the initial cluster findings and decide which areas need deeper investigation. \
+        Return ONLY a JSON object with these boolean fields: \
+        operator_logs, cluster_logs, events, metrics. \
+        Set true only for areas likely to reveal the root cause. \
+        For example, if all pods are healthy and the cluster is Ready, set all to false. \
+        If pods are crashing, set cluster_logs and events to true. \
+        If the cluster is NotReady but pods look fine, set operator_logs and metrics to true.\
+        """;
+
+    static final String ANALYSIS_SYSTEM_PROMPT = """
+        You are diagnosing a Kafka cluster issue. Analyze all the gathered diagnostic data \
+        and produce a concise root cause analysis.
+        
+        Distinguish between:
+        1. Operator-initiated changes (EXPECTED): rolling updates, certificate renewal, config changes
+        2. Infrastructure failures (CRITICAL): OOM, disk full, node failures, network issues
+        3. Configuration errors (HIGH): invalid specs, missing secrets, RBAC issues
+        4. Performance degradation (MEDIUM): overloaded brokers, replication lag
+        5. Cascading failures (CRITICAL): broker overload -> replication lag -> offline partitions
+        
+        Structure your response as:
+        - Root cause (single most likely cause)
+        - Severity (CRITICAL/HIGH/MEDIUM/LOW)
+        - Impact (what is affected)
+        - Evidence (specific findings that support the diagnosis)
+        - Recommendations (prioritized, actionable steps)
+        
+        Remember: symptoms are not root causes. Pod restarts are symptoms; \
+        OOM or disk full are root causes.\
+        """;
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticService.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.dto.KafkaBootstrapResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaCertificateResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterLogsResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterPodsResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaConnectivityDiagnosticReport;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Orchestrates a multistep connectivity diagnostic workflow for Kafka clusters.
+ *
+ * <p>Checks listeners, bootstrap addresses, TLS certificates, authentication,
+ * pod health, and connection-related logs in a single operation. Optionally uses
+ * MCP Sampling for LLM analysis and Elicitation for namespace disambiguation.</p>
+ *
+ * <p>Individual step failures do not abort the workflow. Failed steps are
+ * recorded and the report includes all data that was successfully gathered.</p>
+ */
+@ApplicationScoped
+public class KafkaConnectivityDiagnosticService {
+
+    private static final Logger LOG = Logger.getLogger(KafkaConnectivityDiagnosticService.class);
+    private static final int TRIAGE_MAX_TOKENS = 200;
+    private static final int ANALYSIS_MAX_TOKENS = 1500;
+    private static final int TOTAL_STEPS = 5;
+    private static final List<String> CONNECTIVITY_KEYWORDS = List.of(
+        "TLS", "SSL", "handshake", "authentication", "SASL",
+        "connection refused", "SocketException", "SSLHandshakeException",
+        "SaslAuthenticationException", "listener");
+
+    private static final String STEP_CLUSTER_STATUS = "cluster_status";
+    private static final String STEP_BOOTSTRAP_SERVERS = "bootstrap_servers";
+    private static final String STEP_CERTIFICATES = "certificates";
+    private static final String STEP_POD_HEALTH = "pod_health";
+    private static final String STEP_CLUSTER_LOGS = "cluster_logs";
+
+    @Inject
+    KafkaService kafkaService;
+
+    @Inject
+    KafkaCertificateService kafkaCertificateService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
+    int defaultTailLines;
+
+    KafkaConnectivityDiagnosticService() {
+    }
+
+    /**
+     * Run a multistep connectivity diagnostic workflow for a Kafka cluster.
+     *
+     * <p>Phase 1 gathers cluster status and bootstrap server addresses.
+     * Phase 2 uses Sampling (if supported) to decide which areas need
+     * deeper investigation, then gathers certificates, pod health,
+     * and/or connection-related logs. Phase 3 uses Sampling to produce
+     * a connectivity analysis.</p>
+     *
+     * @param namespace    optional namespace (elicited if ambiguous)
+     * @param clusterName  the Kafka cluster name
+     * @param listenerName optional listener to focus on
+     * @param sampling     MCP Sampling for LLM analysis (may be unsupported)
+     * @param elicitation  MCP Elicitation for user input (may be unsupported)
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated connectivity diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public KafkaConnectivityDiagnosticReport diagnose(final String namespace,
+                                                      final String clusterName,
+                                                      final String listenerName,
+                                                      final Sampling sampling,
+                                                      final Elicitation elicitation,
+                                                      final McpLog mcpLog,
+                                                      final Progress progress,
+                                                      final Cancellation cancellation) {
+        String ns = InputUtils.normalizeInput(namespace);
+        String name = InputUtils.normalizeInput(clusterName);
+        String listener = InputUtils.normalizeInput(listenerName);
+
+        if (name == null) {
+            throw new ToolCallException("Cluster name is required");
+        }
+
+        LOG.infof("Starting connectivity diagnostic for cluster=%s (namespace=%s, listener=%s)",
+            name, ns != null ? ns : "auto", listener != null ? listener : "all");
+
+        List<String> completed = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        int stepIndex = 0;
+
+        // === Phase 1: Initial data gathering ===
+        KafkaClusterResponse cluster = gatherClusterStatus(
+            ns, name, elicitation, completed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        String resolvedNs = cluster.namespace();
+
+        KafkaBootstrapResponse bootstrapServers = gatherBootstrapServers(
+            resolvedNs, name, completed, failed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        // === Phase 2: Deep investigation ===
+        InvestigationAreas areas = decideInvestigationAreas(
+            sampling, cluster, bootstrapServers);
+
+        KafkaCertificateResponse certificates = null;
+        if (areas.certificates) {
+            certificates = gatherCertificates(
+                resolvedNs, name, listener, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        KafkaClusterPodsResponse pods = null;
+        if (areas.pods) {
+            pods = gatherClusterPods(
+                resolvedNs, name, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        KafkaClusterLogsResponse clusterLogs = null;
+        if (areas.clusterLogs) {
+            clusterLogs = gatherConnectivityLogs(
+                resolvedNs, name, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        // === Phase 3: Final analysis ===
+        String analysis = produceAnalysis(sampling, cluster, bootstrapServers,
+            certificates, pods, clusterLogs, listener);
+
+        return KafkaConnectivityDiagnosticReport.of(cluster, bootstrapServers,
+            certificates, pods, clusterLogs, analysis,
+            completed, failed.isEmpty() ? null : failed);
+    }
+
+    // ---- Phase 1: Initial data gathering ----
+
+    private KafkaClusterResponse gatherClusterStatus(final String namespace,
+                                                     final String clusterName,
+                                                     final Elicitation elicitation,
+                                                     final List<String> completed,
+                                                     final McpLog mcpLog) {
+        try {
+            KafkaClusterResponse result = kafkaService.getCluster(namespace, clusterName);
+            completed.add(STEP_CLUSTER_STATUS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked cluster status: " + result.readiness());
+            return result;
+        } catch (ToolCallException e) {
+            if (DiagnosticHelper.isMultipleNamespacesError(e)
+                    && elicitation != null && elicitation.isSupported()) {
+                String resolved = DiagnosticHelper.elicitNamespace(e, elicitation, "checked for connectivity");
+                return gatherClusterStatus(resolved, clusterName, null,
+                    completed, mcpLog);
+            }
+            throw e;
+        }
+    }
+
+    private KafkaBootstrapResponse gatherBootstrapServers(final String namespace,
+                                                          final String clusterName,
+                                                          final List<String> completed,
+                                                          final List<String> failed,
+                                                          final McpLog mcpLog) {
+        try {
+            KafkaBootstrapResponse result = kafkaService.getBootstrapServers(namespace, clusterName);
+            completed.add(STEP_BOOTSTRAP_SERVERS);
+            int listenerCount = result.bootstrapServers() != null ? result.bootstrapServers().size() : 0;
+            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d listeners", listenerCount));
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather bootstrap servers: %s", e.getMessage());
+            failed.add(STEP_BOOTSTRAP_SERVERS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Phase 2: Deep investigation ----
+
+    private KafkaCertificateResponse gatherCertificates(final String namespace,
+                                                        final String clusterName,
+                                                        final String listenerName,
+                                                        final List<String> completed,
+                                                        final List<String> failed,
+                                                        final McpLog mcpLog) {
+        try {
+            KafkaCertificateResponse result = kafkaCertificateService.getCertificates(
+                namespace, clusterName, listenerName);
+            completed.add(STEP_CERTIFICATES);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked TLS certificates and authentication");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather certificates: %s", e.getMessage());
+            failed.add(STEP_CERTIFICATES + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private KafkaClusterPodsResponse gatherClusterPods(final String namespace,
+                                                       final String clusterName,
+                                                       final List<String> completed,
+                                                       final List<String> failed,
+                                                       final McpLog mcpLog) {
+        try {
+            KafkaClusterPodsResponse result = kafkaService.getClusterPods(namespace, clusterName);
+            completed.add(STEP_POD_HEALTH);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked pod health");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather pod health: %s", e.getMessage());
+            failed.add(STEP_POD_HEALTH + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private KafkaClusterLogsResponse gatherConnectivityLogs(final String namespace,
+                                                            final String clusterName,
+                                                            final List<String> completed,
+                                                            final List<String> failed,
+                                                            final McpLog mcpLog) {
+        try {
+            LogCollectionParams params = LogCollectionParams.builder(defaultTailLines)
+                .keywords(CONNECTIVITY_KEYWORDS)
+                .build();
+            KafkaClusterLogsResponse result = kafkaService.getClusterLogs(
+                namespace, clusterName, params);
+            completed.add(STEP_CLUSTER_LOGS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected connectivity-related logs");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather connectivity logs: %s", e.getMessage());
+            failed.add(STEP_CLUSTER_LOGS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Sampling: triage and analysis ----
+
+    private InvestigationAreas decideInvestigationAreas(final Sampling sampling,
+                                                        final KafkaClusterResponse cluster,
+                                                        final KafkaBootstrapResponse bootstrapServers) {
+        if (sampling == null || !sampling.isSupported()) {
+            return InvestigationAreas.all();
+        }
+
+        try {
+            Map<String, Object> summary = buildPhase1Summary(cluster, bootstrapServers);
+            String summaryJson = objectMapper.writeValueAsString(summary);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(summaryJson))
+                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return parseInvestigationAreas(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling triage failed, investigating all areas: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private String produceAnalysis(final Sampling sampling,
+                                   final KafkaClusterResponse cluster,
+                                   final KafkaBootstrapResponse bootstrapServers,
+                                   final KafkaCertificateResponse certificates,
+                                   final KafkaClusterPodsResponse pods,
+                                   final KafkaClusterLogsResponse clusterLogs,
+                                   final String listenerName) {
+        if (sampling == null || !sampling.isSupported()) {
+            return null;
+        }
+
+        try {
+            Map<String, Object> fullData = buildFullSummary(
+                cluster, bootstrapServers, certificates, pods, clusterLogs, listenerName);
+            String dataJson = objectMapper.writeValueAsString(fullData);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(dataJson))
+                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return DiagnosticHelper.extractSamplingText(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling analysis failed: %s", e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Helpers ----
+
+    private Map<String, Object> buildPhase1Summary(final KafkaClusterResponse cluster,
+                                                   final KafkaBootstrapResponse bootstrapServers) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("cluster_readiness", cluster.readiness());
+        if (bootstrapServers != null) {
+            summary.put(STEP_BOOTSTRAP_SERVERS, bootstrapServers);
+        }
+        return summary;
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private Map<String, Object> buildFullSummary(final KafkaClusterResponse cluster,
+                                                 final KafkaBootstrapResponse bootstrapServers,
+                                                 final KafkaCertificateResponse certificates,
+                                                 final KafkaClusterPodsResponse pods,
+                                                 final KafkaClusterLogsResponse clusterLogs,
+                                                 final String listenerName) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        if (listenerName != null) {
+            data.put("listener_filter", listenerName);
+        }
+        DiagnosticHelper.putIfNotNull(data, STEP_CLUSTER_STATUS, cluster);
+        DiagnosticHelper.putIfNotNull(data, STEP_BOOTSTRAP_SERVERS, bootstrapServers);
+        DiagnosticHelper.putIfNotNull(data, STEP_CERTIFICATES, certificates);
+        DiagnosticHelper.putIfNotNull(data, STEP_POD_HEALTH, pods);
+        DiagnosticHelper.putIfNotNull(data, STEP_CLUSTER_LOGS, clusterLogs);
+        return data;
+    }
+
+    private InvestigationAreas parseInvestigationAreas(final SamplingResponse response) {
+        try {
+            String text = DiagnosticHelper.extractSamplingText(response);
+            Map<String, Object> parsed = objectMapper.readValue(text, DiagnosticHelper.MAP_TYPE_REF);
+            return new InvestigationAreas(
+                Boolean.TRUE.equals(parsed.get(STEP_CERTIFICATES)),
+                Boolean.TRUE.equals(parsed.get(STEP_POD_HEALTH)),
+                Boolean.TRUE.equals(parsed.get(STEP_CLUSTER_LOGS))
+            );
+        } catch (Exception e) {
+            LOG.debugf("Could not parse triage response, investigating all: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    /**
+     * Flags indicating which investigation areas the LLM recommended.
+     *
+     * @param certificates whether to gather TLS certificates and authentication
+     * @param pods         whether to gather pod health
+     * @param clusterLogs  whether to gather connection-related logs
+     */
+    record InvestigationAreas(boolean certificates, boolean pods, boolean clusterLogs) {
+
+        /**
+         * Returns areas with all flags set to true (fallback when Sampling is unavailable).
+         *
+         * @return investigation areas with all flags enabled
+         */
+        static InvestigationAreas all() {
+            return new InvestigationAreas(true, true, true);
+        }
+    }
+
+    // ---- Sampling system prompts ----
+
+    static final String TRIAGE_SYSTEM_PROMPT = """
+        You are a Kafka connectivity diagnostics assistant. \
+        Analyze the cluster status and listener configuration to decide which areas \
+        need deeper investigation. \
+        Return ONLY a JSON object with these boolean fields: \
+        certificates, pod_health, cluster_logs. \
+        Set true only for areas likely to reveal connectivity issues. \
+        For example, if listeners use TLS, set certificates to true. \
+        If the cluster is NotReady, set pod_health to true. \
+        If listeners look correct but connectivity fails, set cluster_logs to true.\
+        """;
+
+    static final String ANALYSIS_SYSTEM_PROMPT = """
+        You are troubleshooting Kafka cluster connectivity. Analyze all gathered data \
+        and produce a concise connectivity analysis.
+        
+        For each listener, determine:
+        - Connection protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
+        - Whether the listener is accessible based on type (internal, route, loadbalancer, nodeport, ingress)
+        - Any blocking issues (expired certs, auth misconfiguration, pods not ready)
+        
+        Common connectivity issues:
+        1. TLS certificate expired or about to expire (< 30 days)
+        2. Authentication type mismatch (client uses wrong auth method)
+        3. Listener type mismatch (client tries internal address from outside cluster)
+        4. Broker pods not ready (clients cannot connect regardless of config)
+        5. Port conflicts or listener binding failures
+        6. SSL/TLS handshake failures (wrong truststore, protocol mismatch)
+        
+        Structure your response as:
+        - Issue summary (what is preventing connectivity, or "no issues found")
+        - Affected listeners (which listeners have problems)
+        - Root cause (most likely cause)
+        - Recommendations (specific steps to fix, with example client properties)
+        - Example client configuration for working listener(s)\
+        """;
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticService.java
@@ -22,6 +22,7 @@ import io.streamshub.mcp.strimzi.dto.KafkaClusterLogsResponse;
 import io.streamshub.mcp.strimzi.dto.KafkaClusterPodsResponse;
 import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
 import io.streamshub.mcp.strimzi.dto.KafkaConnectivityDiagnosticReport;
+import io.streamshub.mcp.strimzi.util.NamespaceElicitationHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -186,9 +187,9 @@ public class KafkaConnectivityDiagnosticService {
             DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka cluster status: " + result.readiness());
             return result;
         } catch (ToolCallException e) {
-            if (DiagnosticHelper.isMultipleNamespacesError(e)
+            if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
                     && elicitation != null && elicitation.isSupported()) {
-                String resolved = DiagnosticHelper.elicitNamespace(e, elicitation, "checked for connectivity");
+                String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "checked for connectivity");
                 return gatherClusterStatus(resolved, clusterName, null,
                     completed, mcpLog);
             }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticService.java
@@ -46,9 +46,8 @@ import java.util.Map;
 public class KafkaConnectivityDiagnosticService {
 
     private static final Logger LOG = Logger.getLogger(KafkaConnectivityDiagnosticService.class);
-    private static final int TRIAGE_MAX_TOKENS = 200;
-    private static final int ANALYSIS_MAX_TOKENS = 1500;
     private static final int TOTAL_STEPS = 5;
+    private static final String DIAGNOSTIC_LABEL = "Kafka connectivity diagnostic";
     private static final List<String> CONNECTIVITY_KEYWORDS = List.of(
         "TLS", "SSL", "handshake", "authentication", "SASL",
         "connection refused", "SocketException", "SSLHandshakeException",
@@ -71,6 +70,12 @@ public class KafkaConnectivityDiagnosticService {
 
     @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
     int defaultTailLines;
+
+    @ConfigProperty(name = "mcp.sampling.triage-max-tokens", defaultValue = "200")
+    int triageMaxTokens;
+
+    @ConfigProperty(name = "mcp.sampling.analysis-max-tokens", defaultValue = "1500")
+    int analysisMaxTokens;
 
     KafkaConnectivityDiagnosticService() {
     }
@@ -121,14 +126,14 @@ public class KafkaConnectivityDiagnosticService {
         // === Phase 1: Initial data gathering ===
         KafkaClusterResponse cluster = gatherClusterStatus(
             ns, name, elicitation, completed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         String resolvedNs = cluster.namespace();
 
         KafkaBootstrapResponse bootstrapServers = gatherBootstrapServers(
             resolvedNs, name, completed, failed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         // === Phase 2: Deep investigation ===
@@ -139,7 +144,7 @@ public class KafkaConnectivityDiagnosticService {
         if (areas.certificates) {
             certificates = gatherCertificates(
                 resolvedNs, name, listener, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -147,7 +152,7 @@ public class KafkaConnectivityDiagnosticService {
         if (areas.pods) {
             pods = gatherClusterPods(
                 resolvedNs, name, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -155,7 +160,7 @@ public class KafkaConnectivityDiagnosticService {
         if (areas.clusterLogs) {
             clusterLogs = gatherConnectivityLogs(
                 resolvedNs, name, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Connectivity diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -178,7 +183,7 @@ public class KafkaConnectivityDiagnosticService {
         try {
             KafkaClusterResponse result = kafkaService.getCluster(namespace, clusterName);
             completed.add(STEP_CLUSTER_STATUS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked cluster status: " + result.readiness());
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka cluster status: " + result.readiness());
             return result;
         } catch (ToolCallException e) {
             if (DiagnosticHelper.isMultipleNamespacesError(e)
@@ -200,10 +205,10 @@ public class KafkaConnectivityDiagnosticService {
             KafkaBootstrapResponse result = kafkaService.getBootstrapServers(namespace, clusterName);
             completed.add(STEP_BOOTSTRAP_SERVERS);
             int listenerCount = result.bootstrapServers() != null ? result.bootstrapServers().size() : 0;
-            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d listeners", listenerCount));
+            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Found %d Kafka listeners", listenerCount));
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather bootstrap servers: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka bootstrap servers: %s", e.getMessage());
             failed.add(STEP_BOOTSTRAP_SERVERS + ": " + e.getMessage());
             return null;
         }
@@ -224,7 +229,7 @@ public class KafkaConnectivityDiagnosticService {
             DiagnosticHelper.sendClientNotification(mcpLog, "Checked TLS certificates and authentication");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather certificates: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka TLS certificates: %s", e.getMessage());
             failed.add(STEP_CERTIFICATES + ": " + e.getMessage());
             return null;
         }
@@ -238,10 +243,10 @@ public class KafkaConnectivityDiagnosticService {
         try {
             KafkaClusterPodsResponse result = kafkaService.getClusterPods(namespace, clusterName);
             completed.add(STEP_POD_HEALTH);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked pod health");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka pod health");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather pod health: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka pod health: %s", e.getMessage());
             failed.add(STEP_POD_HEALTH + ": " + e.getMessage());
             return null;
         }
@@ -262,7 +267,7 @@ public class KafkaConnectivityDiagnosticService {
             DiagnosticHelper.sendClientNotification(mcpLog, "Collected connectivity-related logs");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather connectivity logs: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka connectivity logs: %s", e.getMessage());
             failed.add(STEP_CLUSTER_LOGS + ": " + e.getMessage());
             return null;
         }
@@ -284,7 +289,7 @@ public class KafkaConnectivityDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(summaryJson))
-                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .setMaxTokens(triageMaxTokens)
                 .build()
                 .sendAndAwait();
 
@@ -315,7 +320,7 @@ public class KafkaConnectivityDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(dataJson))
-                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .setMaxTokens(analysisMaxTokens)
                 .build()
                 .sendAndAwait();
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
@@ -290,10 +290,10 @@ public class KafkaMetricsDiagnosticService {
 
     private String categoryStepName(final String category) {
         return switch (category) {
-            case "replication" -> STEP_REPLICATION_METRICS;
-            case "performance" -> STEP_PERFORMANCE_METRICS;
-            case "resources" -> STEP_RESOURCE_METRICS;
-            case "throughput" -> STEP_THROUGHPUT_METRICS;
+            case KafkaMetricCategories.REPLICATION -> STEP_REPLICATION_METRICS;
+            case KafkaMetricCategories.PERFORMANCE -> STEP_PERFORMANCE_METRICS;
+            case KafkaMetricCategories.RESOURCES -> STEP_RESOURCE_METRICS;
+            case KafkaMetricCategories.THROUGHPUT -> STEP_THROUGHPUT_METRICS;
             default -> category + "_metrics";
         };
     }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.config.metrics.KafkaMetricCategories;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterPodsResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.KafkaMetricsDiagnosticReport;
+import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
+import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Orchestrates a multistep metrics diagnostic workflow for Kafka clusters.
+ *
+ * <p>Gathers cluster status and pod health, then selectively queries
+ * replication, performance, resource, and throughput metrics. Optionally uses
+ * MCP Sampling to get LLM analysis of intermediate results and Elicitation
+ * to resolve ambiguous inputs (e.g., multiple namespaces).</p>
+ *
+ * <p>Individual step failures do not abort the workflow. Failed steps are
+ * recorded and the report includes all data that was successfully gathered.</p>
+ */
+@ApplicationScoped
+public class KafkaMetricsDiagnosticService {
+
+    private static final Logger LOG = Logger.getLogger(KafkaMetricsDiagnosticService.class);
+    private static final int TRIAGE_MAX_TOKENS = 200;
+    private static final int ANALYSIS_MAX_TOKENS = 1500;
+    private static final int TOTAL_STEPS = 6;
+    private static final String STEP_CLUSTER_STATUS = "cluster_status";
+    private static final String STEP_POD_HEALTH = "pod_health";
+    private static final String STEP_REPLICATION_METRICS = "replication_metrics";
+    private static final String STEP_PERFORMANCE_METRICS = "performance_metrics";
+    private static final String STEP_RESOURCE_METRICS = "resource_metrics";
+    private static final String STEP_THROUGHPUT_METRICS = "throughput_metrics";
+
+    @Inject
+    KafkaService kafkaService;
+
+    @Inject
+    KafkaMetricsService kafkaMetricsService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    KafkaMetricsDiagnosticService() {
+    }
+
+    /**
+     * Run a multistep metrics diagnostic workflow for a Kafka cluster.
+     *
+     * <p>Phase 1 gathers cluster status and pod health. Phase 2 uses
+     * Sampling (if supported) to decide which metric categories need
+     * investigation, then gathers the selected categories. Phase 3 uses
+     * Sampling to produce a metrics-based diagnosis.</p>
+     *
+     * @param namespace    optional namespace (elicited if ambiguous)
+     * @param clusterName  the Kafka cluster name
+     * @param concern      optional concern description for context
+     * @param rangeMinutes optional relative time range in minutes
+     * @param startTime    optional absolute start time (ISO 8601)
+     * @param endTime      optional absolute end time (ISO 8601)
+     * @param stepSeconds  optional range query step interval in seconds
+     * @param sampling     MCP Sampling for LLM analysis (may be unsupported)
+     * @param elicitation  MCP Elicitation for user input (may be unsupported)
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated metrics diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public KafkaMetricsDiagnosticReport diagnose(final String namespace,
+                                                 final String clusterName,
+                                                 final String concern,
+                                                 final Integer rangeMinutes,
+                                                 final String startTime,
+                                                 final String endTime,
+                                                 final Integer stepSeconds,
+                                                 final Sampling sampling,
+                                                 final Elicitation elicitation,
+                                                 final McpLog mcpLog,
+                                                 final Progress progress,
+                                                 final Cancellation cancellation) {
+        String ns = InputUtils.normalizeInput(namespace);
+        String name = InputUtils.normalizeInput(clusterName);
+
+        if (name == null) {
+            throw new ToolCallException("Cluster name is required");
+        }
+
+        LOG.infof("Starting metrics diagnostic for cluster=%s (namespace=%s, concern=%s)",
+            name, ns != null ? ns : "auto", concern);
+
+        List<String> completed = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        int stepIndex = 0;
+
+        // === Phase 1: Initial data gathering ===
+        KafkaClusterResponse cluster = gatherClusterStatus(
+            ns, name, elicitation, completed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Metrics diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        String resolvedNs = cluster.namespace();
+
+        KafkaClusterPodsResponse pods = gatherClusterPods(
+            resolvedNs, name, completed, failed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Metrics diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        // === Phase 2: Metrics investigation (single scrape for all categories) ===
+        InvestigationAreas areas = decideInvestigationAreas(
+            sampling, cluster, pods, concern);
+
+        KafkaMetricsResponse replicationMetrics = null;
+        KafkaMetricsResponse performanceMetrics = null;
+        KafkaMetricsResponse resourceMetrics = null;
+        KafkaMetricsResponse throughputMetrics = null;
+
+        Map<String, KafkaMetricsResponse> categoryResults = gatherAllMetrics(
+            resolvedNs, name, areas, rangeMinutes, startTime, endTime, stepSeconds,
+            completed, failed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Metrics diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        if (categoryResults != null) {
+            replicationMetrics = categoryResults.get("replication");
+            performanceMetrics = categoryResults.get("performance");
+            resourceMetrics = categoryResults.get("resources");
+            throughputMetrics = categoryResults.get("throughput");
+        }
+
+        // === Phase 3: Final analysis ===
+        String analysis = produceAnalysis(sampling, cluster, pods,
+            replicationMetrics, performanceMetrics, resourceMetrics,
+            throughputMetrics, concern);
+
+        return KafkaMetricsDiagnosticReport.of(cluster, pods,
+            replicationMetrics, performanceMetrics, resourceMetrics,
+            throughputMetrics, analysis,
+            completed, failed.isEmpty() ? null : failed);
+    }
+
+    // ---- Phase 1: Initial data gathering ----
+
+    private KafkaClusterResponse gatherClusterStatus(final String namespace,
+                                                     final String clusterName,
+                                                     final Elicitation elicitation,
+                                                     final List<String> completed,
+                                                     final McpLog mcpLog) {
+        try {
+            KafkaClusterResponse result = kafkaService.getCluster(namespace, clusterName);
+            completed.add(STEP_CLUSTER_STATUS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked cluster status: " + result.readiness());
+            return result;
+        } catch (ToolCallException e) {
+            if (DiagnosticHelper.isMultipleNamespacesError(e)
+                    && elicitation != null && elicitation.isSupported()) {
+                String resolved = DiagnosticHelper.elicitNamespace(e, elicitation, "analyzed for metrics");
+                return gatherClusterStatus(resolved, clusterName, null,
+                    completed, mcpLog);
+            }
+            throw e;
+        }
+    }
+
+    private KafkaClusterPodsResponse gatherClusterPods(final String namespace,
+                                                       final String clusterName,
+                                                       final List<String> completed,
+                                                       final List<String> failed,
+                                                       final McpLog mcpLog) {
+        try {
+            KafkaClusterPodsResponse result = kafkaService.getClusterPods(namespace, clusterName);
+            completed.add(STEP_POD_HEALTH);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked pod health");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather pod health: %s", e.getMessage());
+            failed.add(STEP_POD_HEALTH + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Phase 2: Metrics investigation (single scrape) ----
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private Map<String, KafkaMetricsResponse> gatherAllMetrics(final String namespace,
+                                                                final String clusterName,
+                                                                final InvestigationAreas areas,
+                                                                final Integer rangeMinutes,
+                                                                final String startTime,
+                                                                final String endTime,
+                                                                final Integer stepSeconds,
+                                                                final List<String> completed,
+                                                                final List<String> failed,
+                                                                final McpLog mcpLog) {
+        // Collect all metric names from selected categories
+        Map<String, List<String>> categoryMetricNames = new LinkedHashMap<>();
+        if (areas.replication) {
+            categoryMetricNames.put("replication", KafkaMetricCategories.resolve("replication"));
+        }
+        if (areas.performance) {
+            categoryMetricNames.put("performance", KafkaMetricCategories.resolve("performance"));
+        }
+        if (areas.resources) {
+            categoryMetricNames.put("resources", KafkaMetricCategories.resolve("resources"));
+        }
+        if (areas.throughput) {
+            categoryMetricNames.put("throughput", KafkaMetricCategories.resolve("throughput"));
+        }
+
+        if (categoryMetricNames.isEmpty()) {
+            return Map.of();
+        }
+
+        // Merge all metric names and scrape once
+        String allNames = categoryMetricNames.values().stream()
+            .flatMap(List::stream)
+            .distinct()
+            .collect(Collectors.joining(","));
+
+        KafkaMetricsResponse allMetrics;
+        try {
+            allMetrics = kafkaMetricsService.getKafkaMetrics(
+                namespace, clusterName, null, allNames, rangeMinutes, startTime, endTime, stepSeconds);
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather metrics: %s", e.getMessage());
+            for (String cat : categoryMetricNames.keySet()) {
+                failed.add(categoryStepName(cat) + ": " + e.getMessage());
+            }
+            return null;
+        }
+
+        // Split results by category
+        Map<String, KafkaMetricsResponse> results = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : categoryMetricNames.entrySet()) {
+            String category = entry.getKey();
+            Set<String> names = new HashSet<>(entry.getValue());
+            List<MetricSample> categorySamples = allMetrics.metrics() != null
+                ? allMetrics.metrics().stream()
+                    .filter(s -> names.contains(s.name()))
+                    .toList()
+                : List.of();
+
+            String interpretation = KafkaMetricCategories.interpretation(List.of(category));
+            KafkaMetricsResponse categoryResponse = KafkaMetricsResponse.of(
+                allMetrics.clusterName(), allMetrics.namespace(),
+                allMetrics.provider(), List.of(category),
+                categorySamples, interpretation);
+            results.put(category, categoryResponse);
+            completed.add(categoryStepName(category));
+        }
+
+        DiagnosticHelper.sendClientNotification(mcpLog, String.format("Retrieved metrics for %d categories (single scrape)",
+            categoryMetricNames.size()));
+        return results;
+    }
+
+    private String categoryStepName(final String category) {
+        return switch (category) {
+            case "replication" -> STEP_REPLICATION_METRICS;
+            case "performance" -> STEP_PERFORMANCE_METRICS;
+            case "resources" -> STEP_RESOURCE_METRICS;
+            case "throughput" -> STEP_THROUGHPUT_METRICS;
+            default -> category + "_metrics";
+        };
+    }
+
+    // ---- Sampling: triage and analysis ----
+
+    private InvestigationAreas decideInvestigationAreas(final Sampling sampling,
+                                                        final KafkaClusterResponse cluster,
+                                                        final KafkaClusterPodsResponse pods,
+                                                        final String concern) {
+        if (sampling == null || !sampling.isSupported()) {
+            return InvestigationAreas.all();
+        }
+
+        try {
+            Map<String, Object> summary = buildPhase1Summary(cluster, pods, concern);
+            String summaryJson = objectMapper.writeValueAsString(summary);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(summaryJson))
+                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return parseInvestigationAreas(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling triage failed, investigating all areas: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private String produceAnalysis(final Sampling sampling,
+                                   final KafkaClusterResponse cluster,
+                                   final KafkaClusterPodsResponse pods,
+                                   final KafkaMetricsResponse replicationMetrics,
+                                   final KafkaMetricsResponse performanceMetrics,
+                                   final KafkaMetricsResponse resourceMetrics,
+                                   final KafkaMetricsResponse throughputMetrics,
+                                   final String concern) {
+        if (sampling == null || !sampling.isSupported()) {
+            return null;
+        }
+
+        try {
+            Map<String, Object> fullData = buildFullSummary(
+                cluster, pods, replicationMetrics, performanceMetrics,
+                resourceMetrics, throughputMetrics, concern);
+            String dataJson = objectMapper.writeValueAsString(fullData);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(dataJson))
+                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return DiagnosticHelper.extractSamplingText(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling analysis failed: %s", e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Helpers ----
+
+    private Map<String, Object> buildPhase1Summary(final KafkaClusterResponse cluster,
+                                                   final KafkaClusterPodsResponse pods,
+                                                   final String concern) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        if (concern != null) {
+            summary.put("concern", concern);
+        }
+        summary.put("cluster_readiness", cluster.readiness());
+        if (cluster.replicas() != null) {
+            summary.put("expected_replicas", cluster.replicas().expected());
+            summary.put("ready_replicas", cluster.replicas().ready());
+        }
+        if (pods != null) {
+            summary.put("pods", pods);
+        }
+        return summary;
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private Map<String, Object> buildFullSummary(final KafkaClusterResponse cluster,
+                                                 final KafkaClusterPodsResponse pods,
+                                                 final KafkaMetricsResponse replicationMetrics,
+                                                 final KafkaMetricsResponse performanceMetrics,
+                                                 final KafkaMetricsResponse resourceMetrics,
+                                                 final KafkaMetricsResponse throughputMetrics,
+                                                 final String concern) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        if (concern != null) {
+            data.put("concern", concern);
+        }
+        DiagnosticHelper.putIfNotNull(data, STEP_CLUSTER_STATUS, cluster);
+        DiagnosticHelper.putIfNotNull(data, STEP_POD_HEALTH, pods);
+        DiagnosticHelper.putIfNotNull(data, STEP_REPLICATION_METRICS, replicationMetrics);
+        DiagnosticHelper.putIfNotNull(data, STEP_PERFORMANCE_METRICS, performanceMetrics);
+        DiagnosticHelper.putIfNotNull(data, STEP_RESOURCE_METRICS, resourceMetrics);
+        DiagnosticHelper.putIfNotNull(data, STEP_THROUGHPUT_METRICS, throughputMetrics);
+        return data;
+    }
+
+    private InvestigationAreas parseInvestigationAreas(final SamplingResponse response) {
+        try {
+            String text = DiagnosticHelper.extractSamplingText(response);
+            Map<String, Object> parsed = objectMapper.readValue(text, DiagnosticHelper.MAP_TYPE_REF);
+            return new InvestigationAreas(
+                Boolean.TRUE.equals(parsed.get(STEP_REPLICATION_METRICS)),
+                Boolean.TRUE.equals(parsed.get(STEP_PERFORMANCE_METRICS)),
+                Boolean.TRUE.equals(parsed.get(STEP_RESOURCE_METRICS)),
+                Boolean.TRUE.equals(parsed.get(STEP_THROUGHPUT_METRICS))
+            );
+        } catch (Exception e) {
+            LOG.debugf("Could not parse triage response, investigating all: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    /**
+     * Flags indicating which metric categories the LLM recommended investigating.
+     *
+     * @param replication whether to gather replication metrics
+     * @param performance whether to gather performance metrics
+     * @param resources   whether to gather resource metrics
+     * @param throughput  whether to gather throughput metrics
+     */
+    record InvestigationAreas(boolean replication, boolean performance,
+                              boolean resources, boolean throughput) {
+
+        /**
+         * Returns areas with all flags set to true (fallback when Sampling is unavailable).
+         *
+         * @return investigation areas with all flags enabled
+         */
+        static InvestigationAreas all() {
+            return new InvestigationAreas(true, true, true, true);
+        }
+    }
+
+    // ---- Sampling system prompts ----
+
+    static final String TRIAGE_SYSTEM_PROMPT = """
+        You are a Kafka metrics diagnostics assistant. \
+        Analyze the cluster health and pod status to decide which metric categories \
+        need investigation. \
+        Return ONLY a JSON object with these boolean fields: \
+        replication_metrics, performance_metrics, resource_metrics, throughput_metrics. \
+        Set true only for categories likely to reveal the root cause. \
+        For example, if pods are healthy and cluster is Ready with no concern, set all to false. \
+        If pods show restarts or OOM, set resource_metrics and performance_metrics to true. \
+        If the concern mentions latency, set performance_metrics and throughput_metrics to true. \
+        If the concern mentions replication or lag, set replication_metrics to true.\
+        """;
+
+    static final String ANALYSIS_SYSTEM_PROMPT = """
+        You are analyzing Kafka cluster metrics to diagnose health issues. \
+        Analyze all gathered metrics data and produce a concise metrics-based diagnosis.
+        
+        Distinguish between:
+        1. Replication failures (CRITICAL): offline partitions, under-replicated partitions, growing lag
+        2. Performance degradation (HIGH): low handler idle, high queue times, network saturation
+        3. Resource exhaustion (MEDIUM): GC thrashing, high heap usage, CPU saturation
+        4. Throughput anomalies (LOW): rate drops, cross-broker imbalance
+        
+        Look for cascading failure patterns:
+        - Resource exhaustion -> performance degradation -> replication lag
+        - GC thrashing -> CPU spikes -> handler idle drops -> queue time increases
+        - Network saturation -> replication lag -> under-replicated partitions
+        
+        Structure your response as:
+        - Root cause (single most likely cause based on metrics)
+        - Severity (CRITICAL/HIGH/MEDIUM/LOW)
+        - Key metrics (specific values that support the diagnosis)
+        - Cascading effects (how the root cause propagates)
+        - Recommendations (prioritized, actionable steps)
+        
+        Correlate pod health (restarts, OOM) with metric patterns. \
+        A pod with recent restarts + high GC metrics suggests memory pressure.\
+        """;
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
@@ -22,6 +22,7 @@ import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
 import io.streamshub.mcp.strimzi.dto.KafkaMetricsDiagnosticReport;
 import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
 import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
+import io.streamshub.mcp.strimzi.util.NamespaceElicitationHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -54,10 +55,6 @@ public class KafkaMetricsDiagnosticService {
     private static final String DIAGNOSTIC_LABEL = "Kafka metrics diagnostic";
     private static final String STEP_CLUSTER_STATUS = "cluster_status";
     private static final String STEP_POD_HEALTH = "pod_health";
-    private static final String CATEGORY_REPLICATION = "replication";
-    private static final String CATEGORY_PERFORMANCE = "performance";
-    private static final String CATEGORY_RESOURCES = "resources";
-    private static final String CATEGORY_THROUGHPUT = "throughput";
     private static final String STEP_REPLICATION_METRICS = "replication_metrics";
     private static final String STEP_PERFORMANCE_METRICS = "performance_metrics";
     private static final String STEP_RESOURCE_METRICS = "resource_metrics";
@@ -159,10 +156,10 @@ public class KafkaMetricsDiagnosticService {
         DiagnosticHelper.checkCancellation(cancellation);
 
         if (categoryResults != null) {
-            replicationMetrics = categoryResults.get(CATEGORY_REPLICATION);
-            performanceMetrics = categoryResults.get(CATEGORY_PERFORMANCE);
-            resourceMetrics = categoryResults.get(CATEGORY_RESOURCES);
-            throughputMetrics = categoryResults.get(CATEGORY_THROUGHPUT);
+            replicationMetrics = categoryResults.get(KafkaMetricCategories.REPLICATION);
+            performanceMetrics = categoryResults.get(KafkaMetricCategories.PERFORMANCE);
+            resourceMetrics = categoryResults.get(KafkaMetricCategories.RESOURCES);
+            throughputMetrics = categoryResults.get(KafkaMetricCategories.THROUGHPUT);
         }
 
         // === Phase 3: Final analysis ===
@@ -189,9 +186,9 @@ public class KafkaMetricsDiagnosticService {
             DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka cluster status: " + result.readiness());
             return result;
         } catch (ToolCallException e) {
-            if (DiagnosticHelper.isMultipleNamespacesError(e)
+            if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
                     && elicitation != null && elicitation.isSupported()) {
-                String resolved = DiagnosticHelper.elicitNamespace(e, elicitation, "analyzed for metrics");
+                String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "analyzed for metrics");
                 return gatherClusterStatus(resolved, clusterName, null,
                     completed, mcpLog);
             }
@@ -232,16 +229,16 @@ public class KafkaMetricsDiagnosticService {
         // Collect all metric names from selected categories
         Map<String, List<String>> categoryMetricNames = new LinkedHashMap<>();
         if (areas.replication) {
-            categoryMetricNames.put(CATEGORY_REPLICATION, KafkaMetricCategories.resolve(CATEGORY_REPLICATION));
+            categoryMetricNames.put(KafkaMetricCategories.REPLICATION, KafkaMetricCategories.resolve(KafkaMetricCategories.REPLICATION));
         }
         if (areas.performance) {
-            categoryMetricNames.put(CATEGORY_PERFORMANCE, KafkaMetricCategories.resolve(CATEGORY_PERFORMANCE));
+            categoryMetricNames.put(KafkaMetricCategories.PERFORMANCE, KafkaMetricCategories.resolve(KafkaMetricCategories.PERFORMANCE));
         }
         if (areas.resources) {
-            categoryMetricNames.put(CATEGORY_RESOURCES, KafkaMetricCategories.resolve(CATEGORY_RESOURCES));
+            categoryMetricNames.put(KafkaMetricCategories.RESOURCES, KafkaMetricCategories.resolve(KafkaMetricCategories.RESOURCES));
         }
         if (areas.throughput) {
-            categoryMetricNames.put(CATEGORY_THROUGHPUT, KafkaMetricCategories.resolve(CATEGORY_THROUGHPUT));
+            categoryMetricNames.put(KafkaMetricCategories.THROUGHPUT, KafkaMetricCategories.resolve(KafkaMetricCategories.THROUGHPUT));
         }
 
         if (categoryMetricNames.isEmpty()) {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
@@ -24,6 +24,7 @@ import io.streamshub.mcp.strimzi.dto.metrics.KafkaMetricsResponse;
 import io.streamshub.mcp.strimzi.service.metrics.KafkaMetricsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
@@ -49,11 +50,14 @@ import java.util.stream.Collectors;
 public class KafkaMetricsDiagnosticService {
 
     private static final Logger LOG = Logger.getLogger(KafkaMetricsDiagnosticService.class);
-    private static final int TRIAGE_MAX_TOKENS = 200;
-    private static final int ANALYSIS_MAX_TOKENS = 1500;
     private static final int TOTAL_STEPS = 6;
+    private static final String DIAGNOSTIC_LABEL = "Kafka metrics diagnostic";
     private static final String STEP_CLUSTER_STATUS = "cluster_status";
     private static final String STEP_POD_HEALTH = "pod_health";
+    private static final String CATEGORY_REPLICATION = "replication";
+    private static final String CATEGORY_PERFORMANCE = "performance";
+    private static final String CATEGORY_RESOURCES = "resources";
+    private static final String CATEGORY_THROUGHPUT = "throughput";
     private static final String STEP_REPLICATION_METRICS = "replication_metrics";
     private static final String STEP_PERFORMANCE_METRICS = "performance_metrics";
     private static final String STEP_RESOURCE_METRICS = "resource_metrics";
@@ -67,6 +71,12 @@ public class KafkaMetricsDiagnosticService {
 
     @Inject
     ObjectMapper objectMapper;
+
+    @ConfigProperty(name = "mcp.sampling.triage-max-tokens", defaultValue = "200")
+    int triageMaxTokens;
+
+    @ConfigProperty(name = "mcp.sampling.analysis-max-tokens", defaultValue = "1500")
+    int analysisMaxTokens;
 
     KafkaMetricsDiagnosticService() {
     }
@@ -123,14 +133,14 @@ public class KafkaMetricsDiagnosticService {
         // === Phase 1: Initial data gathering ===
         KafkaClusterResponse cluster = gatherClusterStatus(
             ns, name, elicitation, completed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Metrics diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         String resolvedNs = cluster.namespace();
 
         KafkaClusterPodsResponse pods = gatherClusterPods(
             resolvedNs, name, completed, failed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Metrics diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         // === Phase 2: Metrics investigation (single scrape for all categories) ===
@@ -145,14 +155,14 @@ public class KafkaMetricsDiagnosticService {
         Map<String, KafkaMetricsResponse> categoryResults = gatherAllMetrics(
             resolvedNs, name, areas, rangeMinutes, startTime, endTime, stepSeconds,
             completed, failed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Metrics diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         if (categoryResults != null) {
-            replicationMetrics = categoryResults.get("replication");
-            performanceMetrics = categoryResults.get("performance");
-            resourceMetrics = categoryResults.get("resources");
-            throughputMetrics = categoryResults.get("throughput");
+            replicationMetrics = categoryResults.get(CATEGORY_REPLICATION);
+            performanceMetrics = categoryResults.get(CATEGORY_PERFORMANCE);
+            resourceMetrics = categoryResults.get(CATEGORY_RESOURCES);
+            throughputMetrics = categoryResults.get(CATEGORY_THROUGHPUT);
         }
 
         // === Phase 3: Final analysis ===
@@ -176,7 +186,7 @@ public class KafkaMetricsDiagnosticService {
         try {
             KafkaClusterResponse result = kafkaService.getCluster(namespace, clusterName);
             completed.add(STEP_CLUSTER_STATUS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked cluster status: " + result.readiness());
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka cluster status: " + result.readiness());
             return result;
         } catch (ToolCallException e) {
             if (DiagnosticHelper.isMultipleNamespacesError(e)
@@ -197,10 +207,10 @@ public class KafkaMetricsDiagnosticService {
         try {
             KafkaClusterPodsResponse result = kafkaService.getClusterPods(namespace, clusterName);
             completed.add(STEP_POD_HEALTH);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked pod health");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked Kafka pod health");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather pod health: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka pod health: %s", e.getMessage());
             failed.add(STEP_POD_HEALTH + ": " + e.getMessage());
             return null;
         }
@@ -222,16 +232,16 @@ public class KafkaMetricsDiagnosticService {
         // Collect all metric names from selected categories
         Map<String, List<String>> categoryMetricNames = new LinkedHashMap<>();
         if (areas.replication) {
-            categoryMetricNames.put("replication", KafkaMetricCategories.resolve("replication"));
+            categoryMetricNames.put(CATEGORY_REPLICATION, KafkaMetricCategories.resolve(CATEGORY_REPLICATION));
         }
         if (areas.performance) {
-            categoryMetricNames.put("performance", KafkaMetricCategories.resolve("performance"));
+            categoryMetricNames.put(CATEGORY_PERFORMANCE, KafkaMetricCategories.resolve(CATEGORY_PERFORMANCE));
         }
         if (areas.resources) {
-            categoryMetricNames.put("resources", KafkaMetricCategories.resolve("resources"));
+            categoryMetricNames.put(CATEGORY_RESOURCES, KafkaMetricCategories.resolve(CATEGORY_RESOURCES));
         }
         if (areas.throughput) {
-            categoryMetricNames.put("throughput", KafkaMetricCategories.resolve("throughput"));
+            categoryMetricNames.put(CATEGORY_THROUGHPUT, KafkaMetricCategories.resolve(CATEGORY_THROUGHPUT));
         }
 
         if (categoryMetricNames.isEmpty()) {
@@ -249,7 +259,7 @@ public class KafkaMetricsDiagnosticService {
             allMetrics = kafkaMetricsService.getKafkaMetrics(
                 namespace, clusterName, null, allNames, rangeMinutes, startTime, endTime, stepSeconds);
         } catch (Exception e) {
-            LOG.warnf("Failed to gather metrics: %s", e.getMessage());
+            LOG.warnf("Failed to gather Kafka metrics: %s", e.getMessage());
             for (String cat : categoryMetricNames.keySet()) {
                 failed.add(categoryStepName(cat) + ": " + e.getMessage());
             }
@@ -308,7 +318,7 @@ public class KafkaMetricsDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(summaryJson))
-                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .setMaxTokens(triageMaxTokens)
                 .build()
                 .sendAndAwait();
 
@@ -341,7 +351,7 @@ public class KafkaMetricsDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(dataJson))
-                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .setMaxTokens(analysisMaxTokens)
                 .build()
                 .sendAndAwait();
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
@@ -44,9 +44,8 @@ import java.util.Map;
 public class OperatorMetricsDiagnosticService {
 
     private static final Logger LOG = Logger.getLogger(OperatorMetricsDiagnosticService.class);
-    private static final int TRIAGE_MAX_TOKENS = 200;
-    private static final int ANALYSIS_MAX_TOKENS = 1500;
     private static final int TOTAL_STEPS = 5;
+    private static final String DIAGNOSTIC_LABEL = "Strimzi operator metrics diagnostic";
     private static final String STEP_OPERATOR_STATUS = "operator_status";
     private static final String STEP_RECONCILIATION_METRICS = "reconciliation_metrics";
     private static final String STEP_RESOURCE_METRICS = "resource_metrics";
@@ -64,6 +63,12 @@ public class OperatorMetricsDiagnosticService {
 
     @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
     int defaultTailLines;
+
+    @ConfigProperty(name = "mcp.sampling.triage-max-tokens", defaultValue = "200")
+    int triageMaxTokens;
+
+    @ConfigProperty(name = "mcp.sampling.analysis-max-tokens", defaultValue = "1500")
+    int analysisMaxTokens;
 
     OperatorMetricsDiagnosticService() {
     }
@@ -118,7 +123,7 @@ public class OperatorMetricsDiagnosticService {
         // === Phase 1: Initial data gathering ===
         StrimziOperatorResponse operator = gatherOperatorStatus(
             ns, name, completed, mcpLog);
-        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 
         String resolvedNs = operator.namespace();
@@ -134,7 +139,7 @@ public class OperatorMetricsDiagnosticService {
                 resolvedNs, resolvedName, cluster, "reconciliation",
                 rangeMinutes, startTime, endTime, stepSeconds,
                 STEP_RECONCILIATION_METRICS, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -144,7 +149,7 @@ public class OperatorMetricsDiagnosticService {
                 resolvedNs, resolvedName, cluster, "resources",
                 rangeMinutes, startTime, endTime, stepSeconds,
                 STEP_RESOURCE_METRICS, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -154,7 +159,7 @@ public class OperatorMetricsDiagnosticService {
                 resolvedNs, resolvedName, cluster, "jvm",
                 rangeMinutes, startTime, endTime, stepSeconds,
                 STEP_JVM_METRICS, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -162,7 +167,7 @@ public class OperatorMetricsDiagnosticService {
         if (areas.operatorLogs) {
             operatorLogs = gatherOperatorLogs(
                 resolvedNs, resolvedName, completed, failed, mcpLog);
-            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }
 
@@ -186,7 +191,8 @@ public class OperatorMetricsDiagnosticService {
         if (operatorName != null) {
             StrimziOperatorResponse result = operatorService.getOperator(namespace, operatorName);
             completed.add(STEP_OPERATOR_STATUS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Checked operator status: " + result.status());
+            DiagnosticHelper.sendClientNotification(mcpLog,
+                String.format("Checked Strimzi operator '%s' status: %s", result.name(), result.status()));
             return result;
         }
 
@@ -224,10 +230,11 @@ public class OperatorMetricsDiagnosticService {
                 namespace, operatorName, clusterName, category,
                 null, rangeMinutes, startTime, endTime, stepSeconds);
             completed.add(stepName);
-            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Retrieved %s metrics", category));
+            DiagnosticHelper.sendClientNotification(mcpLog,
+                String.format("Retrieved Strimzi operator %s metrics", category));
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather %s metrics: %s", category, e.getMessage());
+            LOG.warnf("Failed to gather Strimzi operator %s metrics: %s", category, e.getMessage());
             failed.add(stepName + ": " + e.getMessage());
             return null;
         }
@@ -245,10 +252,10 @@ public class OperatorMetricsDiagnosticService {
             StrimziOperatorLogsResponse result = operatorService.getOperatorLogs(
                 namespace, operatorName, params);
             completed.add(STEP_OPERATOR_LOGS);
-            DiagnosticHelper.sendClientNotification(mcpLog, "Collected operator logs");
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected Strimzi operator logs");
             return result;
         } catch (Exception e) {
-            LOG.warnf("Failed to gather operator logs: %s", e.getMessage());
+            LOG.warnf("Failed to gather Strimzi operator logs: %s", e.getMessage());
             failed.add(STEP_OPERATOR_LOGS + ": " + e.getMessage());
             return null;
         }
@@ -270,7 +277,7 @@ public class OperatorMetricsDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(summaryJson))
-                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .setMaxTokens(triageMaxTokens)
                 .build()
                 .sendAndAwait();
 
@@ -302,7 +309,7 @@ public class OperatorMetricsDiagnosticService {
             SamplingResponse response = sampling.requestBuilder()
                 .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
                 .addMessage(SamplingMessage.withUserRole(dataJson))
-                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .setMaxTokens(analysisMaxTokens)
                 .build()
                 .sendAndAwait();
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.LogCollectionParams;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.dto.OperatorMetricsDiagnosticReport;
+import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
+import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
+import io.streamshub.mcp.strimzi.dto.metrics.StrimziOperatorMetricsResponse;
+import io.streamshub.mcp.strimzi.service.metrics.StrimziOperatorMetricsService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Orchestrates a multistep metrics diagnostic workflow for Strimzi operators.
+ *
+ * <p>Gathers operator status, then selectively queries reconciliation, resource,
+ * and JVM metrics along with operator logs. Optionally uses MCP Sampling to get
+ * LLM analysis of intermediate results.</p>
+ *
+ * <p>Individual step failures do not abort the workflow. Failed steps are
+ * recorded and the report includes all data that was successfully gathered.</p>
+ */
+@ApplicationScoped
+public class OperatorMetricsDiagnosticService {
+
+    private static final Logger LOG = Logger.getLogger(OperatorMetricsDiagnosticService.class);
+    private static final int TRIAGE_MAX_TOKENS = 200;
+    private static final int ANALYSIS_MAX_TOKENS = 1500;
+    private static final int TOTAL_STEPS = 5;
+    private static final String STEP_OPERATOR_STATUS = "operator_status";
+    private static final String STEP_RECONCILIATION_METRICS = "reconciliation_metrics";
+    private static final String STEP_RESOURCE_METRICS = "resource_metrics";
+    private static final String STEP_JVM_METRICS = "jvm_metrics";
+    private static final String STEP_OPERATOR_LOGS = "operator_logs";
+
+    @Inject
+    StrimziOperatorService operatorService;
+
+    @Inject
+    StrimziOperatorMetricsService operatorMetricsService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
+    int defaultTailLines;
+
+    OperatorMetricsDiagnosticService() {
+    }
+
+    /**
+     * Run a multi-step metrics diagnostic workflow for a Strimzi operator.
+     *
+     * <p>Phase 1 gathers operator deployment status. Phase 2 uses Sampling
+     * (if supported) to decide which metric categories and logs need
+     * investigation, then gathers the selected areas. Phase 3 uses Sampling
+     * to produce an operator health diagnosis.</p>
+     *
+     * @param namespace    optional namespace
+     * @param operatorName optional operator deployment name
+     * @param clusterName  optional Kafka cluster name to include entity operator metrics
+     * @param concern      optional concern description for context
+     * @param rangeMinutes optional relative time range in minutes
+     * @param startTime    optional absolute start time (ISO 8601)
+     * @param endTime      optional absolute end time (ISO 8601)
+     * @param stepSeconds  optional range query step interval in seconds
+     * @param sampling     MCP Sampling for LLM analysis (may be unsupported)
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated operator metrics diagnostic report
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public OperatorMetricsDiagnosticReport diagnose(final String namespace,
+                                                    final String operatorName,
+                                                    final String clusterName,
+                                                    final String concern,
+                                                    final Integer rangeMinutes,
+                                                    final String startTime,
+                                                    final String endTime,
+                                                    final Integer stepSeconds,
+                                                    final Sampling sampling,
+                                                    final McpLog mcpLog,
+                                                    final Progress progress,
+                                                    final Cancellation cancellation) {
+        String ns = InputUtils.normalizeInput(namespace);
+        String name = InputUtils.normalizeInput(operatorName);
+        String cluster = InputUtils.normalizeInput(clusterName);
+
+        LOG.infof("Starting operator metrics diagnostic (namespace=%s, operator=%s, cluster=%s, concern=%s)",
+            ns != null ? ns : "auto", name != null ? name : "auto",
+            cluster != null ? cluster : "none", concern);
+
+        List<String> completed = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        int stepIndex = 0;
+
+        // === Phase 1: Initial data gathering ===
+        StrimziOperatorResponse operator = gatherOperatorStatus(
+            ns, name, completed, mcpLog);
+        DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+        DiagnosticHelper.checkCancellation(cancellation);
+
+        String resolvedNs = operator.namespace();
+        String resolvedName = operator.name();
+
+        // === Phase 2: Metrics investigation ===
+        InvestigationAreas areas = decideInvestigationAreas(
+            sampling, operator, concern);
+
+        StrimziOperatorMetricsResponse reconciliationMetrics = null;
+        if (areas.reconciliation) {
+            reconciliationMetrics = gatherMetrics(
+                resolvedNs, resolvedName, cluster, "reconciliation",
+                rangeMinutes, startTime, endTime, stepSeconds,
+                STEP_RECONCILIATION_METRICS, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        StrimziOperatorMetricsResponse resourceMetrics = null;
+        if (areas.resources) {
+            resourceMetrics = gatherMetrics(
+                resolvedNs, resolvedName, cluster, "resources",
+                rangeMinutes, startTime, endTime, stepSeconds,
+                STEP_RESOURCE_METRICS, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        StrimziOperatorMetricsResponse jvmMetrics = null;
+        if (areas.jvm) {
+            jvmMetrics = gatherMetrics(
+                resolvedNs, resolvedName, cluster, "jvm",
+                rangeMinutes, startTime, endTime, stepSeconds,
+                STEP_JVM_METRICS, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        StrimziOperatorLogsResponse operatorLogs = null;
+        if (areas.operatorLogs) {
+            operatorLogs = gatherOperatorLogs(
+                resolvedNs, resolvedName, completed, failed, mcpLog);
+            DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, "Operator metrics diagnostic");
+            DiagnosticHelper.checkCancellation(cancellation);
+        }
+
+        // === Phase 3: Final analysis ===
+        String analysis = produceAnalysis(sampling, operator,
+            reconciliationMetrics, resourceMetrics, jvmMetrics,
+            operatorLogs, concern);
+
+        return OperatorMetricsDiagnosticReport.of(operator,
+            reconciliationMetrics, resourceMetrics, jvmMetrics,
+            operatorLogs, analysis,
+            completed, failed.isEmpty() ? null : failed);
+    }
+
+    // ---- Phase 1: Initial data gathering ----
+
+    private StrimziOperatorResponse gatherOperatorStatus(final String namespace,
+                                                         final String operatorName,
+                                                         final List<String> completed,
+                                                         final McpLog mcpLog) {
+        if (operatorName != null) {
+            StrimziOperatorResponse result = operatorService.getOperator(namespace, operatorName);
+            completed.add(STEP_OPERATOR_STATUS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Checked operator status: " + result.status());
+            return result;
+        }
+
+        List<StrimziOperatorResponse> operators = operatorService.listOperators(namespace);
+        if (operators.isEmpty()) {
+            String location = namespace != null
+                ? "in namespace '" + namespace + "'"
+                : "in any namespace";
+            throw new ToolCallException("No Strimzi operator found " + location);
+        }
+
+        StrimziOperatorResponse result = operators.getFirst();
+        completed.add(STEP_OPERATOR_STATUS);
+        DiagnosticHelper.sendClientNotification(mcpLog, "Checked operator status: " + result.status());
+        return result;
+    }
+
+    // ---- Phase 2: Metrics investigation ----
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private StrimziOperatorMetricsResponse gatherMetrics(final String namespace,
+                                                         final String operatorName,
+                                                         final String clusterName,
+                                                         final String category,
+                                                         final Integer rangeMinutes,
+                                                         final String startTime,
+                                                         final String endTime,
+                                                         final Integer stepSeconds,
+                                                         final String stepName,
+                                                         final List<String> completed,
+                                                         final List<String> failed,
+                                                         final McpLog mcpLog) {
+        try {
+            StrimziOperatorMetricsResponse result = operatorMetricsService.getOperatorMetrics(
+                namespace, operatorName, clusterName, category,
+                null, rangeMinutes, startTime, endTime, stepSeconds);
+            completed.add(stepName);
+            DiagnosticHelper.sendClientNotification(mcpLog, String.format("Retrieved %s metrics", category));
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather %s metrics: %s", category, e.getMessage());
+            failed.add(stepName + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private StrimziOperatorLogsResponse gatherOperatorLogs(final String namespace,
+                                                           final String operatorName,
+                                                           final List<String> completed,
+                                                           final List<String> failed,
+                                                           final McpLog mcpLog) {
+        try {
+            LogCollectionParams params = LogCollectionParams.builder(defaultTailLines)
+                .filter("errors")
+                .build();
+            StrimziOperatorLogsResponse result = operatorService.getOperatorLogs(
+                namespace, operatorName, params);
+            completed.add(STEP_OPERATOR_LOGS);
+            DiagnosticHelper.sendClientNotification(mcpLog, "Collected operator logs");
+            return result;
+        } catch (Exception e) {
+            LOG.warnf("Failed to gather operator logs: %s", e.getMessage());
+            failed.add(STEP_OPERATOR_LOGS + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Sampling: triage and analysis ----
+
+    private InvestigationAreas decideInvestigationAreas(final Sampling sampling,
+                                                        final StrimziOperatorResponse operator,
+                                                        final String concern) {
+        if (sampling == null || !sampling.isSupported()) {
+            return InvestigationAreas.all();
+        }
+
+        try {
+            Map<String, Object> summary = buildPhase1Summary(operator, concern);
+            String summaryJson = objectMapper.writeValueAsString(summary);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(TRIAGE_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(summaryJson))
+                .setMaxTokens(TRIAGE_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return parseInvestigationAreas(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling triage failed, investigating all areas: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private String produceAnalysis(final Sampling sampling,
+                                   final StrimziOperatorResponse operator,
+                                   final StrimziOperatorMetricsResponse reconciliationMetrics,
+                                   final StrimziOperatorMetricsResponse resourceMetrics,
+                                   final StrimziOperatorMetricsResponse jvmMetrics,
+                                   final StrimziOperatorLogsResponse operatorLogs,
+                                   final String concern) {
+        if (sampling == null || !sampling.isSupported()) {
+            return null;
+        }
+
+        try {
+            Map<String, Object> fullData = buildFullSummary(
+                operator, reconciliationMetrics, resourceMetrics,
+                jvmMetrics, operatorLogs, concern);
+            String dataJson = objectMapper.writeValueAsString(fullData);
+
+            SamplingResponse response = sampling.requestBuilder()
+                .setSystemPrompt(ANALYSIS_SYSTEM_PROMPT)
+                .addMessage(SamplingMessage.withUserRole(dataJson))
+                .setMaxTokens(ANALYSIS_MAX_TOKENS)
+                .build()
+                .sendAndAwait();
+
+            return DiagnosticHelper.extractSamplingText(response);
+        } catch (Exception e) {
+            LOG.warnf("Sampling analysis failed: %s", e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Helpers ----
+
+    private Map<String, Object> buildPhase1Summary(final StrimziOperatorResponse operator,
+                                                   final String concern) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        if (concern != null) {
+            summary.put("concern", concern);
+        }
+        summary.put(STEP_OPERATOR_STATUS, operator.status());
+        summary.put("operator_ready", operator.ready());
+        if (operator.uptimeHours() != null) {
+            summary.put("uptime_hours", operator.uptimeHours());
+        }
+        if (operator.replicas() != null) {
+            summary.put("replicas", operator.replicas());
+            summary.put("ready_replicas", operator.readyReplicas());
+        }
+        return summary;
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private Map<String, Object> buildFullSummary(final StrimziOperatorResponse operator,
+                                                 final StrimziOperatorMetricsResponse reconciliationMetrics,
+                                                 final StrimziOperatorMetricsResponse resourceMetrics,
+                                                 final StrimziOperatorMetricsResponse jvmMetrics,
+                                                 final StrimziOperatorLogsResponse operatorLogs,
+                                                 final String concern) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        if (concern != null) {
+            data.put("concern", concern);
+        }
+        DiagnosticHelper.putIfNotNull(data, STEP_OPERATOR_STATUS, operator);
+        DiagnosticHelper.putIfNotNull(data, STEP_RECONCILIATION_METRICS, reconciliationMetrics);
+        DiagnosticHelper.putIfNotNull(data, STEP_RESOURCE_METRICS, resourceMetrics);
+        DiagnosticHelper.putIfNotNull(data, STEP_JVM_METRICS, jvmMetrics);
+        DiagnosticHelper.putIfNotNull(data, STEP_OPERATOR_LOGS, operatorLogs);
+        return data;
+    }
+
+    private InvestigationAreas parseInvestigationAreas(final SamplingResponse response) {
+        try {
+            String text = DiagnosticHelper.extractSamplingText(response);
+            Map<String, Object> parsed = objectMapper.readValue(text, DiagnosticHelper.MAP_TYPE_REF);
+            return new InvestigationAreas(
+                Boolean.TRUE.equals(parsed.get(STEP_RECONCILIATION_METRICS)),
+                Boolean.TRUE.equals(parsed.get(STEP_RESOURCE_METRICS)),
+                Boolean.TRUE.equals(parsed.get(STEP_JVM_METRICS)),
+                Boolean.TRUE.equals(parsed.get(STEP_OPERATOR_LOGS))
+            );
+        } catch (Exception e) {
+            LOG.debugf("Could not parse triage response, investigating all: %s", e.getMessage());
+            return InvestigationAreas.all();
+        }
+    }
+
+    /**
+     * Flags indicating which investigation areas the LLM recommended.
+     *
+     * @param reconciliation whether to gather reconciliation metrics
+     * @param resources      whether to gather resource metrics
+     * @param jvm            whether to gather JVM metrics
+     * @param operatorLogs   whether to gather operator logs
+     */
+    record InvestigationAreas(boolean reconciliation, boolean resources,
+                              boolean jvm, boolean operatorLogs) {
+
+        /**
+         * Returns areas with all flags set to true (fallback when Sampling is unavailable).
+         *
+         * @return investigation areas with all flags enabled
+         */
+        static InvestigationAreas all() {
+            return new InvestigationAreas(true, true, true, true);
+        }
+    }
+
+    // ---- Sampling system prompts ----
+
+    static final String TRIAGE_SYSTEM_PROMPT = """
+        You are a Strimzi operator diagnostics assistant. \
+        Analyze the operator health to decide which areas need deeper investigation. \
+        Return ONLY a JSON object with these boolean fields: \
+        reconciliation_metrics, resource_metrics, jvm_metrics, operator_logs. \
+        Set true only for areas likely to reveal the root cause. \
+        For example, if the operator is healthy with no concern, set all to false. \
+        If the operator shows degraded status, set reconciliation_metrics and operator_logs to true. \
+        If the concern mentions slow reconciliation, set reconciliation_metrics and jvm_metrics to true. \
+        If the concern mentions restarts or OOM, set resource_metrics, jvm_metrics, and operator_logs to true.\
+        """;
+
+    static final String ANALYSIS_SYSTEM_PROMPT = """
+        You are analyzing Strimzi operator metrics to diagnose operational issues. \
+        Analyze all gathered data and produce a concise operator health diagnosis.
+        
+        Distinguish between:
+        1. Reconciliation failures (CRITICAL): stuck reconciliations, high failure rates, timeout patterns
+        2. Resource exhaustion (HIGH): OOM kills, CPU throttling, pod restarts
+        3. JVM issues (MEDIUM): GC pressure, thread contention, heap exhaustion
+        4. Performance degradation (LOW): slow reconciliation times, growing queue depth
+        
+        Look for correlating patterns:
+        - High GC pause time -> reconciliation slowdown -> timeout failures
+        - Memory pressure -> OOM restarts -> reconciliation interruption
+        - Thread contention -> slow reconciliations -> backed-up queue
+        
+        Structure your response as:
+        - Root cause (single most likely cause based on metrics)
+        - Severity (CRITICAL/HIGH/MEDIUM/LOW)
+        - Key metrics (specific values that support the diagnosis)
+        - Impact on managed resources (how this affects Kafka clusters)
+        - Recommendations (prioritized, actionable steps)
+        
+        Correlate operator status (restarts, uptime) with metric patterns.\
+        """;
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
@@ -15,6 +15,7 @@ import io.quarkiverse.mcp.server.ToolCallException;
 import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.service.DiagnosticHelper;
 import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.config.metrics.StrimziOperatorMetricCategories;
 import io.streamshub.mcp.strimzi.dto.OperatorMetricsDiagnosticReport;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorLogsResponse;
 import io.streamshub.mcp.strimzi.dto.StrimziOperatorResponse;
@@ -136,7 +137,7 @@ public class OperatorMetricsDiagnosticService {
         StrimziOperatorMetricsResponse reconciliationMetrics = null;
         if (areas.reconciliation) {
             reconciliationMetrics = gatherMetrics(
-                resolvedNs, resolvedName, cluster, "reconciliation",
+                resolvedNs, resolvedName, cluster, StrimziOperatorMetricCategories.RECONCILIATION,
                 rangeMinutes, startTime, endTime, stepSeconds,
                 STEP_RECONCILIATION_METRICS, completed, failed, mcpLog);
             DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
@@ -146,7 +147,7 @@ public class OperatorMetricsDiagnosticService {
         StrimziOperatorMetricsResponse resourceMetrics = null;
         if (areas.resources) {
             resourceMetrics = gatherMetrics(
-                resolvedNs, resolvedName, cluster, "resources",
+                resolvedNs, resolvedName, cluster, StrimziOperatorMetricCategories.RESOURCES,
                 rangeMinutes, startTime, endTime, stepSeconds,
                 STEP_RESOURCE_METRICS, completed, failed, mcpLog);
             DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);
@@ -156,7 +157,7 @@ public class OperatorMetricsDiagnosticService {
         StrimziOperatorMetricsResponse jvmMetrics = null;
         if (areas.jvm) {
             jvmMetrics = gatherMetrics(
-                resolvedNs, resolvedName, cluster, "jvm",
+                resolvedNs, resolvedName, cluster, StrimziOperatorMetricCategories.JVM,
                 rangeMinutes, startTime, endTime, stepSeconds,
                 STEP_JVM_METRICS, completed, failed, mcpLog);
             DiagnosticHelper.sendProgress(progress, ++stepIndex, TOTAL_STEPS, DIAGNOSTIC_LABEL);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaExporterMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaExporterMetricsService.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class KafkaExporterMetricsService {
 
     private static final Logger LOG = Logger.getLogger(KafkaExporterMetricsService.class);
-    private static final String DEFAULT_CATEGORY = "consumer_lag";
+    private static final String DEFAULT_CATEGORY = KafkaExporterMetricCategories.CONSUMER_LAG;
 
     @Inject
     KubernetesResourceService k8sService;

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public class KafkaMetricsService {
 
     private static final Logger LOG = Logger.getLogger(KafkaMetricsService.class);
-    private static final String DEFAULT_CATEGORY = "replication";
+    private static final String DEFAULT_CATEGORY = KafkaMetricCategories.REPLICATION;
 
     @Inject
     KubernetesResourceService k8sService;

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class StrimziOperatorMetricsService {
 
     private static final Logger LOG = Logger.getLogger(StrimziOperatorMetricsService.class);
-    private static final String DEFAULT_CATEGORY = "reconciliation";
+    private static final String DEFAULT_CATEGORY = StrimziOperatorMetricCategories.RECONCILIATION;
 
     @Inject
     MetricsQueryService metricsQueryService;

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/DiagnosticTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/DiagnosticTools.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.tool;
+
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.WrapBusinessError;
+import io.streamshub.mcp.common.guardrail.Guarded;
+import io.streamshub.mcp.strimzi.config.StrimziToolsPrompts;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterDiagnosticReport;
+import io.streamshub.mcp.strimzi.dto.KafkaConnectivityDiagnosticReport;
+import io.streamshub.mcp.strimzi.dto.KafkaMetricsDiagnosticReport;
+import io.streamshub.mcp.strimzi.dto.OperatorMetricsDiagnosticReport;
+import io.streamshub.mcp.strimzi.service.KafkaClusterDiagnosticService;
+import io.streamshub.mcp.strimzi.service.KafkaConnectivityDiagnosticService;
+import io.streamshub.mcp.strimzi.service.KafkaMetricsDiagnosticService;
+import io.streamshub.mcp.strimzi.service.OperatorMetricsDiagnosticService;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * MCP tool for composite Kafka cluster diagnosis.
+ *
+ * <p>Runs a multi-step diagnostic workflow in a single tool call,
+ * using Sampling for LLM analysis and Elicitation for user input.</p>
+ */
+@Singleton
+@Guarded
+@WrapBusinessError(Exception.class)
+public class DiagnosticTools {
+
+    @Inject
+    KafkaClusterDiagnosticService clusterDiagnosticService;
+
+    @Inject
+    KafkaConnectivityDiagnosticService connectivityDiagnosticService;
+
+    @Inject
+    KafkaMetricsDiagnosticService metricsDiagnosticService;
+
+    @Inject
+    OperatorMetricsDiagnosticService operatorMetricsDiagnosticService;
+
+    DiagnosticTools() {
+    }
+
+    /**
+     * Run a composite diagnostic workflow for a Kafka cluster.
+     *
+     * @param clusterName  the Kafka cluster name
+     * @param namespace    optional namespace
+     * @param symptom      optional symptom description
+     * @param sinceMinutes optional time window for logs and events
+     * @param sampling     MCP Sampling for LLM analysis
+     * @param elicitation  MCP Elicitation for user input
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated diagnostic report
+     */
+    @Tool(
+        name = "diagnose_kafka_cluster",
+        description = "Runs a multi-step diagnostic workflow for a Kafka cluster."
+            + " Gathers cluster status, node pools, pods, operator logs, cluster logs,"
+            + " events, and metrics in a single call."
+            + " Uses Sampling to get LLM analysis of intermediate results"
+            + " and Elicitation to resolve ambiguity (e.g., multiple namespaces)."
+            + " Falls back to gathering all data when Sampling is not supported."
+    )
+    public KafkaClusterDiagnosticReport diagnoseKafkaCluster(
+        @ToolArg(
+            description = StrimziToolsPrompts.CLUSTER_DESC
+        ) final String clusterName,
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace,
+        @ToolArg(
+            description = StrimziToolsPrompts.SYMPTOM_DESC,
+            required = false
+        ) final String symptom,
+        @ToolArg(
+            description = StrimziToolsPrompts.SINCE_MINUTES_DESC,
+            required = false
+        ) final Integer sinceMinutes,
+        final Sampling sampling,
+        final Elicitation elicitation,
+        final McpLog mcpLog,
+        final Progress progress,
+        final Cancellation cancellation
+    ) {
+        return clusterDiagnosticService.diagnose(
+            namespace, clusterName, symptom, sinceMinutes,
+            sampling, elicitation, mcpLog, progress, cancellation);
+    }
+
+    /**
+     * Run a composite connectivity diagnostic for a Kafka cluster.
+     *
+     * @param clusterName  the Kafka cluster name
+     * @param namespace    optional namespace
+     * @param listenerName optional listener to focus on
+     * @param sampling     MCP Sampling for LLM analysis
+     * @param elicitation  MCP Elicitation for user input
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated connectivity diagnostic report
+     */
+    @Tool(
+        name = "diagnose_kafka_connectivity",
+        description = "Runs a multi-step connectivity diagnostic for a Kafka cluster."
+            + " Checks listeners, bootstrap addresses, TLS certificates,"
+            + " authentication, pod health, and connection-related logs."
+            + " Uses Sampling for analysis and Elicitation for disambiguation."
+            + " Falls back to gathering all data when Sampling is not supported."
+    )
+    public KafkaConnectivityDiagnosticReport diagnoseKafkaConnectivity(
+        @ToolArg(
+            description = StrimziToolsPrompts.CLUSTER_DESC
+        ) final String clusterName,
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace,
+        @ToolArg(
+            description = StrimziToolsPrompts.LISTENER_DESC,
+            required = false
+        ) final String listenerName,
+        final Sampling sampling,
+        final Elicitation elicitation,
+        final McpLog mcpLog,
+        final Progress progress,
+        final Cancellation cancellation
+    ) {
+        return connectivityDiagnosticService.diagnose(
+            namespace, clusterName, listenerName,
+            sampling, elicitation, mcpLog, progress, cancellation);
+    }
+
+    /**
+     * Run a composite metrics diagnostic workflow for a Kafka cluster.
+     *
+     * @param clusterName  the Kafka cluster name
+     * @param namespace    optional namespace
+     * @param concern      optional concern description
+     * @param rangeMinutes optional relative time range in minutes
+     * @param startTime    optional absolute start time (ISO 8601)
+     * @param endTime      optional absolute end time (ISO 8601)
+     * @param stepSeconds  optional range query step interval in seconds
+     * @param sampling     MCP Sampling for LLM analysis
+     * @param elicitation  MCP Elicitation for user input
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated metrics diagnostic report
+     */
+    @Tool(
+        name = "diagnose_kafka_metrics",
+        description = "Runs a multi-step metrics diagnostic for a Kafka cluster."
+            + " Gathers cluster status and pod health, then selectively queries"
+            + " replication, performance, resource, and throughput metrics."
+            + " Uses Sampling for analysis and Elicitation for disambiguation."
+            + " Falls back to gathering all metric categories when Sampling is not supported."
+    )
+    public KafkaMetricsDiagnosticReport diagnoseKafkaMetrics(
+        @ToolArg(
+            description = StrimziToolsPrompts.CLUSTER_DESC
+        ) final String clusterName,
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace,
+        @ToolArg(
+            description = StrimziToolsPrompts.CONCERN_DESC,
+            required = false
+        ) final String concern,
+        @ToolArg(
+            description = StrimziToolsPrompts.RANGE_MINUTES_DESC,
+            required = false
+        ) final Integer rangeMinutes,
+        @ToolArg(
+            description = StrimziToolsPrompts.START_TIME_DESC,
+            required = false
+        ) final String startTime,
+        @ToolArg(
+            description = StrimziToolsPrompts.END_TIME_DESC,
+            required = false
+        ) final String endTime,
+        @ToolArg(
+            description = StrimziToolsPrompts.STEP_SECONDS_DESC,
+            required = false
+        ) final Integer stepSeconds,
+        final Sampling sampling,
+        final Elicitation elicitation,
+        final McpLog mcpLog,
+        final Progress progress,
+        final Cancellation cancellation
+    ) {
+        return metricsDiagnosticService.diagnose(
+            namespace, clusterName, concern,
+            rangeMinutes, startTime, endTime, stepSeconds,
+            sampling, elicitation, mcpLog, progress, cancellation);
+    }
+
+    /**
+     * Run a composite metrics diagnostic workflow for a Strimzi operator.
+     *
+     * @param namespace    optional namespace
+     * @param operatorName optional operator deployment name
+     * @param clusterName  optional Kafka cluster name for entity operator metrics
+     * @param concern      optional concern description
+     * @param rangeMinutes optional relative time range in minutes
+     * @param startTime    optional absolute start time (ISO 8601)
+     * @param endTime      optional absolute end time (ISO 8601)
+     * @param stepSeconds  optional range query step interval in seconds
+     * @param sampling     MCP Sampling for LLM analysis
+     * @param mcpLog       MCP log for progress notifications
+     * @param progress     MCP progress tracking
+     * @param cancellation MCP cancellation checking
+     * @return a consolidated operator metrics diagnostic report
+     */
+    @Tool(
+        name = "diagnose_operator_metrics",
+        description = "Runs a multi-step metrics diagnostic for a Strimzi operator."
+            + " Gathers operator status, then selectively queries reconciliation,"
+            + " resource, and JVM metrics along with operator logs."
+            + " Uses Sampling for analysis."
+            + " Falls back to gathering all data when Sampling is not supported."
+    )
+    public OperatorMetricsDiagnosticReport diagnoseOperatorMetrics(
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace,
+        @ToolArg(
+            description = StrimziToolsPrompts.OPERATOR_NAME_DESC,
+            required = false
+        ) final String operatorName,
+        @ToolArg(
+            description = StrimziToolsPrompts.OPERATOR_CLUSTER_DESC,
+            required = false
+        ) final String clusterName,
+        @ToolArg(
+            description = StrimziToolsPrompts.CONCERN_DESC,
+            required = false
+        ) final String concern,
+        @ToolArg(
+            description = StrimziToolsPrompts.RANGE_MINUTES_DESC,
+            required = false
+        ) final Integer rangeMinutes,
+        @ToolArg(
+            description = StrimziToolsPrompts.START_TIME_DESC,
+            required = false
+        ) final String startTime,
+        @ToolArg(
+            description = StrimziToolsPrompts.END_TIME_DESC,
+            required = false
+        ) final String endTime,
+        @ToolArg(
+            description = StrimziToolsPrompts.STEP_SECONDS_DESC,
+            required = false
+        ) final Integer stepSeconds,
+        final Sampling sampling,
+        final McpLog mcpLog,
+        final Progress progress,
+        final Cancellation cancellation
+    ) {
+        return operatorMetricsDiagnosticService.diagnose(
+            namespace, operatorName, clusterName, concern,
+            rangeMinutes, startTime, endTime, stepSeconds,
+            sampling, mcpLog, progress, cancellation);
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/util/NamespaceElicitationHelper.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/util/NamespaceElicitationHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.util;
+
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Strimzi-specific helpers for resolving namespace ambiguity via MCP Elicitation.
+ *
+ * <p>When a Kafka cluster exists in multiple namespaces, these utilities
+ * parse the Strimzi-specific error message and delegate to
+ * {@link DiagnosticHelper#elicitSelection} for the generic Elicitation call.</p>
+ */
+public final class NamespaceElicitationHelper {
+
+    private static final Pattern NAMESPACES_PATTERN = Pattern.compile("namespaces: (.+)\\. Please");
+
+    private NamespaceElicitationHelper() {
+    }
+
+    /**
+     * Check if a {@link ToolCallException} indicates multiple Kafka clusters
+     * found in different namespaces.
+     *
+     * @param e the exception
+     * @return true if the error is a multi-namespace ambiguity
+     */
+    public static boolean isMultipleNamespacesError(final ToolCallException e) {
+        return e.getMessage() != null && e.getMessage().contains("Multiple clusters named");
+    }
+
+    /**
+     * Ask the user to select a namespace via MCP Elicitation when a Kafka cluster
+     * exists in multiple namespaces. Parses the namespace list from the Strimzi
+     * error message and delegates to {@link DiagnosticHelper#elicitSelection}.
+     *
+     * @param error       the original ambiguity error
+     * @param elicitation the MCP Elicitation interface
+     * @param context     descriptive context for the prompt (e.g., "diagnosed", "checked for connectivity")
+     * @return the selected namespace
+     * @throws ToolCallException the original error if namespaces cannot be parsed,
+     *                           elicitation fails, or the user declines
+     */
+    public static String elicitNamespace(final ToolCallException error,
+                                          final Elicitation elicitation,
+                                          final String context) {
+        List<String> namespaces = parseNamespacesFromError(error.getMessage());
+        if (namespaces.isEmpty()) {
+            throw error;
+        }
+
+        String selected = DiagnosticHelper.elicitSelection(
+            elicitation,
+            "The Kafka cluster exists in multiple namespaces. Which namespace should be " + context + "?",
+            "namespace",
+            "Select the namespace",
+            namespaces);
+
+        if (selected != null) {
+            return selected;
+        }
+        throw error;
+    }
+
+    /**
+     * Parse namespace names from a "Multiple clusters named 'x' found in namespaces: a, b" error.
+     *
+     * @param message the error message
+     * @return list of namespace names
+     */
+    public static List<String> parseNamespacesFromError(final String message) {
+        if (message == null) {
+            return List.of();
+        }
+        Matcher matcher = NAMESPACES_PATTERN.matcher(message);
+        if (matcher.find()) {
+            return Arrays.stream(matcher.group(1).split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        }
+        return List.of();
+    }
+}

--- a/strimzi-mcp/src/main/resources/application.properties
+++ b/strimzi-mcp/src/main/resources/application.properties
@@ -85,6 +85,14 @@ mcp.metrics.prometheus.sa-token-path=/var/run/secrets/kubernetes.io/serviceaccou
 
 # OAuth2/OIDC: not yet supported — planned for future release
 
+# =============================================================================
+# Sampling Configuration (LLM-powered diagnostic analysis)
+# =============================================================================
+# Max tokens for triage requests (decides which areas to investigate)
+mcp.sampling.triage-max-tokens=200
+# Max tokens for analysis requests (produces root cause analysis)
+mcp.sampling.analysis-max-tokens=1500
+
 # Logging Configuration
 %dev.quarkus.log.category."io.streamshub.mcp".level=DEBUG
 quarkus.log.category."io.quarkiverse.mcp".level=INFO

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticServiceTest.java
@@ -22,8 +22,8 @@ import io.fabric8.kubernetes.client.dsl.V1APIGroupDSL;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.streamshub.mcp.common.service.DiagnosticHelper;
 import io.streamshub.mcp.strimzi.dto.KafkaClusterDiagnosticReport;
+import io.streamshub.mcp.strimzi.util.NamespaceElicitationHelper;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
@@ -145,7 +145,7 @@ class KafkaClusterDiagnosticServiceTest {
 
     @Test
     void testParseNamespacesFromError() {
-        List<String> namespaces = DiagnosticHelper.parseNamespacesFromError(
+        List<String> namespaces = NamespaceElicitationHelper.parseNamespacesFromError(
             "Multiple clusters named 'my-cluster' found in namespaces: kafka-prod, kafka-dev. Please specify namespace.");
 
         assertEquals(2, namespaces.size());
@@ -155,12 +155,12 @@ class KafkaClusterDiagnosticServiceTest {
 
     @Test
     void testParseNamespacesFromErrorReturnsEmptyForNull() {
-        assertTrue(DiagnosticHelper.parseNamespacesFromError(null).isEmpty());
+        assertTrue(NamespaceElicitationHelper.parseNamespacesFromError(null).isEmpty());
     }
 
     @Test
     void testParseNamespacesFromErrorReturnsEmptyForUnrelatedMessage() {
-        assertTrue(DiagnosticHelper.parseNamespacesFromError("Some other error").isEmpty());
+        assertTrue(NamespaceElicitationHelper.parseNamespacesFromError("Some other error").isEmpty());
     }
 
     // ---- Test helpers ----

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticServiceTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.EventList;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.fabric8.kubernetes.client.dsl.V1APIGroupDSL;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.strimzi.dto.KafkaClusterDiagnosticReport;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolList;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link KafkaClusterDiagnosticService}.
+ */
+@QuarkusTest
+class KafkaClusterDiagnosticServiceTest {
+
+    @InjectMock
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    KafkaClusterDiagnosticService diagnosticService;
+
+    KafkaClusterDiagnosticServiceTest() {
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        // Mock pods (empty by default)
+        MixedOperation<Pod, PodList, PodResource> podOp = Mockito.mock(MixedOperation.class);
+        Mockito.lenient().when(kubernetesClient.pods()).thenReturn(podOp);
+
+        // Mock deployments (for operator lookups)
+        MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentOp =
+            Mockito.mock(MixedOperation.class);
+        AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
+        Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
+        Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        // Mock events (empty by default)
+        setupEmptyEvents();
+    }
+
+    @Test
+    void testThrowsWhenClusterNameMissing() {
+        assertThrows(ToolCallException.class, () ->
+            diagnosticService.diagnose("kafka", null, null, null,
+                null, null, null, null, null));
+    }
+
+    @Test
+    void testThrowsWhenClusterNotFound() {
+        assertThrows(ToolCallException.class, () ->
+            diagnosticService.diagnose("kafka", "missing-cluster", null, null,
+                null, null, null, null, null));
+    }
+
+    @Test
+    void testFullWorkflowWithHealthyCluster() {
+        setupKafkaCluster("my-cluster", "kafka", true);
+        setupNodePools("kafka");
+
+        KafkaClusterDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "my-cluster", null, null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertEquals("my-cluster", report.cluster().name());
+        assertEquals("kafka", report.cluster().namespace());
+        assertNotNull(report.stepsCompleted());
+        assertTrue(report.stepsCompleted().contains("cluster_status"));
+        assertTrue(report.stepsCompleted().contains("node_pools"));
+        assertTrue(report.stepsCompleted().contains("pod_health"));
+        assertNotNull(report.timestamp());
+        assertNotNull(report.message());
+        // No sampling → analysis should be null
+        assertNull(report.analysis());
+    }
+
+    @Test
+    void testStepFailureDoesNotAbortWorkflow() {
+        setupKafkaCluster("my-cluster", "kafka", false);
+        // Node pools will return empty (no mock), events/metrics will fail
+        // But the workflow should still complete
+
+        KafkaClusterDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "my-cluster", "NotReady", 15,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertNotNull(report.cluster());
+        assertEquals("Error", report.cluster().readiness());
+        // Some steps should have failed (metrics at least, since no provider is mocked)
+        assertTrue(report.stepsCompleted().contains("cluster_status"));
+    }
+
+    @Test
+    void testReportIncludesSymptomContext() {
+        setupKafkaCluster("my-cluster", "kafka", true);
+
+        KafkaClusterDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "my-cluster", "pods restarting", null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertNotNull(report.message());
+        assertTrue(report.message().contains("my-cluster"));
+    }
+
+    @Test
+    void testParseNamespacesFromError() {
+        List<String> namespaces = DiagnosticHelper.parseNamespacesFromError(
+            "Multiple clusters named 'my-cluster' found in namespaces: kafka-prod, kafka-dev. Please specify namespace.");
+
+        assertEquals(2, namespaces.size());
+        assertEquals("kafka-prod", namespaces.get(0));
+        assertEquals("kafka-dev", namespaces.get(1));
+    }
+
+    @Test
+    void testParseNamespacesFromErrorReturnsEmptyForNull() {
+        assertTrue(DiagnosticHelper.parseNamespacesFromError(null).isEmpty());
+    }
+
+    @Test
+    void testParseNamespacesFromErrorReturnsEmptyForUnrelatedMessage() {
+        assertTrue(DiagnosticHelper.parseNamespacesFromError("Some other error").isEmpty());
+    }
+
+    // ---- Test helpers ----
+
+    @SuppressWarnings("unchecked")
+    private void setupKafkaCluster(final String name, final String namespace, final boolean ready) {
+        KafkaStatusBuilder statusBuilder = new KafkaStatusBuilder();
+        if (ready) {
+            statusBuilder.addNewCondition()
+                .withType("Ready")
+                .withStatus("True")
+                .endCondition();
+        } else {
+            statusBuilder.addNewCondition()
+                .withType("Ready")
+                .withStatus("False")
+                .withReason("PodNotReady")
+                .withMessage("1 out of 3 brokers not ready")
+                .endCondition();
+        }
+
+        Kafka kafka = new KafkaBuilder()
+            .withNewMetadata().withName(name).withNamespace(namespace).endMetadata()
+            .withStatus(statusBuilder.build())
+            .build();
+
+        MixedOperation kafkaOp = Mockito.mock(MixedOperation.class);
+        when(kubernetesClient.resources(Kafka.class)).thenReturn(kafkaOp);
+
+        NonNamespaceOperation nsKafkaOp = Mockito.mock(NonNamespaceOperation.class);
+        when(kafkaOp.inNamespace(namespace)).thenReturn(nsKafkaOp);
+
+        Resource kafkaResource = Mockito.mock(Resource.class);
+        when(nsKafkaOp.withName(name)).thenReturn(kafkaResource);
+        when(kafkaResource.get()).thenReturn(kafka);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupNodePools(final String namespace) {
+        MixedOperation nodePoolOp = Mockito.mock(MixedOperation.class);
+        Mockito.lenient().when(kubernetesClient.resources(KafkaNodePool.class)).thenReturn(nodePoolOp);
+
+        NonNamespaceOperation nsNodePoolOp = Mockito.mock(NonNamespaceOperation.class);
+        Mockito.lenient().when(nodePoolOp.inNamespace(namespace)).thenReturn(nsNodePoolOp);
+
+        FilterWatchListDeletable filteredNodePools = Mockito.mock(FilterWatchListDeletable.class);
+        Mockito.lenient().when(nsNodePoolOp.withLabel(anyString(), anyString())).thenReturn(filteredNodePools);
+
+        KafkaNodePoolList emptyList = new KafkaNodePoolList();
+        emptyList.setItems(List.of());
+        Mockito.lenient().when(filteredNodePools.list()).thenReturn(emptyList);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupEmptyEvents() {
+        V1APIGroupDSL v1 = Mockito.mock(V1APIGroupDSL.class);
+        Mockito.lenient().when(kubernetesClient.v1()).thenReturn(v1);
+
+        MixedOperation<Event, EventList, Resource<Event>> eventOp = Mockito.mock(MixedOperation.class);
+        Mockito.lenient().when(v1.events()).thenReturn(eventOp);
+
+        NonNamespaceOperation<Event, EventList, Resource<Event>> nsEventOp =
+            Mockito.mock(NonNamespaceOperation.class);
+        Mockito.lenient().when(eventOp.inNamespace(anyString())).thenReturn(nsEventOp);
+
+        FilterWatchListDeletable<Event, EventList, Resource<Event>> fieldEventOp =
+            Mockito.mock(FilterWatchListDeletable.class);
+        Mockito.lenient().when(nsEventOp.withField(anyString(), anyString())).thenReturn(fieldEventOp);
+        Mockito.lenient().when(fieldEventOp.withField(anyString(), anyString())).thenReturn(fieldEventOp);
+
+        EventList emptyEventList = new EventList();
+        emptyEventList.setItems(List.of());
+        Mockito.lenient().when(fieldEventOp.list()).thenReturn(emptyEventList);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticServiceTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.strimzi.dto.KafkaConnectivityDiagnosticReport;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.ListenerStatusBuilder;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link KafkaConnectivityDiagnosticService}.
+ */
+@QuarkusTest
+class KafkaConnectivityDiagnosticServiceTest {
+
+    @InjectMock
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    KafkaConnectivityDiagnosticService connectivityDiagnosticService;
+
+    KafkaConnectivityDiagnosticServiceTest() {
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MixedOperation<Pod, PodList, PodResource> podOp = Mockito.mock(MixedOperation.class);
+        Mockito.lenient().when(kubernetesClient.pods()).thenReturn(podOp);
+
+        MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentOp =
+            Mockito.mock(MixedOperation.class);
+        AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
+        Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
+        Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+    }
+
+    @Test
+    void testThrowsWhenClusterNameMissing() {
+        assertThrows(ToolCallException.class, () ->
+            connectivityDiagnosticService.diagnose("kafka", null, null,
+                null, null, null, null, null));
+    }
+
+    @Test
+    void testThrowsWhenClusterNotFound() {
+        assertThrows(ToolCallException.class, () ->
+            connectivityDiagnosticService.diagnose("kafka", "missing-cluster", null,
+                null, null, null, null, null));
+    }
+
+    @Test
+    void testFullWorkflowWithListeners() {
+        setupKafkaClusterWithListeners("my-cluster", "kafka");
+
+        KafkaConnectivityDiagnosticReport report = connectivityDiagnosticService.diagnose(
+            "kafka", "my-cluster", null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertEquals("my-cluster", report.cluster().name());
+        assertEquals("kafka", report.cluster().namespace());
+        assertTrue(report.stepsCompleted().contains("cluster_status"));
+        assertTrue(report.stepsCompleted().contains("bootstrap_servers"));
+        assertNotNull(report.bootstrapServers());
+        assertNull(report.analysis());
+        assertNotNull(report.timestamp());
+    }
+
+    @Test
+    void testStepFailureDoesNotAbortWorkflow() {
+        setupKafkaCluster("my-cluster", "kafka");
+        // Certificates will fail (no secret mock), pods empty, logs empty
+        // But workflow should complete
+
+        KafkaConnectivityDiagnosticReport report = connectivityDiagnosticService.diagnose(
+            "kafka", "my-cluster", null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertTrue(report.stepsCompleted().contains("cluster_status"));
+    }
+
+    @Test
+    void testWithListenerNameFilter() {
+        setupKafkaClusterWithListeners("my-cluster", "kafka");
+
+        KafkaConnectivityDiagnosticReport report = connectivityDiagnosticService.diagnose(
+            "kafka", "my-cluster", "tls",
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertNotNull(report.cluster());
+        assertTrue(report.message().contains("my-cluster"));
+    }
+
+    @Test
+    void testParseNamespacesFromError() {
+        List<String> namespaces = DiagnosticHelper.parseNamespacesFromError(
+            "Multiple clusters named 'my-cluster' found in namespaces: ns-a, ns-b. Please specify namespace.");
+
+        assertEquals(2, namespaces.size());
+        assertEquals("ns-a", namespaces.get(0));
+        assertEquals("ns-b", namespaces.get(1));
+    }
+
+    @Test
+    void testParseNamespacesFromErrorReturnsEmptyForNull() {
+        assertTrue(DiagnosticHelper.parseNamespacesFromError(null).isEmpty());
+    }
+
+    // ---- Test helpers ----
+
+    @SuppressWarnings("unchecked")
+    private void setupKafkaCluster(final String name, final String namespace) {
+        Kafka kafka = new KafkaBuilder()
+            .withNewMetadata().withName(name).withNamespace(namespace).endMetadata()
+            .withNewStatus()
+                .addNewCondition()
+                    .withType("Ready")
+                    .withStatus("True")
+                .endCondition()
+            .endStatus()
+            .build();
+
+        MixedOperation kafkaOp = Mockito.mock(MixedOperation.class);
+        when(kubernetesClient.resources(Kafka.class)).thenReturn(kafkaOp);
+
+        NonNamespaceOperation nsKafkaOp = Mockito.mock(NonNamespaceOperation.class);
+        when(kafkaOp.inNamespace(namespace)).thenReturn(nsKafkaOp);
+
+        Resource kafkaResource = Mockito.mock(Resource.class);
+        when(nsKafkaOp.withName(name)).thenReturn(kafkaResource);
+        when(kafkaResource.get()).thenReturn(kafka);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupKafkaClusterWithListeners(final String name, final String namespace) {
+        Kafka kafka = new KafkaBuilder()
+            .withNewMetadata().withName(name).withNamespace(namespace).endMetadata()
+            .withNewSpec()
+                .withNewKafka()
+                    .addNewListener()
+                        .withName("plain")
+                        .withPort(9092)
+                        .withType(io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType.INTERNAL)
+                        .withTls(false)
+                    .endListener()
+                    .addNewListener()
+                        .withName("tls")
+                        .withPort(9093)
+                        .withType(io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType.INTERNAL)
+                        .withTls(true)
+                    .endListener()
+                .endKafka()
+            .endSpec()
+            .withNewStatus()
+                .addNewCondition()
+                    .withType("Ready")
+                    .withStatus("True")
+                .endCondition()
+                .withListeners(List.of(
+                    new ListenerStatusBuilder()
+                        .withName("plain")
+                        .addNewAddress()
+                            .withHost(name + "-kafka-bootstrap." + namespace + ".svc")
+                            .withPort(9092)
+                        .endAddress()
+                        .build(),
+                    new ListenerStatusBuilder()
+                        .withName("tls")
+                        .addNewAddress()
+                            .withHost(name + "-kafka-bootstrap." + namespace + ".svc")
+                            .withPort(9093)
+                        .endAddress()
+                        .build()
+                ))
+            .endStatus()
+            .build();
+
+        MixedOperation kafkaOp = Mockito.mock(MixedOperation.class);
+        when(kubernetesClient.resources(Kafka.class)).thenReturn(kafkaOp);
+
+        NonNamespaceOperation nsKafkaOp = Mockito.mock(NonNamespaceOperation.class);
+        when(kafkaOp.inNamespace(namespace)).thenReturn(nsKafkaOp);
+
+        Resource kafkaResource = Mockito.mock(Resource.class);
+        when(nsKafkaOp.withName(name)).thenReturn(kafkaResource);
+        when(kafkaResource.get()).thenReturn(kafka);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticServiceTest.java
@@ -18,8 +18,8 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.streamshub.mcp.common.service.DiagnosticHelper;
 import io.streamshub.mcp.strimzi.dto.KafkaConnectivityDiagnosticReport;
+import io.streamshub.mcp.strimzi.util.NamespaceElicitationHelper;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatusBuilder;
@@ -126,7 +126,7 @@ class KafkaConnectivityDiagnosticServiceTest {
 
     @Test
     void testParseNamespacesFromError() {
-        List<String> namespaces = DiagnosticHelper.parseNamespacesFromError(
+        List<String> namespaces = NamespaceElicitationHelper.parseNamespacesFromError(
             "Multiple clusters named 'my-cluster' found in namespaces: ns-a, ns-b. Please specify namespace.");
 
         assertEquals(2, namespaces.size());
@@ -136,7 +136,7 @@ class KafkaConnectivityDiagnosticServiceTest {
 
     @Test
     void testParseNamespacesFromErrorReturnsEmptyForNull() {
-        assertTrue(DiagnosticHelper.parseNamespacesFromError(null).isEmpty());
+        assertTrue(NamespaceElicitationHelper.parseNamespacesFromError(null).isEmpty());
     }
 
     // ---- Test helpers ----

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticServiceTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.streamshub.mcp.common.service.DiagnosticHelper;
+import io.streamshub.mcp.strimzi.dto.KafkaMetricsDiagnosticReport;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link KafkaMetricsDiagnosticService}.
+ */
+@QuarkusTest
+class KafkaMetricsDiagnosticServiceTest {
+
+    @InjectMock
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    KafkaMetricsDiagnosticService diagnosticService;
+
+    KafkaMetricsDiagnosticServiceTest() {
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MixedOperation<Pod, PodList, PodResource> podOp = Mockito.mock(MixedOperation.class);
+        Mockito.lenient().when(kubernetesClient.pods()).thenReturn(podOp);
+
+        MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentOp =
+            Mockito.mock(MixedOperation.class);
+        AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
+        Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
+        Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+    }
+
+    /**
+     * Verify that a null cluster name throws a ToolCallException.
+     */
+    @Test
+    void testThrowsWhenClusterNameMissing() {
+        assertThrows(ToolCallException.class, () ->
+            diagnosticService.diagnose("kafka", null, null,
+                null, null, null, null,
+                null, null, null, null, null));
+    }
+
+    /**
+     * Verify that a non-existent cluster throws a ToolCallException.
+     */
+    @Test
+    void testThrowsWhenClusterNotFound() {
+        assertThrows(ToolCallException.class, () ->
+            diagnosticService.diagnose("kafka", "missing-cluster", null,
+                null, null, null, null,
+                null, null, null, null, null));
+    }
+
+    /**
+     * Verify a full diagnostic workflow with a healthy cluster completes successfully.
+     */
+    @Test
+    void testFullWorkflowWithHealthyCluster() {
+        setupKafkaCluster("my-cluster", "kafka", true);
+
+        KafkaMetricsDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "my-cluster", null,
+            null, null, null, null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertEquals("my-cluster", report.cluster().name());
+        assertEquals("kafka", report.cluster().namespace());
+        assertNotNull(report.stepsCompleted());
+        assertTrue(report.stepsCompleted().contains("cluster_status"));
+        assertTrue(report.stepsCompleted().contains("pod_health"));
+        assertNotNull(report.timestamp());
+        assertNotNull(report.message());
+        assertNull(report.analysis());
+    }
+
+    /**
+     * Verify that a failed step does not abort the entire workflow.
+     */
+    @Test
+    void testStepFailureDoesNotAbortWorkflow() {
+        setupKafkaCluster("my-cluster", "kafka", false);
+
+        KafkaMetricsDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "my-cluster", "high latency",
+            null, null, null, null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertNotNull(report.cluster());
+        assertEquals("Error", report.cluster().readiness());
+        assertTrue(report.stepsCompleted().contains("cluster_status"));
+    }
+
+    /**
+     * Verify the report message includes the cluster name.
+     */
+    @Test
+    void testReportIncludesConcernContext() {
+        setupKafkaCluster("my-cluster", "kafka", true);
+
+        KafkaMetricsDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "my-cluster", "replication lag",
+            null, null, null, null,
+            null, null, null, null, null);
+
+        assertNotNull(report);
+        assertNotNull(report.message());
+        assertTrue(report.message().contains("my-cluster"));
+    }
+
+    /**
+     * Verify namespace parsing from multi-namespace error messages.
+     */
+    @Test
+    void testParseNamespacesFromError() {
+        List<String> namespaces = DiagnosticHelper.parseNamespacesFromError(
+            "Multiple clusters named 'my-cluster' found in namespaces: kafka-prod, kafka-dev. "
+                + "Please specify namespace.");
+
+        assertEquals(2, namespaces.size());
+        assertEquals("kafka-prod", namespaces.get(0));
+        assertEquals("kafka-dev", namespaces.get(1));
+    }
+
+    /**
+     * Verify namespace parsing returns empty list for null input.
+     */
+    @Test
+    void testParseNamespacesFromErrorReturnsEmptyForNull() {
+        assertTrue(DiagnosticHelper.parseNamespacesFromError(null).isEmpty());
+    }
+
+    /**
+     * Verify namespace parsing returns empty list for unrelated messages.
+     */
+    @Test
+    void testParseNamespacesFromErrorReturnsEmptyForUnrelatedMessage() {
+        assertTrue(DiagnosticHelper.parseNamespacesFromError("Some other error").isEmpty());
+    }
+
+    // ---- Test helpers ----
+
+    @SuppressWarnings("unchecked")
+    private void setupKafkaCluster(final String name, final String namespace, final boolean ready) {
+        KafkaStatusBuilder statusBuilder = new KafkaStatusBuilder();
+        if (ready) {
+            statusBuilder.addNewCondition()
+                .withType("Ready")
+                .withStatus("True")
+                .endCondition();
+        } else {
+            statusBuilder.addNewCondition()
+                .withType("Ready")
+                .withStatus("False")
+                .withReason("PodNotReady")
+                .withMessage("1 out of 3 brokers not ready")
+                .endCondition();
+        }
+
+        Kafka kafka = new KafkaBuilder()
+            .withNewMetadata().withName(name).withNamespace(namespace).endMetadata()
+            .withStatus(statusBuilder.build())
+            .build();
+
+        MixedOperation kafkaOp = Mockito.mock(MixedOperation.class);
+        when(kubernetesClient.resources(Kafka.class)).thenReturn(kafkaOp);
+
+        NonNamespaceOperation nsKafkaOp = Mockito.mock(NonNamespaceOperation.class);
+        when(kafkaOp.inNamespace(namespace)).thenReturn(nsKafkaOp);
+
+        Resource kafkaResource = Mockito.mock(Resource.class);
+        when(nsKafkaOp.withName(name)).thenReturn(kafkaResource);
+        when(kafkaResource.get()).thenReturn(kafka);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticServiceTest.java
@@ -18,8 +18,8 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.streamshub.mcp.common.service.DiagnosticHelper;
 import io.streamshub.mcp.strimzi.dto.KafkaMetricsDiagnosticReport;
+import io.streamshub.mcp.strimzi.util.NamespaceElicitationHelper;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
@@ -150,7 +150,7 @@ class KafkaMetricsDiagnosticServiceTest {
      */
     @Test
     void testParseNamespacesFromError() {
-        List<String> namespaces = DiagnosticHelper.parseNamespacesFromError(
+        List<String> namespaces = NamespaceElicitationHelper.parseNamespacesFromError(
             "Multiple clusters named 'my-cluster' found in namespaces: kafka-prod, kafka-dev. "
                 + "Please specify namespace.");
 
@@ -164,7 +164,7 @@ class KafkaMetricsDiagnosticServiceTest {
      */
     @Test
     void testParseNamespacesFromErrorReturnsEmptyForNull() {
-        assertTrue(DiagnosticHelper.parseNamespacesFromError(null).isEmpty());
+        assertTrue(NamespaceElicitationHelper.parseNamespacesFromError(null).isEmpty());
     }
 
     /**
@@ -172,7 +172,7 @@ class KafkaMetricsDiagnosticServiceTest {
      */
     @Test
     void testParseNamespacesFromErrorReturnsEmptyForUnrelatedMessage() {
-        assertTrue(DiagnosticHelper.parseNamespacesFromError("Some other error").isEmpty());
+        assertTrue(NamespaceElicitationHelper.parseNamespacesFromError("Some other error").isEmpty());
     }
 
     // ---- Test helpers ----

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticServiceTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.streamshub.mcp.strimzi.dto.OperatorMetricsDiagnosticReport;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link OperatorMetricsDiagnosticService}.
+ */
+@QuarkusTest
+class OperatorMetricsDiagnosticServiceTest {
+
+    @InjectMock
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    OperatorMetricsDiagnosticService diagnosticService;
+
+    OperatorMetricsDiagnosticServiceTest() {
+    }
+
+    @BeforeEach
+    void setUp() {
+        // No default mocks needed - individual tests set up their own
+    }
+
+    /**
+     * Verify that a missing operator throws a ToolCallException.
+     */
+    @Test
+    void testThrowsWhenOperatorNotFound() {
+        setupEmptyDeployments("kafka");
+
+        assertThrows(ToolCallException.class, () ->
+            diagnosticService.diagnose("kafka", null, null, null,
+                null, null, null, null,
+                null, null, null, null));
+    }
+
+    /**
+     * Verify a full diagnostic workflow with a healthy operator completes successfully.
+     */
+    @Test
+    void testFullWorkflowWithHealthyOperator() {
+        setupOperatorDeployment("strimzi-cluster-operator", "kafka");
+
+        OperatorMetricsDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "strimzi-cluster-operator", null, null,
+            null, null, null, null,
+            null, null, null, null);
+
+        assertNotNull(report);
+        assertEquals("strimzi-cluster-operator", report.operator().name());
+        assertEquals("kafka", report.operator().namespace());
+        assertNotNull(report.stepsCompleted());
+        assertTrue(report.stepsCompleted().contains("operator_status"));
+        assertNotNull(report.timestamp());
+        assertNotNull(report.message());
+        assertNull(report.analysis());
+    }
+
+    /**
+     * Verify that a failed step does not abort the entire workflow.
+     */
+    @Test
+    void testStepFailureDoesNotAbortWorkflow() {
+        setupOperatorDeployment("strimzi-cluster-operator", "kafka");
+
+        OperatorMetricsDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "strimzi-cluster-operator", null, "high memory",
+            null, null, null, null,
+            null, null, null, null);
+
+        assertNotNull(report);
+        assertTrue(report.stepsCompleted().contains("operator_status"));
+    }
+
+    /**
+     * Verify the report message includes the operator name.
+     */
+    @Test
+    void testReportIncludesConcernContext() {
+        setupOperatorDeployment("strimzi-cluster-operator", "kafka");
+
+        OperatorMetricsDiagnosticReport report = diagnosticService.diagnose(
+            "kafka", "strimzi-cluster-operator", null, "reconciliation failures",
+            null, null, null, null,
+            null, null, null, null);
+
+        assertNotNull(report);
+        assertNotNull(report.message());
+        assertTrue(report.message().contains("strimzi-cluster-operator"));
+    }
+
+    // ---- Test helpers ----
+
+    @SuppressWarnings("unchecked")
+    private void setupEmptyDeployments(final String namespace) {
+        // Mock resources(Deployment.class) chain used by KubernetesResourceService
+        MixedOperation deploymentOp = Mockito.mock(MixedOperation.class);
+        when(kubernetesClient.resources(Deployment.class)).thenReturn(deploymentOp);
+
+        NonNamespaceOperation nsOp = Mockito.mock(NonNamespaceOperation.class);
+        when(deploymentOp.inNamespace(namespace)).thenReturn(nsOp);
+        when(nsOp.withLabel(anyString(), anyString())).thenReturn(nsOp);
+
+        DeploymentList emptyList = new DeploymentList();
+        emptyList.setItems(List.of());
+        when(nsOp.list()).thenReturn(emptyList);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupOperatorDeployment(final String name, final String namespace) {
+        Container container = new ContainerBuilder()
+            .withName("strimzi-cluster-operator")
+            .withImage("quay.io/strimzi/operator:0.51.0")
+            .build();
+
+        Deployment deployment = new DeploymentBuilder()
+            .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .withLabels(Map.of("app", "strimzi"))
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(1)
+                .withNewTemplate()
+                    .withNewSpec()
+                        .withContainers(container)
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .withNewStatus()
+                .withReplicas(1)
+                .withReadyReplicas(1)
+                .withAvailableReplicas(1)
+            .endStatus()
+            .build();
+
+        // Mock resources(Deployment.class) chain used by KubernetesResourceService.getResource
+        MixedOperation deploymentOp = Mockito.mock(MixedOperation.class);
+        when(kubernetesClient.resources(Deployment.class)).thenReturn(deploymentOp);
+
+        NonNamespaceOperation nsOp = Mockito.mock(NonNamespaceOperation.class);
+        when(deploymentOp.inNamespace(namespace)).thenReturn(nsOp);
+
+        Resource deploymentResource = Mockito.mock(Resource.class);
+        when(nsOp.withName(name)).thenReturn(deploymentResource);
+        when(deploymentResource.get()).thenReturn(deployment);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpDiscoveryTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpDiscoveryTest.java
@@ -47,7 +47,7 @@ class McpDiscoveryTest {
     }
 
     /**
-     * Verify all 16 tools are registered.
+     * Verify all 20 tools are registered.
      */
     @Test
     void testToolDiscovery() {
@@ -69,7 +69,11 @@ class McpDiscoveryTest {
                     "get_strimzi_operator",
                     "get_strimzi_operator_logs",
                     "get_strimzi_operator_pod",
-                    "get_strimzi_events"
+                    "get_strimzi_events",
+                    "diagnose_kafka_cluster",
+                    "diagnose_kafka_connectivity",
+                    "diagnose_kafka_metrics",
+                    "diagnose_operator_metrics"
                 );
 
                 for (String toolName : expectedTools) {


### PR DESCRIPTION
Create same tools as current prompt templates with sampling and elicitation which can be used by other agents. This is a primary usage to expose diagnostic tools to other agents without using llm for every partial step.