### PR TITLE
Add tools annotations and upgrade quarkus-mcp to 1.12.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,10 +152,12 @@ public class XxxTools {
 }
 ```
 
-### Critical: No @Tool.Annotations
+### Tool Annotations
 
-Do NOT use `annotations = @Tool.Annotations(...)` on any `@Tool`. This causes Claude Code
-to silently drop all MCP tools during discovery. Not even empty `@Tool.Annotations()` works.
+All tools declare `@Tool.Annotations` with `readOnlyHint = true`, `destructiveHint = false`,
+`idempotentHint = true`, `openWorldHint = false` since all tools are read-only Kubernetes queries.
+When adding new tools, always include these annotations — MCP clients like ChatGPT default
+tools to "write" mode without them.
 
 ### Tool naming
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.34.5</quarkus.platform.version>
-        <quarkus.mcp.server.version>1.11.1</quarkus.mcp.server.version>
+        <quarkus.mcp.server.version>1.12.0</quarkus.mcp.server.version>
         <strimzi.version>0.51.0</strimzi.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/DiagnosticTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/DiagnosticTools.java
@@ -72,7 +72,13 @@ public class DiagnosticTools {
             + " events, and metrics in a single call."
             + " Uses Sampling to get LLM analysis of intermediate results"
             + " and Elicitation to resolve ambiguity (e.g., multiple namespaces)."
-            + " Falls back to gathering all data when Sampling is not supported."
+            + " Falls back to gathering all data when Sampling is not supported.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaClusterDiagnosticReport diagnoseKafkaCluster(
         @ToolArg(
@@ -120,7 +126,13 @@ public class DiagnosticTools {
             + " Checks listeners, bootstrap addresses, TLS certificates,"
             + " authentication, pod health, and connection-related logs."
             + " Uses Sampling for analysis and Elicitation for disambiguation."
-            + " Falls back to gathering all data when Sampling is not supported."
+            + " Falls back to gathering all data when Sampling is not supported.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaConnectivityDiagnosticReport diagnoseKafkaConnectivity(
         @ToolArg(
@@ -168,7 +180,13 @@ public class DiagnosticTools {
             + " Gathers cluster status and pod health, then selectively queries"
             + " replication, performance, resource, and throughput metrics."
             + " Uses Sampling for analysis and Elicitation for disambiguation."
-            + " Falls back to gathering all metric categories when Sampling is not supported."
+            + " Falls back to gathering all metric categories when Sampling is not supported.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaMetricsDiagnosticReport diagnoseKafkaMetrics(
         @ToolArg(
@@ -233,7 +251,13 @@ public class DiagnosticTools {
             + " Gathers operator status, then selectively queries reconciliation,"
             + " resource, and JVM metrics along with operator logs."
             + " Uses Sampling for analysis."
-            + " Falls back to gathering all data when Sampling is not supported."
+            + " Falls back to gathering all data when Sampling is not supported.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public OperatorMetricsDiagnosticReport diagnoseOperatorMetrics(
         @ToolArg(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaNodePoolTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaNodePoolTools.java
@@ -40,7 +40,13 @@ public class KafkaNodePoolTools {
      */
     @Tool(
         name = "list_kafka_node_pools",
-        description = "List KafkaNodePools for a cluster showing roles, replicas, and storage configuration."
+        description = "List KafkaNodePools for a cluster showing roles, replicas, and storage configuration.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public List<KafkaNodePoolResponse> listKafkaNodePools(
         @ToolArg(
@@ -64,7 +70,13 @@ public class KafkaNodePoolTools {
      */
     @Tool(
         name = "get_kafka_node_pool",
-        description = "Get detailed information about a specific KafkaNodePool including roles, replicas, and storage."
+        description = "Get detailed information about a specific KafkaNodePool including roles, replicas, and storage.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaNodePoolResponse getKafkaNodePool(
         @ToolArg(
@@ -91,7 +103,13 @@ public class KafkaNodePoolTools {
      */
     @Tool(
         name = "get_kafka_node_pool_pods",
-        description = "Get pod summaries for a KafkaNodePool with phase, readiness, restarts, and age."
+        description = "Get pod summaries for a KafkaNodePool with phase, readiness, restarts, and age.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public List<PodSummaryResponse.PodInfo> getKafkaNodePoolPods(
         @ToolArg(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTools.java
@@ -60,7 +60,13 @@ public class KafkaTools {
         name = "list_kafka_clusters",
         description = "List Kafka clusters with status"
             + " and configuration."
-            + " Optionally filter by namespace."
+            + " Optionally filter by namespace.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public List<KafkaClusterResponse> listKafkaClusters(
         @ToolArg(
@@ -82,7 +88,13 @@ public class KafkaTools {
         name = "get_kafka_cluster",
         description = "Get detailed information about"
             + " a specific Kafka cluster including"
-            + " status, version, and configuration."
+            + " status, version, and configuration.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaClusterResponse getKafkaCluster(
         @ToolArg(
@@ -107,7 +119,13 @@ public class KafkaTools {
         name = "get_kafka_cluster_pods",
         description = "Get pod summaries for a Kafka"
             + " cluster with component type, phase,"
-            + " readiness, restarts, and age."
+            + " readiness, restarts, and age.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaClusterPodsResponse getKafkaClusterPods(
         @ToolArg(
@@ -133,7 +151,13 @@ public class KafkaTools {
     @Tool(
         name = "get_kafka_bootstrap_servers",
         description = "Get bootstrap server addresses for a Kafka cluster"
-            + " with listener names, types, hosts, and ports."
+            + " with listener names, types, hosts, and ports.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaBootstrapResponse getKafkaBootstrapServers(
         @ToolArg(
@@ -160,7 +184,13 @@ public class KafkaTools {
         description = "Returns TLS certificate metadata and listener authentication"
             + " configuration for a Kafka cluster."
             + " Includes certificate expiry dates, issuers, and SANs from"
-            + " Strimzi-managed secrets. Requires opt-in sensitive RBAC Role."
+            + " Strimzi-managed secrets. Requires opt-in sensitive RBAC Role.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaCertificateResponse getKafkaClusterCertificates(
         @ToolArg(
@@ -198,7 +228,13 @@ public class KafkaTools {
     @Tool(
         name = "get_kafka_cluster_logs",
         description = "Get logs from Kafka cluster pods with error analysis."
-            + " Returns logs from all pods belonging to the cluster."
+            + " Returns logs from all pods belonging to the cluster.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     @RateCategory("log")
     public KafkaClusterLogsResponse getKafkaClusterLogs(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTopicTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTopicTools.java
@@ -41,7 +41,13 @@ public class KafkaTopicTools {
     @Tool(
         name = "list_kafka_topics",
         description = "List Kafka topics for a cluster with partitions, replicas, and status."
-            + " Returns paginated results (default 100 per page). Use offset to get more."
+            + " Returns paginated results (default 100 per page). Use offset to get more.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaTopicListResponse listKafkaTopics(
         @ToolArg(
@@ -74,7 +80,13 @@ public class KafkaTopicTools {
     @Tool(
         name = "get_kafka_topic",
         description = "Get detailed information for a specific Kafka topic including"
-            + " configuration, partitions, replicas, and status."
+            + " configuration, partitions, replicas, and status.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public KafkaTopicResponse getKafkaTopic(
         @ToolArg(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/StrimziEventsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/StrimziEventsTools.java
@@ -40,7 +40,13 @@ public class StrimziEventsTools {
         name = "get_strimzi_events",
         description = "Get Kubernetes events for a Kafka cluster and all related resources"
             + " (pods, PVCs, node pools). Shows scheduling, restarts, volume issues,"
-            + " and operator reconciliation events."
+            + " and operator reconciliation events.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public StrimziEventsResponse getStrimziEvents(
         @ToolArg(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/StrimziOperatorTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/StrimziOperatorTools.java
@@ -57,7 +57,13 @@ public class StrimziOperatorTools {
     @Tool(
         name = "list_strimzi_operators",
         description = "List Strimzi cluster operators with deployment status and health."
-            + " Optionally filter by namespace."
+            + " Optionally filter by namespace.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public List<StrimziOperatorResponse> listStrimziOperators(
         @ToolArg(
@@ -78,7 +84,13 @@ public class StrimziOperatorTools {
     @Tool(
         name = "get_strimzi_operator",
         description = "Get detailed information about a specific Strimzi operator"
-            + " including status, version, image, and uptime."
+            + " including status, version, image, and uptime.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public StrimziOperatorResponse getStrimziOperator(
         @ToolArg(
@@ -111,7 +123,13 @@ public class StrimziOperatorTools {
     @Tool(
         name = "get_strimzi_operator_logs",
         description = "Get logs from Strimzi operator pods with error analysis."
-            + " Returns logs from all operator pods."
+            + " Returns logs from all operator pods.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     @RateCategory("log")
     public StrimziOperatorLogsResponse getStrimziOperatorLogs(
@@ -184,7 +202,13 @@ public class StrimziOperatorTools {
     @Tool(
         name = "get_strimzi_operator_pod",
         description = "Get detailed description of a Strimzi operator pod including"
-            + " environment, resources, volumes, and conditions."
+            + " environment, resources, volumes, and conditions.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     public PodSummaryResponse getStrimziOperatorPod(
         @ToolArg(

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
@@ -56,7 +56,13 @@ public class MetricsTools {
     @Tool(
         name = "get_kafka_metrics",
         description = "Retrieves Prometheus metrics from Kafka cluster pods by category or explicit metric names."
-            + " Returns samples with an interpretation guide for thresholds and diagnostics."
+            + " Returns samples with an interpretation guide for thresholds and diagnostics.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     @RateCategory("metrics")
     public KafkaMetricsResponse getKafkaMetrics(
@@ -112,7 +118,13 @@ public class MetricsTools {
     @Tool(
         name = "get_kafka_exporter_metrics",
         description = "Retrieves Prometheus metrics from Kafka Exporter pods by category or explicit metric names."
-            + " Returns consumer group lag, topic partition offsets, and JVM metrics with interpretation guide."
+            + " Returns consumer group lag, topic partition offsets, and JVM metrics with interpretation guide.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     @RateCategory("metrics")
     public KafkaExporterMetricsResponse getKafkaExporterMetrics(
@@ -172,7 +184,13 @@ public class MetricsTools {
         name = "get_strimzi_operator_metrics",
         description = "Retrieves Prometheus metrics from Strimzi operator pods by category or explicit metric names."
             + " When clusterName is provided, also includes entity operator (user-operator and topic-operator) metrics."
-            + " Returns samples with an interpretation guide for thresholds and diagnostics."
+            + " Returns samples with an interpretation guide for thresholds and diagnostics.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
     )
     @RateCategory("metrics")
     public StrimziOperatorMetricsResponse getStrimziOperatorMetrics(

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <kubetest4j.version>1.1.0</kubetest4j.version>
-        <quarkus.mcp.server.test.version>1.11.1</quarkus.mcp.server.test.version>
+        <quarkus.mcp.server.test.version>1.12.0</quarkus.mcp.server.test.version>
         <strimzi.test-clients.version>0.13.0</strimzi.test-clients.version>
         <allure.junit.version>2.34.0</allure.junit.version>
         <allure.report.version>2.39.0</allure.report.version>


### PR DESCRIPTION
## Description

Upgraded quarkus-mcp-server to 1.12.0 and added tools annotations for the clients.

## Type of change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

