### PR TITLE
Propagate Kubernetes query errors

### DIFF
--- a/common/src/main/java/io/streamshub/mcp/common/service/KubernetesQueryException.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/KubernetesQueryException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service;
+
+/**
+ * Thrown when a Kubernetes API query fails (e.g., RBAC denial,
+ * network error, API server unavailable).
+ */
+public class KubernetesQueryException extends RuntimeException {
+
+    /**
+     * Creates a new query exception.
+     *
+     * @param message context about what was being queried
+     * @param cause   the original exception from the Kubernetes client
+     */
+    public KubernetesQueryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/service/KubernetesResourceService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/KubernetesResourceService.java
@@ -47,7 +47,9 @@ public class KubernetesResourceService {
                 "Error querying %s in ns %s: %s",
                 resourceClass.getSimpleName(),
                 namespace, e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query %s in namespace '%s'",
+                    resourceClass.getSimpleName(), namespace), e);
         }
     }
 
@@ -70,7 +72,9 @@ public class KubernetesResourceService {
                 "Error querying %s in any ns: %s",
                 resourceClass.getSimpleName(),
                 e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query %s across all namespaces",
+                    resourceClass.getSimpleName()), e);
         }
     }
 
@@ -100,7 +104,9 @@ public class KubernetesResourceService {
                 resourceClass.getSimpleName(),
                 labelKey, labelValue,
                 namespace, e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query %s by %s=%s in namespace '%s'",
+                    resourceClass.getSimpleName(), labelKey, labelValue, namespace), e);
         }
     }
 
@@ -129,7 +135,9 @@ public class KubernetesResourceService {
                 resourceClass.getSimpleName(),
                 labelKey, labelValue,
                 e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query %s by %s=%s across all namespaces",
+                    resourceClass.getSimpleName(), labelKey, labelValue), e);
         }
     }
 
@@ -157,7 +165,9 @@ public class KubernetesResourceService {
                 "Error querying %s by labels %s in ns %s: %s",
                 resourceClass.getSimpleName(),
                 labels, namespace, e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query %s by labels %s in namespace '%s'",
+                    resourceClass.getSimpleName(), labels, namespace), e);
         }
     }
 
@@ -183,7 +193,9 @@ public class KubernetesResourceService {
                 "Error querying %s by labels %s: %s",
                 resourceClass.getSimpleName(),
                 labels, e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query %s by labels %s across all namespaces",
+                    resourceClass.getSimpleName(), labels), e);
         }
     }
 
@@ -211,7 +223,9 @@ public class KubernetesResourceService {
                 resourceClass.getSimpleName(),
                 labelKey, labelValue,
                 e.getMessage());
-            return List.of();
+            throw new KubernetesQueryException(
+                String.format("Failed to query cluster-scoped %s by %s=%s",
+                    resourceClass.getSimpleName(), labelKey, labelValue), e);
         }
     }
 
@@ -234,7 +248,9 @@ public class KubernetesResourceService {
                 "Error getting cluster-scoped %s %s: %s",
                 resourceClass.getSimpleName(),
                 name, e.getMessage());
-            return null;
+            throw new KubernetesQueryException(
+                String.format("Failed to get cluster-scoped %s '%s'",
+                    resourceClass.getSimpleName(), name), e);
         }
     }
 
@@ -259,7 +275,9 @@ public class KubernetesResourceService {
                 "Error getting %s %s in ns %s: %s",
                 resourceClass.getSimpleName(),
                 name, namespace, e.getMessage());
-            return null;
+            throw new KubernetesQueryException(
+                String.format("Failed to get %s '%s' in namespace '%s'",
+                    resourceClass.getSimpleName(), name, namespace), e);
         }
     }
 }

--- a/common/src/test/java/io/streamshub/mcp/common/service/KubernetesResourceServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/KubernetesResourceServiceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link KubernetesResourceService} error propagation.
+ */
+@QuarkusTest
+class KubernetesResourceServiceTest {
+
+    @InjectMock
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    KubernetesResourceService k8sService;
+
+    KubernetesResourceServiceTest() {
+    }
+
+    @Test
+    void testQueryResourcesThrowsOnError() {
+        when(kubernetesClient.resources(Pod.class))
+            .thenThrow(new KubernetesClientException("Forbidden"));
+
+        KubernetesQueryException ex = assertThrows(KubernetesQueryException.class,
+            () -> k8sService.queryResources(Pod.class, "default"));
+
+        assertTrue(ex.getMessage().contains("Pod"));
+        assertTrue(ex.getMessage().contains("default"));
+        assertNotNull(ex.getCause());
+    }
+
+    @Test
+    void testQueryResourcesInAnyNamespaceThrowsOnError() {
+        when(kubernetesClient.resources(Pod.class))
+            .thenThrow(new KubernetesClientException("Forbidden"));
+
+        KubernetesQueryException ex = assertThrows(KubernetesQueryException.class,
+            () -> k8sService.queryResourcesInAnyNamespace(Pod.class));
+
+        assertTrue(ex.getMessage().contains("Pod"));
+        assertTrue(ex.getMessage().contains("all namespaces"));
+    }
+
+    @Test
+    void testGetResourceThrowsOnError() {
+        when(kubernetesClient.resources(ConfigMap.class))
+            .thenThrow(new KubernetesClientException("Connection refused"));
+
+        KubernetesQueryException ex = assertThrows(KubernetesQueryException.class,
+            () -> k8sService.getResource(ConfigMap.class, "default", "my-config"));
+
+        assertTrue(ex.getMessage().contains("ConfigMap"));
+        assertTrue(ex.getMessage().contains("my-config"));
+    }
+
+    @Test
+    void testQueryResourcesByLabelThrowsOnError() {
+        when(kubernetesClient.resources(Pod.class))
+            .thenThrow(new KubernetesClientException("Forbidden"));
+
+        KubernetesQueryException ex = assertThrows(KubernetesQueryException.class,
+            () -> k8sService.queryResourcesByLabel(Pod.class, "kafka", "app", "strimzi"));
+
+        assertTrue(ex.getMessage().contains("Pod"));
+        assertTrue(ex.getMessage().contains("app=strimzi"));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testQueryResourcesReturnsResultsOnSuccess() {
+        MixedOperation podOp = Mockito.mock(MixedOperation.class);
+        Mockito.doReturn(podOp).when(kubernetesClient).resources(Pod.class);
+
+        NonNamespaceOperation nsOp = Mockito.mock(NonNamespaceOperation.class);
+        when(podOp.inNamespace("default")).thenReturn(nsOp);
+
+        PodList podList = new PodList();
+        podList.setItems(List.of(new Pod()));
+        when(nsOp.list()).thenReturn(podList);
+
+        List<Pod> result = k8sService.queryResources(Pod.class, "default");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testGetResourceReturnsNullWhenNotFound() {
+        MixedOperation podOp = Mockito.mock(MixedOperation.class);
+        Mockito.doReturn(podOp).when(kubernetesClient).resources(ConfigMap.class);
+
+        NonNamespaceOperation nsOp = Mockito.mock(NonNamespaceOperation.class);
+        when(podOp.inNamespace("default")).thenReturn(nsOp);
+
+        Resource resource = Mockito.mock(Resource.class);
+        when(nsOp.withName("missing")).thenReturn(resource);
+        when(resource.get()).thenReturn(null);
+
+        ConfigMap result = k8sService.getResource(ConfigMap.class, "default", "missing");
+
+        assertNull(result);
+    }
+
+    @Test
+    void testQueryResourcesByLabelsThrowsOnError() {
+        when(kubernetesClient.resources(Pod.class))
+            .thenThrow(new KubernetesClientException("Timeout"));
+
+        assertThrows(KubernetesQueryException.class,
+            () -> k8sService.queryResourcesByLabels(Pod.class, "ns", Map.of("a", "b")));
+    }
+
+    @Test
+    void testQueryClusterScopedResourcesByLabelThrowsOnError() {
+        when(kubernetesClient.resources(Pod.class))
+            .thenThrow(new KubernetesClientException("Forbidden"));
+
+        assertThrows(KubernetesQueryException.class,
+            () -> k8sService.queryClusterScopedResourcesByLabel(Pod.class, "app", "test"));
+    }
+
+    @Test
+    void testGetClusterScopedResourceThrowsOnError() {
+        when(kubernetesClient.resources(ConfigMap.class))
+            .thenThrow(new KubernetesClientException("Forbidden"));
+
+        assertThrows(KubernetesQueryException.class,
+            () -> k8sService.getClusterScopedResource(ConfigMap.class, "test"));
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/DrainCleanerService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/DrainCleanerService.java
@@ -15,6 +15,7 @@ import io.streamshub.mcp.common.config.KubernetesConstants;
 import io.streamshub.mcp.common.dto.LogCollectionParams;
 import io.streamshub.mcp.common.dto.PodLogsResult;
 import io.streamshub.mcp.common.service.DeploymentService;
+import io.streamshub.mcp.common.service.KubernetesQueryException;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.service.log.LogCollectionService;
 import io.streamshub.mcp.common.util.CertificateUtils;
@@ -162,14 +163,19 @@ public class DrainCleanerService {
         LOG.infof("Checking Drain Cleaner readiness (namespace=%s)", ns != null ? ns : "all");
 
         List<Deployment> deployments;
-        if (ns != null) {
-            deployments = k8sService.queryResourcesByLabel(
-                Deployment.class, ns,
-                KubernetesConstants.Labels.APP, StrimziConstants.DrainCleaner.APP_LABEL_VALUE);
-        } else {
-            deployments = k8sService.queryResourcesByLabelInAnyNamespace(
-                Deployment.class,
-                KubernetesConstants.Labels.APP, StrimziConstants.DrainCleaner.APP_LABEL_VALUE);
+        try {
+            if (ns != null) {
+                deployments = k8sService.queryResourcesByLabel(
+                    Deployment.class, ns,
+                    KubernetesConstants.Labels.APP, StrimziConstants.DrainCleaner.APP_LABEL_VALUE);
+            } else {
+                deployments = k8sService.queryResourcesByLabelInAnyNamespace(
+                    Deployment.class,
+                    KubernetesConstants.Labels.APP, StrimziConstants.DrainCleaner.APP_LABEL_VALUE);
+            }
+        } catch (KubernetesQueryException e) {
+            throw new ToolCallException(
+                "Unable to check Drain Cleaner readiness: " + e.getMessage());
         }
 
         if (deployments.isEmpty()) {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/StrimziEventsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/StrimziEventsService.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
 import io.streamshub.mcp.common.dto.ResourceEventsResult;
 import io.streamshub.mcp.common.service.KubernetesEventsService;
+import io.streamshub.mcp.common.service.KubernetesQueryException;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.util.InputUtils;
 import io.streamshub.mcp.strimzi.dto.StrimziEventsResponse;
@@ -88,37 +89,49 @@ public class StrimziEventsService {
         resourceEvents.add(eventsService.getEventsForResource(resolvedNs, name, "Kafka", sinceTime));
 
         // Events for related pods (limited to avoid excessive API calls on large clusters)
-        List<Pod> pods = k8sService.queryResourcesByLabel(
-            Pod.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
-        if (pods.size() > maxRelatedResources) {
-            LOG.warnf("Cluster %s has %d pods, limiting event queries to first %d",
-                name, pods.size(), maxRelatedResources);
-            pods = pods.subList(0, maxRelatedResources);
-        }
-        for (Pod pod : pods) {
-            resourceEvents.add(eventsService.getEventsForResource(
-                resolvedNs, pod.getMetadata().getName(), "Pod", sinceTime));
+        try {
+            List<Pod> pods = k8sService.queryResourcesByLabel(
+                Pod.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
+            if (pods.size() > maxRelatedResources) {
+                LOG.warnf("Cluster %s has %d pods, limiting event queries to first %d",
+                    name, pods.size(), maxRelatedResources);
+                pods = pods.subList(0, maxRelatedResources);
+            }
+            for (Pod pod : pods) {
+                resourceEvents.add(eventsService.getEventsForResource(
+                    resolvedNs, pod.getMetadata().getName(), "Pod", sinceTime));
+            }
+        } catch (KubernetesQueryException e) {
+            LOG.warnf("Failed to query pods for event collection: %s", e.getMessage());
         }
 
         // Events for related PVCs
-        List<PersistentVolumeClaim> pvcs = k8sService.queryResourcesByLabel(
-            PersistentVolumeClaim.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
-        if (pvcs.size() > maxRelatedResources) {
-            LOG.warnf("Cluster %s has %d PVCs, limiting event queries to first %d",
-                name, pvcs.size(), maxRelatedResources);
-            pvcs = pvcs.subList(0, maxRelatedResources);
-        }
-        for (PersistentVolumeClaim pvc : pvcs) {
-            resourceEvents.add(eventsService.getEventsForResource(
-                resolvedNs, pvc.getMetadata().getName(), "PersistentVolumeClaim", sinceTime));
+        try {
+            List<PersistentVolumeClaim> pvcs = k8sService.queryResourcesByLabel(
+                PersistentVolumeClaim.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
+            if (pvcs.size() > maxRelatedResources) {
+                LOG.warnf("Cluster %s has %d PVCs, limiting event queries to first %d",
+                    name, pvcs.size(), maxRelatedResources);
+                pvcs = pvcs.subList(0, maxRelatedResources);
+            }
+            for (PersistentVolumeClaim pvc : pvcs) {
+                resourceEvents.add(eventsService.getEventsForResource(
+                    resolvedNs, pvc.getMetadata().getName(), "PersistentVolumeClaim", sinceTime));
+            }
+        } catch (KubernetesQueryException e) {
+            LOG.warnf("Failed to query PVCs for event collection: %s", e.getMessage());
         }
 
         // Events for related KafkaNodePools
-        List<KafkaNodePool> nodePools = k8sService.queryResourcesByLabel(
-            KafkaNodePool.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
-        for (KafkaNodePool nodePool : nodePools) {
-            resourceEvents.add(eventsService.getEventsForResource(
-                resolvedNs, nodePool.getMetadata().getName(), "KafkaNodePool", sinceTime));
+        try {
+            List<KafkaNodePool> nodePools = k8sService.queryResourcesByLabel(
+                KafkaNodePool.class, resolvedNs, ResourceLabels.STRIMZI_CLUSTER_LABEL, name);
+            for (KafkaNodePool nodePool : nodePools) {
+                resourceEvents.add(eventsService.getEventsForResource(
+                    resolvedNs, nodePool.getMetadata().getName(), "KafkaNodePool", sinceTime));
+            }
+        } catch (KubernetesQueryException e) {
+            LOG.warnf("Failed to query KafkaNodePools for event collection: %s", e.getMessage());
         }
 
         // Remove resources with no events

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/DrainCleanerServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/DrainCleanerServiceTest.java
@@ -61,6 +61,9 @@ class DrainCleanerServiceTest {
         AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
         Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
         Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Deployment.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticServiceTest.java
@@ -75,6 +75,11 @@ class KafkaClusterDiagnosticServiceTest {
 
         // Mock events (empty by default)
         setupEmptyEvents();
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Kafka.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, KafkaNodePool.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Deployment.class);
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConfigServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConfigServiceTest.java
@@ -69,6 +69,7 @@ class KafkaConfigServiceTest {
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setUp() {
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Kafka.class);
         setupEmptyNodePools("kafka");
     }
 

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectServiceTest.java
@@ -16,6 +16,7 @@ import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectLogsResponse;
 import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectPodsResponse;
 import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectResponse;
 import io.streamshub.mcp.strimzi.service.kafkaconnect.KafkaConnectService;
+import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,9 @@ class KafkaConnectServiceTest {
     void setUp() {
         MixedOperation<Pod, PodList, PodResource> podOp = Mockito.mock(MixedOperation.class);
         Mockito.lenient().when(kubernetesClient.pods()).thenReturn(podOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, KafkaConnect.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
     }
 
     /**

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectivityDiagnosticServiceTest.java
@@ -63,6 +63,9 @@ class KafkaConnectivityDiagnosticServiceTest {
         AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
         Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
         Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Kafka.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectorServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaConnectorServiceTest.java
@@ -10,7 +10,9 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectorResponse;
 import io.streamshub.mcp.strimzi.service.kafkaconnect.KafkaConnectorService;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -32,6 +34,11 @@ class KafkaConnectorServiceTest {
     KafkaConnectorService connectorService;
 
     KafkaConnectorServiceTest() {
+    }
+
+    @BeforeEach
+    void setUp() {
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, KafkaConnector.class);
     }
 
     /**

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticServiceTest.java
@@ -63,6 +63,9 @@ class KafkaMetricsDiagnosticServiceTest {
         AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
         Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
         Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Kafka.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
     }
 
     /**

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaServiceTest.java
@@ -17,6 +17,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.streamshub.mcp.strimzi.dto.KafkaClusterPodsResponse;
 import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
+import io.strimzi.api.kafka.model.kafka.Kafka;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,9 @@ class KafkaServiceTest {
         AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
         Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
         Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Kafka.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaTopicServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaTopicServiceTest.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.streamshub.mcp.strimzi.dto.KafkaTopicListResponse;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,8 @@ class KafkaTopicServiceTest {
         AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
         Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
         Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, KafkaTopic.class);
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaUserServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaUserServiceTest.java
@@ -9,7 +9,9 @@ import io.quarkiverse.mcp.server.ToolCallException;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.streamshub.mcp.strimzi.dto.KafkaUserResponse;
+import io.strimzi.api.kafka.model.user.KafkaUser;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,6 +33,11 @@ class KafkaUserServiceTest {
     KafkaUserService userService;
 
     KafkaUserServiceTest() {
+    }
+
+    @BeforeEach
+    void setUp() {
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, KafkaUser.class);
     }
 
     /**

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KubernetesMockHelper.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KubernetesMockHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+/**
+ * Helper for setting up mock Kubernetes client chains
+ * that return empty results for {@link io.streamshub.mcp.common.service.KubernetesResourceService}.
+ */
+final class KubernetesMockHelper {
+
+    private KubernetesMockHelper() {
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends HasMetadata> void setupEmptyResourceQuery(
+            KubernetesClient kubernetesClient, Class<T> resourceClass) {
+        MixedOperation resourceOp = Mockito.mock(MixedOperation.class);
+        Mockito.lenient().when(kubernetesClient.resources(resourceClass)).thenReturn(resourceOp);
+
+        NonNamespaceOperation nsOp = Mockito.mock(NonNamespaceOperation.class);
+        Mockito.lenient().when(resourceOp.inNamespace(anyString())).thenReturn(nsOp);
+        Mockito.lenient().when(resourceOp.inAnyNamespace()).thenReturn(nsOp);
+
+        FilterWatchListDeletable labeledOp = Mockito.mock(FilterWatchListDeletable.class);
+        Mockito.lenient().when(nsOp.withLabel(anyString(), anyString())).thenReturn(labeledOp);
+        Mockito.lenient().when(nsOp.withLabels(any())).thenReturn(labeledOp);
+
+        KubernetesResourceList emptyList = Mockito.mock(KubernetesResourceList.class);
+        Mockito.lenient().when(emptyList.getItems()).thenReturn(List.of());
+        Mockito.lenient().when(nsOp.list()).thenReturn(emptyList);
+        Mockito.lenient().when(labeledOp.list()).thenReturn(emptyList);
+        Mockito.lenient().when(resourceOp.list()).thenReturn(emptyList);
+
+        // For withLabel on the top-level op (cluster-scoped queries)
+        Mockito.lenient().when(resourceOp.withLabel(anyString(), anyString())).thenReturn(labeledOp);
+
+        // For getResource() / getClusterScopedResource() calls
+        Resource resourceMock = Mockito.mock(Resource.class);
+        Mockito.lenient().when(nsOp.withName(anyString())).thenReturn(resourceMock);
+        Mockito.lenient().when(resourceOp.withName(anyString())).thenReturn(resourceMock);
+        Mockito.lenient().when(resourceMock.get()).thenReturn(null);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/StrimziEventsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/StrimziEventsServiceTest.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -23,6 +24,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.streamshub.mcp.strimzi.dto.StrimziEventsResponse;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,10 @@ class StrimziEventsServiceTest {
 
         // Mock events API (empty by default)
         setupEmptyEvents();
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, PersistentVolumeClaim.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, KafkaNodePool.class);
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/StrimziOperatorServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/StrimziOperatorServiceTest.java
@@ -59,6 +59,9 @@ class StrimziOperatorServiceTest {
         AppsAPIGroupDSL appsApi = Mockito.mock(AppsAPIGroupDSL.class);
         Mockito.lenient().when(kubernetesClient.apps()).thenReturn(appsApi);
         Mockito.lenient().when(appsApi.deployments()).thenReturn(deploymentOp);
+
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Deployment.class);
+        KubernetesMockHelper.setupEmptyResourceQuery(kubernetesClient, Pod.class);
     }
 
     @Test


### PR DESCRIPTION
## Description

Propagate Kubernetes query errors instead of silently returning empty results 

## Type of change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
