### PR TITLE
Add watch safe closure + reconnection + state reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,10 +396,17 @@ public class XxxCompletions {
 `ResourceSubscriptionManager` establishes Kubernetes watches on startup and sends
 `notifications/resources/updated` to subscribed MCP clients when resource state changes.
 
-- Watches Kafka CRs, KafkaNodePool CRs, KafkaTopic CRs, and operator Deployments
+- Watches Kafka CRs, KafkaNodePool CRs, KafkaTopic CRs, KafkaUser CRs, and operator Deployments
 - De-duplicates by comparing serialized JSON against last known state
 - Started/stopped via `@Observes StartupEvent` / `@Observes ShutdownEvent`
+- Auto-reconnects with exponential backoff when watches close unexpectedly
+- Periodic reconciliation removes orphaned state for deleted resources
 - Can be disabled via `mcp.resource-watches.enabled=false` (used in tests)
+- Configuration:
+  - `mcp.watch.reconnect-initial-delay-ms` (default: 1000) — initial reconnect delay
+  - `mcp.watch.reconnect-max-delay-ms` (default: 60000) — maximum reconnect delay
+  - `mcp.watch.reconnect-max-attempts` (default: 10) — maximum reconnect attempts before giving up
+  - `mcp.watch.reconcile-interval` (default: 5m) — interval for orphaned state cleanup
 
 ## Domain Service Pattern
 

--- a/docs/strimzi-mcp/configuration.md
+++ b/docs/strimzi-mcp/configuration.md
@@ -325,15 +325,21 @@ Control Kubernetes resource watches that send MCP notifications when resources c
 | Property | Default | Description |
 |----------|---------|-------------|
 | `mcp.resource-watches.enabled` | `true` | Enable resource subscriptions |
+| `mcp.watch.reconnect-initial-delay-ms` | `1000` | Initial delay (ms) before first reconnect attempt |
+| `mcp.watch.reconnect-max-delay-ms` | `60000` | Maximum delay (ms) between reconnect attempts |
+| `mcp.watch.reconnect-max-attempts` | `10` | Maximum reconnect attempts before giving up |
+| `mcp.watch.reconcile-interval` | `5m` | Interval for cleaning up orphaned state entries |
 
 When enabled, the server watches:
 
 - Kafka custom resources
 - KafkaNodePool custom resources
 - KafkaTopic custom resources
+- KafkaUser custom resources
 - Strimzi operator Deployments
 
 Changes trigger `notifications/resources/updated` messages to subscribed MCP clients.
+If a watch closes unexpectedly, it reconnects automatically with exponential backoff.
 
 To disable (useful for testing):
 

--- a/strimzi-mcp/pom.xml
+++ b/strimzi-mcp/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-jib</artifactId>
         </dependency>
         <dependency>

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
@@ -103,12 +103,28 @@ public class ResourceSubscriptionManager implements Closeable {
     private final Map<String, String> lastKnownState = new ConcurrentHashMap<>();
     private volatile boolean shuttingDown;
 
-    List<Watch> getActiveWatches() {
-        return activeWatches;
+    void addWatch(final Watch watch) {
+        activeWatches.add(watch);
     }
 
-    Map<String, String> getLastKnownState() {
-        return lastKnownState;
+    void clearWatches() {
+        activeWatches.clear();
+    }
+
+    int watchCount() {
+        return activeWatches.size();
+    }
+
+    void putState(final String uri, final String json) {
+        lastKnownState.put(uri, json);
+    }
+
+    boolean containsState(final String uri) {
+        return lastKnownState.containsKey(uri);
+    }
+
+    void clearState() {
+        lastKnownState.clear();
     }
 
     boolean isShuttingDown() {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
@@ -16,6 +16,7 @@ import io.quarkiverse.mcp.server.ResourceResponse;
 import io.quarkiverse.mcp.server.TextResourceContents;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import io.quarkus.scheduler.Scheduled;
 import io.streamshub.mcp.common.config.KubernetesConstants;
 import io.streamshub.mcp.strimzi.config.StrimziConstants;
 import io.streamshub.mcp.strimzi.dto.KafkaClusterResponse;
@@ -44,6 +45,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Manages Kubernetes watches on Strimzi resources and sends MCP resource
@@ -57,6 +62,15 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ResourceSubscriptionManager implements Closeable {
 
     private static final Logger LOG = Logger.getLogger(ResourceSubscriptionManager.class);
+    private static final String STRIMZI_URI_PREFIX = "strimzi://";
+    private static final int URI_PART_NAMESPACE = 2;
+    private static final int URI_PART_KIND = 3;
+    private static final int URI_PART_NAME = 4;
+    private static final int URI_MIN_PARTS = 5;
+
+    static final long RECONNECT_INITIAL_DELAY_MS = 1000;
+    static final long RECONNECT_MAX_DELAY_MS = 60_000;
+    static final int RECONNECT_MAX_ATTEMPTS = 10;
 
     @Inject
     KubernetesClient kubernetesClient;
@@ -87,6 +101,34 @@ public class ResourceSubscriptionManager implements Closeable {
 
     private final List<Watch> activeWatches = new CopyOnWriteArrayList<>();
     private final Map<String, String> lastKnownState = new ConcurrentHashMap<>();
+    private volatile boolean shuttingDown;
+
+    List<Watch> getActiveWatches() {
+        return activeWatches;
+    }
+
+    Map<String, String> getLastKnownState() {
+        return lastKnownState;
+    }
+
+    boolean isShuttingDown() {
+        return shuttingDown;
+    }
+
+    void setShuttingDown(final boolean shuttingDown) {
+        this.shuttingDown = shuttingDown;
+    }
+
+    void setWatchesEnabled(final boolean watchesEnabled) {
+        this.watchesEnabled = watchesEnabled;
+    }
+
+    private final ScheduledExecutorService reconnectExecutor =
+        Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "watch-reconnect");
+            t.setDaemon(true);
+            return t;
+        });
 
     ResourceSubscriptionManager() {
     }
@@ -121,18 +163,27 @@ public class ResourceSubscriptionManager implements Closeable {
     @Override
     public void close() {
         LOG.info("Closing Strimzi resource watches");
+        shuttingDown = true;
+        reconnectExecutor.shutdownNow();
         for (Watch watch : activeWatches) {
-            watch.close();
+            try {
+                watch.close();
+            } catch (Exception e) {
+                LOG.warnf("Error closing watch: %s", e.getMessage());
+            }
         }
         activeWatches.clear();
         lastKnownState.clear();
     }
 
-    private void startKafkaWatch() {
+    // ---- Watch starters ----
+
+    private boolean startKafkaWatch() {
         try {
-            Watch watch = kubernetesClient.resources(Kafka.class)
+            final Watch[] holder = new Watch[1];
+            holder[0] = kubernetesClient.resources(Kafka.class)
                 .inAnyNamespace()
-                .watch(new Watcher<Kafka>() {
+                .watch(new Watcher<>() {
                     @Override
                     public void eventReceived(final Action action, final Kafka kafka) {
                         handleKafkaEvent(action, kafka);
@@ -142,21 +193,27 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("Kafka watch closed unexpectedly: %s", cause.getMessage());
+                            activeWatches.remove(holder[0]);
+                            scheduleReconnect("Kafka",
+                                () -> startKafkaWatch(), 1);
                         }
                     }
                 });
-            activeWatches.add(watch);
+            activeWatches.add(holder[0]);
             LOG.info("Started watch on Kafka resources");
+            return true;
         } catch (Exception e) {
             LOG.warnf("Could not start Kafka watch: %s", e.getMessage());
+            return false;
         }
     }
 
-    private void startKafkaNodePoolWatch() {
+    private boolean startKafkaNodePoolWatch() {
         try {
-            Watch watch = kubernetesClient.resources(KafkaNodePool.class)
+            final Watch[] holder = new Watch[1];
+            holder[0] = kubernetesClient.resources(KafkaNodePool.class)
                 .inAnyNamespace()
-                .watch(new Watcher<KafkaNodePool>() {
+                .watch(new Watcher<>() {
                     @Override
                     public void eventReceived(final Action action, final KafkaNodePool nodePool) {
                         handleNodePoolEvent(action, nodePool);
@@ -166,21 +223,27 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("KafkaNodePool watch closed unexpectedly: %s", cause.getMessage());
+                            activeWatches.remove(holder[0]);
+                            scheduleReconnect("KafkaNodePool",
+                                () -> startKafkaNodePoolWatch(), 1);
                         }
                     }
                 });
-            activeWatches.add(watch);
+            activeWatches.add(holder[0]);
             LOG.info("Started watch on KafkaNodePool resources");
+            return true;
         } catch (Exception e) {
             LOG.warnf("Could not start KafkaNodePool watch: %s", e.getMessage());
+            return false;
         }
     }
 
-    private void startKafkaTopicWatch() {
+    private boolean startKafkaTopicWatch() {
         try {
-            Watch watch = kubernetesClient.resources(KafkaTopic.class)
+            final Watch[] holder = new Watch[1];
+            holder[0] = kubernetesClient.resources(KafkaTopic.class)
                 .inAnyNamespace()
-                .watch(new Watcher<KafkaTopic>() {
+                .watch(new Watcher<>() {
                     @Override
                     public void eventReceived(final Action action, final KafkaTopic topic) {
                         handleTopicEvent(action, topic);
@@ -190,21 +253,27 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("KafkaTopic watch closed unexpectedly: %s", cause.getMessage());
+                            activeWatches.remove(holder[0]);
+                            scheduleReconnect("KafkaTopic",
+                                () -> startKafkaTopicWatch(), 1);
                         }
                     }
                 });
-            activeWatches.add(watch);
+            activeWatches.add(holder[0]);
             LOG.info("Started watch on KafkaTopic resources");
+            return true;
         } catch (Exception e) {
             LOG.warnf("Could not start KafkaTopic watch: %s", e.getMessage());
+            return false;
         }
     }
 
-    private void startKafkaUserWatch() {
+    private boolean startKafkaUserWatch() {
         try {
-            Watch watch = kubernetesClient.resources(KafkaUser.class)
+            final Watch[] holder = new Watch[1];
+            holder[0] = kubernetesClient.resources(KafkaUser.class)
                 .inAnyNamespace()
-                .watch(new Watcher<KafkaUser>() {
+                .watch(new Watcher<>() {
                     @Override
                     public void eventReceived(final Action action, final KafkaUser user) {
                         handleUserEvent(action, user);
@@ -214,22 +283,28 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("KafkaUser watch closed unexpectedly: %s", cause.getMessage());
+                            activeWatches.remove(holder[0]);
+                            scheduleReconnect("KafkaUser",
+                                () -> startKafkaUserWatch(), 1);
                         }
                     }
                 });
-            activeWatches.add(watch);
+            activeWatches.add(holder[0]);
             LOG.info("Started watch on KafkaUser resources");
+            return true;
         } catch (Exception e) {
             LOG.warnf("Could not start KafkaUser watch: %s", e.getMessage());
+            return false;
         }
     }
 
-    private void startOperatorWatch() {
+    private boolean startOperatorWatch() {
         try {
-            Watch watch = kubernetesClient.apps().deployments()
+            final Watch[] holder = new Watch[1];
+            holder[0] = kubernetesClient.apps().deployments()
                 .inAnyNamespace()
                 .withLabel(KubernetesConstants.Labels.APP, StrimziConstants.Operator.APP_LABEL_VALUE)
-                .watch(new Watcher<Deployment>() {
+                .watch(new Watcher<>() {
                     @Override
                     public void eventReceived(final Action action, final Deployment deployment) {
                         handleOperatorEvent(action, deployment);
@@ -239,15 +314,112 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("Operator watch closed unexpectedly: %s", cause.getMessage());
+                            activeWatches.remove(holder[0]);
+                            scheduleReconnect("Operator",
+                                () -> startOperatorWatch(), 1);
                         }
                     }
                 });
-            activeWatches.add(watch);
+            activeWatches.add(holder[0]);
             LOG.info("Started watch on Strimzi operator Deployments");
+            return true;
         } catch (Exception e) {
             LOG.warnf("Could not start operator watch: %s", e.getMessage());
+            return false;
         }
     }
+
+    // ---- Reconnection ----
+
+    void scheduleReconnect(final String watchName, final Supplier<Boolean> starter, final int attempt) {
+        if (shuttingDown) {
+            return;
+        }
+        if (attempt > RECONNECT_MAX_ATTEMPTS) {
+            LOG.errorf("%s watch reconnection failed after %d attempts",
+                watchName, RECONNECT_MAX_ATTEMPTS);
+            return;
+        }
+        long delay = Math.min(
+            RECONNECT_INITIAL_DELAY_MS << (attempt - 1),
+            RECONNECT_MAX_DELAY_MS);
+        LOG.infof("Scheduling %s watch reconnect (attempt %d/%d, delay %dms)",
+            watchName, attempt, RECONNECT_MAX_ATTEMPTS, delay);
+        reconnectExecutor.schedule(() -> {
+            if (shuttingDown) {
+                return;
+            }
+            if (starter.get()) {
+                LOG.infof("%s watch reconnected successfully", watchName);
+            } else {
+                scheduleReconnect(watchName, starter, attempt + 1);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    // ---- Reconciliation ----
+
+    @Scheduled(every = "5m", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    void reconcileState() {
+        if (!watchesEnabled || shuttingDown) {
+            return;
+        }
+        LOG.debug("Running periodic lastKnownState reconciliation");
+        int removed = 0;
+        for (String uri : lastKnownState.keySet()) {
+            if (shuttingDown) {
+                return;
+            }
+            try {
+                if (!resourceExistsInCluster(uri)) {
+                    lastKnownState.remove(uri);
+                    resourceManager.removeResource(uri);
+                    removed++;
+                    LOG.infof("Reconciliation: removed orphaned entry %s", uri);
+                }
+            } catch (Exception e) {
+                LOG.debugf("Reconciliation: could not verify %s: %s", uri, e.getMessage());
+            }
+        }
+        if (removed > 0) {
+            LOG.infof("Reconciliation complete: removed %d orphaned entries", removed);
+        }
+    }
+
+    boolean resourceExistsInCluster(final String uri) {
+        if (!uri.startsWith(STRIMZI_URI_PREFIX)) {
+            return true;
+        }
+        String path = uri.substring(STRIMZI_URI_PREFIX.length());
+        String[] parts = path.split("/");
+        if (parts.length < URI_MIN_PARTS) {
+            return true;
+        }
+        String namespace = parts[URI_PART_NAMESPACE];
+        String kind = parts[URI_PART_KIND];
+        String name = parts[URI_PART_NAME];
+
+        return switch (kind) {
+            case "kafkas" ->
+                kubernetesClient.resources(Kafka.class)
+                    .inNamespace(namespace).withName(name).get() != null;
+            case "kafkanodepools" ->
+                kubernetesClient.resources(KafkaNodePool.class)
+                    .inNamespace(namespace).withName(name).get() != null;
+            case "kafkatopics" ->
+                kubernetesClient.resources(KafkaTopic.class)
+                    .inNamespace(namespace).withName(name).get() != null;
+            case "kafkausers" ->
+                kubernetesClient.resources(KafkaUser.class)
+                    .inNamespace(namespace).withName(name).get() != null;
+            case "clusteroperator" ->
+                kubernetesClient.apps().deployments()
+                    .inNamespace(namespace).withName(name).get() != null;
+            default -> true;
+        };
+    }
+
+    // ---- Event handlers ----
 
     private void handleKafkaEvent(final Watcher.Action action, final Kafka kafka) {
         String name = kafka.getMetadata().getName();
@@ -341,6 +513,8 @@ public class ResourceSubscriptionManager implements Closeable {
 
         notifyOperatorStatus(operatorUri, namespace, name);
     }
+
+    // ---- Notification helpers ----
 
     private void notifyClusterStatus(final String uri, final String namespace, final String name) {
         try {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -68,9 +69,14 @@ public class ResourceSubscriptionManager implements Closeable {
     private static final int URI_PART_NAME = 4;
     private static final int URI_MIN_PARTS = 5;
 
-    static final long RECONNECT_INITIAL_DELAY_MS = 1000;
-    static final long RECONNECT_MAX_DELAY_MS = 60_000;
-    static final int RECONNECT_MAX_ATTEMPTS = 10;
+    @ConfigProperty(name = "mcp.watch.reconnect-initial-delay-ms", defaultValue = "1000")
+    long reconnectInitialDelayMs;
+
+    @ConfigProperty(name = "mcp.watch.reconnect-max-delay-ms", defaultValue = "60000")
+    long reconnectMaxDelayMs;
+
+    @ConfigProperty(name = "mcp.watch.reconnect-max-attempts", defaultValue = "10")
+    int reconnectMaxAttempts;
 
     @Inject
     KubernetesClient kubernetesClient;
@@ -196,8 +202,8 @@ public class ResourceSubscriptionManager implements Closeable {
 
     private boolean startKafkaWatch() {
         try {
-            final Watch[] holder = new Watch[1];
-            holder[0] = kubernetesClient.resources(Kafka.class)
+            final AtomicReference<Watch> watchRef = new AtomicReference<>();
+            watchRef.set(kubernetesClient.resources(Kafka.class)
                 .inAnyNamespace()
                 .watch(new Watcher<>() {
                     @Override
@@ -209,13 +215,13 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("Kafka watch closed unexpectedly: %s", cause.getMessage());
-                            activeWatches.remove(holder[0]);
+                            activeWatches.remove(watchRef.get());
                             scheduleReconnect("Kafka",
                                 () -> startKafkaWatch(), 1);
                         }
                     }
-                });
-            activeWatches.add(holder[0]);
+                }));
+            activeWatches.add(watchRef.get());
             LOG.info("Started watch on Kafka resources");
             return true;
         } catch (Exception e) {
@@ -226,8 +232,8 @@ public class ResourceSubscriptionManager implements Closeable {
 
     private boolean startKafkaNodePoolWatch() {
         try {
-            final Watch[] holder = new Watch[1];
-            holder[0] = kubernetesClient.resources(KafkaNodePool.class)
+            final AtomicReference<Watch> watchRef = new AtomicReference<>();
+            watchRef.set(kubernetesClient.resources(KafkaNodePool.class)
                 .inAnyNamespace()
                 .watch(new Watcher<>() {
                     @Override
@@ -239,13 +245,13 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("KafkaNodePool watch closed unexpectedly: %s", cause.getMessage());
-                            activeWatches.remove(holder[0]);
+                            activeWatches.remove(watchRef.get());
                             scheduleReconnect("KafkaNodePool",
                                 () -> startKafkaNodePoolWatch(), 1);
                         }
                     }
-                });
-            activeWatches.add(holder[0]);
+                }));
+            activeWatches.add(watchRef.get());
             LOG.info("Started watch on KafkaNodePool resources");
             return true;
         } catch (Exception e) {
@@ -256,8 +262,8 @@ public class ResourceSubscriptionManager implements Closeable {
 
     private boolean startKafkaTopicWatch() {
         try {
-            final Watch[] holder = new Watch[1];
-            holder[0] = kubernetesClient.resources(KafkaTopic.class)
+            final AtomicReference<Watch> watchRef = new AtomicReference<>();
+            watchRef.set(kubernetesClient.resources(KafkaTopic.class)
                 .inAnyNamespace()
                 .watch(new Watcher<>() {
                     @Override
@@ -269,13 +275,13 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("KafkaTopic watch closed unexpectedly: %s", cause.getMessage());
-                            activeWatches.remove(holder[0]);
+                            activeWatches.remove(watchRef.get());
                             scheduleReconnect("KafkaTopic",
                                 () -> startKafkaTopicWatch(), 1);
                         }
                     }
-                });
-            activeWatches.add(holder[0]);
+                }));
+            activeWatches.add(watchRef.get());
             LOG.info("Started watch on KafkaTopic resources");
             return true;
         } catch (Exception e) {
@@ -286,8 +292,8 @@ public class ResourceSubscriptionManager implements Closeable {
 
     private boolean startKafkaUserWatch() {
         try {
-            final Watch[] holder = new Watch[1];
-            holder[0] = kubernetesClient.resources(KafkaUser.class)
+            final AtomicReference<Watch> watchRef = new AtomicReference<>();
+            watchRef.set(kubernetesClient.resources(KafkaUser.class)
                 .inAnyNamespace()
                 .watch(new Watcher<>() {
                     @Override
@@ -299,13 +305,13 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("KafkaUser watch closed unexpectedly: %s", cause.getMessage());
-                            activeWatches.remove(holder[0]);
+                            activeWatches.remove(watchRef.get());
                             scheduleReconnect("KafkaUser",
                                 () -> startKafkaUserWatch(), 1);
                         }
                     }
-                });
-            activeWatches.add(holder[0]);
+                }));
+            activeWatches.add(watchRef.get());
             LOG.info("Started watch on KafkaUser resources");
             return true;
         } catch (Exception e) {
@@ -316,8 +322,8 @@ public class ResourceSubscriptionManager implements Closeable {
 
     private boolean startOperatorWatch() {
         try {
-            final Watch[] holder = new Watch[1];
-            holder[0] = kubernetesClient.apps().deployments()
+            final AtomicReference<Watch> watchRef = new AtomicReference<>();
+            watchRef.set(kubernetesClient.apps().deployments()
                 .inAnyNamespace()
                 .withLabel(KubernetesConstants.Labels.APP, StrimziConstants.Operator.APP_LABEL_VALUE)
                 .watch(new Watcher<>() {
@@ -330,13 +336,13 @@ public class ResourceSubscriptionManager implements Closeable {
                     public void onClose(final WatcherException cause) {
                         if (cause != null) {
                             LOG.warnf("Operator watch closed unexpectedly: %s", cause.getMessage());
-                            activeWatches.remove(holder[0]);
+                            activeWatches.remove(watchRef.get());
                             scheduleReconnect("Operator",
                                 () -> startOperatorWatch(), 1);
                         }
                     }
-                });
-            activeWatches.add(holder[0]);
+                }));
+            activeWatches.add(watchRef.get());
             LOG.info("Started watch on Strimzi operator Deployments");
             return true;
         } catch (Exception e) {
@@ -351,16 +357,16 @@ public class ResourceSubscriptionManager implements Closeable {
         if (shuttingDown) {
             return;
         }
-        if (attempt > RECONNECT_MAX_ATTEMPTS) {
+        if (attempt > reconnectMaxAttempts) {
             LOG.errorf("%s watch reconnection failed after %d attempts",
-                watchName, RECONNECT_MAX_ATTEMPTS);
+                watchName, reconnectMaxAttempts);
             return;
         }
         long delay = Math.min(
-            RECONNECT_INITIAL_DELAY_MS << (attempt - 1),
-            RECONNECT_MAX_DELAY_MS);
+            reconnectInitialDelayMs << (attempt - 1),
+            reconnectMaxDelayMs);
         LOG.infof("Scheduling %s watch reconnect (attempt %d/%d, delay %dms)",
-            watchName, attempt, RECONNECT_MAX_ATTEMPTS, delay);
+            watchName, attempt, reconnectMaxAttempts, delay);
         reconnectExecutor.schedule(() -> {
             if (shuttingDown) {
                 return;
@@ -375,7 +381,7 @@ public class ResourceSubscriptionManager implements Closeable {
 
     // ---- Reconciliation ----
 
-    @Scheduled(every = "5m", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(every = "${mcp.watch.reconcile-interval:5m}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void reconcileState() {
         if (!watchesEnabled || shuttingDown) {
             return;

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManagerTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManagerTest.java
@@ -37,6 +37,10 @@ import static org.mockito.Mockito.when;
 @QuarkusTest
 class ResourceSubscriptionManagerTest {
 
+    private static final long DEFAULT_INITIAL_DELAY_MS = 1000;
+    private static final long DEFAULT_MAX_DELAY_MS = 60_000;
+    private static final int DEFAULT_MAX_ATTEMPTS = 10;
+
     @InjectMock
     KubernetesClient kubernetesClient;
 
@@ -133,25 +137,17 @@ class ResourceSubscriptionManagerTest {
         manager.scheduleReconnect("Test", () -> {
             callCount.incrementAndGet();
             return false;
-        }, ResourceSubscriptionManager.RECONNECT_MAX_ATTEMPTS + 1);
+        }, DEFAULT_MAX_ATTEMPTS + 1);
 
         assertEquals(0, callCount.get());
     }
 
     @Test
     void testReconnectBackoffDelayCalculation() {
-        assertEquals(1000L,
-            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 0,
-                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
-        assertEquals(2000L,
-            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 1,
-                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
-        assertEquals(4000L,
-            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 2,
-                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
-        assertEquals(60_000L,
-            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 6,
-                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
+        assertEquals(1000L, Math.min(DEFAULT_INITIAL_DELAY_MS << 0, DEFAULT_MAX_DELAY_MS));
+        assertEquals(2000L, Math.min(DEFAULT_INITIAL_DELAY_MS << 1, DEFAULT_MAX_DELAY_MS));
+        assertEquals(4000L, Math.min(DEFAULT_INITIAL_DELAY_MS << 2, DEFAULT_MAX_DELAY_MS));
+        assertEquals(60_000L, Math.min(DEFAULT_INITIAL_DELAY_MS << 6, DEFAULT_MAX_DELAY_MS));
     }
 
     @Test

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManagerTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManagerTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.resource;
+
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ResourceSubscriptionManager} watch resilience.
+ */
+@QuarkusTest
+class ResourceSubscriptionManagerTest {
+
+    @InjectMock
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    ResourceSubscriptionManager manager;
+
+    ResourceSubscriptionManagerTest() {
+    }
+
+    @BeforeEach
+    void setUp() {
+        manager.setShuttingDown(false);
+        manager.setWatchesEnabled(true);
+        manager.getActiveWatches().clear();
+        manager.getLastKnownState().clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        manager.setShuttingDown(false);
+        manager.setWatchesEnabled(false);
+    }
+
+    // ---- 2a: Safe watch closure ----
+
+    @Test
+    void testCloseHandlesExceptionFromOneWatch() {
+        Watch watch1 = mock(Watch.class);
+        Watch watch2 = mock(Watch.class);
+        Watch watch3 = mock(Watch.class);
+        Mockito.doThrow(new RuntimeException("close failed")).when(watch2).close();
+
+        manager.getActiveWatches().add(watch1);
+        manager.getActiveWatches().add(watch2);
+        manager.getActiveWatches().add(watch3);
+
+        manager.close();
+
+        verify(watch1).close();
+        verify(watch2).close();
+        verify(watch3).close();
+        assertTrue(manager.getActiveWatches().isEmpty());
+        assertTrue(manager.getLastKnownState().isEmpty());
+    }
+
+    @Test
+    void testCloseHandlesAllWatchesThrowingExceptions() {
+        Watch watch1 = mock(Watch.class);
+        Watch watch2 = mock(Watch.class);
+        Mockito.doThrow(new RuntimeException("fail1")).when(watch1).close();
+        Mockito.doThrow(new RuntimeException("fail2")).when(watch2).close();
+
+        manager.getActiveWatches().add(watch1);
+        manager.getActiveWatches().add(watch2);
+
+        manager.close();
+
+        verify(watch1).close();
+        verify(watch2).close();
+        assertTrue(manager.getActiveWatches().isEmpty());
+    }
+
+    @Test
+    void testCloseSetsShuttingDown() {
+        manager.close();
+        assertTrue(manager.isShuttingDown());
+    }
+
+    @Test
+    void testCloseClearsLastKnownState() {
+        manager.getLastKnownState().put("strimzi://test/uri", "{}");
+        manager.close();
+        assertTrue(manager.getLastKnownState().isEmpty());
+    }
+
+    // ---- 2b: Watch reconnection ----
+
+    @Test
+    void testNoReconnectDuringShutdown() {
+        manager.setShuttingDown(true);
+        AtomicInteger callCount = new AtomicInteger();
+
+        manager.scheduleReconnect("Test", () -> {
+            callCount.incrementAndGet();
+            return true;
+        }, 1);
+
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    void testReconnectGivesUpAfterMaxAttempts() {
+        AtomicInteger callCount = new AtomicInteger();
+
+        manager.scheduleReconnect("Test", () -> {
+            callCount.incrementAndGet();
+            return false;
+        }, ResourceSubscriptionManager.RECONNECT_MAX_ATTEMPTS + 1);
+
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    void testReconnectBackoffDelayCalculation() {
+        assertEquals(1000L,
+            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 0,
+                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
+        assertEquals(2000L,
+            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 1,
+                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
+        assertEquals(4000L,
+            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 2,
+                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
+        assertEquals(60_000L,
+            Math.min(ResourceSubscriptionManager.RECONNECT_INITIAL_DELAY_MS << 6,
+                ResourceSubscriptionManager.RECONNECT_MAX_DELAY_MS));
+    }
+
+    @Test
+    void testSuccessfulReconnectDoesNotRetry() throws InterruptedException {
+        AtomicInteger callCount = new AtomicInteger();
+
+        manager.scheduleReconnect("Test", () -> {
+            callCount.incrementAndGet();
+            return true;
+        }, 1);
+
+        Thread.sleep(2000);
+        assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void testFailedReconnectSchedulesRetry() throws InterruptedException {
+        AtomicInteger callCount = new AtomicInteger();
+
+        manager.scheduleReconnect("Test", () -> {
+            callCount.incrementAndGet();
+            return false;
+        }, 1);
+
+        Thread.sleep(4000);
+        assertTrue(callCount.get() >= 2, "Expected at least 2 attempts, got " + callCount.get());
+    }
+
+    // ---- 2d: Reconciliation ----
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testReconcileRemovesOrphanedKafkaEntry() {
+        String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
+        manager.getLastKnownState().put(uri, "{}");
+
+        MixedOperation kafkaOp = mock(MixedOperation.class);
+        Mockito.doReturn(kafkaOp).when(kubernetesClient).resources(Kafka.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        when(kafkaOp.inNamespace("kafka")).thenReturn(nsOp);
+        Resource resource = mock(Resource.class);
+        when(nsOp.withName("my-cluster")).thenReturn(resource);
+        when(resource.get()).thenReturn(null);
+
+        manager.reconcileState();
+
+        assertFalse(manager.getLastKnownState().containsKey(uri));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testReconcileKeepsExistingResource() {
+        String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
+        manager.getLastKnownState().put(uri, "{}");
+
+        MixedOperation kafkaOp = mock(MixedOperation.class);
+        Mockito.doReturn(kafkaOp).when(kubernetesClient).resources(Kafka.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        when(kafkaOp.inNamespace("kafka")).thenReturn(nsOp);
+        Resource resource = mock(Resource.class);
+        when(nsOp.withName("my-cluster")).thenReturn(resource);
+        when(resource.get()).thenReturn(new Kafka());
+
+        manager.reconcileState();
+
+        assertTrue(manager.getLastKnownState().containsKey(uri));
+    }
+
+    @Test
+    void testReconcileSkipsWhenShuttingDown() {
+        manager.setShuttingDown(true);
+        String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
+        manager.getLastKnownState().put(uri, "{}");
+
+        manager.reconcileState();
+
+        assertTrue(manager.getLastKnownState().containsKey(uri));
+    }
+
+    @Test
+    void testReconcileHandlesUnparsableUri() {
+        manager.getLastKnownState().put("invalid-uri", "{}");
+
+        manager.reconcileState();
+
+        assertTrue(manager.getLastKnownState().containsKey("invalid-uri"));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testReconcileHandlesKubernetesApiFailure() {
+        String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
+        manager.getLastKnownState().put(uri, "{}");
+
+        when(kubernetesClient.resources(Kafka.class))
+            .thenThrow(new RuntimeException("API unavailable"));
+
+        manager.reconcileState();
+
+        assertTrue(manager.getLastKnownState().containsKey(uri));
+    }
+
+    @Test
+    void testResourceExistsReturnsTrueForUnknownKind() {
+        assertTrue(manager.resourceExistsInCluster(
+            "strimzi://test/namespaces/ns/unknownkind/name/status"));
+    }
+
+    @Test
+    void testResourceExistsReturnsTrueForShortUri() {
+        assertTrue(manager.resourceExistsInCluster("strimzi://too/short"));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testReconcileRemovesOrphanedTopicEntry() {
+        String uri = "strimzi://kafka.strimzi.io/namespaces/prod/kafkatopics/my-topic/status";
+        manager.getLastKnownState().put(uri, "{}");
+
+        MixedOperation topicOp = mock(MixedOperation.class);
+        Mockito.doReturn(topicOp).when(kubernetesClient).resources(KafkaTopic.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        when(topicOp.inNamespace("prod")).thenReturn(nsOp);
+        Resource resource = mock(Resource.class);
+        when(nsOp.withName("my-topic")).thenReturn(resource);
+        when(resource.get()).thenReturn(null);
+
+        manager.reconcileState();
+
+        assertFalse(manager.getLastKnownState().containsKey(uri));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testReconcileChecksOperatorDeployment() {
+        String uri = "strimzi://operator.strimzi.io/namespaces/kafka/clusteroperator/strimzi-co/status";
+        manager.getLastKnownState().put(uri, "{}");
+
+        AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
+        when(kubernetesClient.apps()).thenReturn(appsApi);
+        MixedOperation deploymentOp = mock(MixedOperation.class);
+        when(appsApi.deployments()).thenReturn(deploymentOp);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        when(deploymentOp.inNamespace("kafka")).thenReturn(nsOp);
+        RollableScalableResource resource = mock(RollableScalableResource.class);
+        when(nsOp.withName("strimzi-co")).thenReturn(resource);
+        when(resource.get()).thenReturn(new Deployment());
+
+        manager.reconcileState();
+
+        assertTrue(manager.getLastKnownState().containsKey(uri));
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManagerTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManagerTest.java
@@ -50,8 +50,8 @@ class ResourceSubscriptionManagerTest {
     void setUp() {
         manager.setShuttingDown(false);
         manager.setWatchesEnabled(true);
-        manager.getActiveWatches().clear();
-        manager.getLastKnownState().clear();
+        manager.clearWatches();
+        manager.clearState();
     }
 
     @AfterEach
@@ -69,17 +69,16 @@ class ResourceSubscriptionManagerTest {
         Watch watch3 = mock(Watch.class);
         Mockito.doThrow(new RuntimeException("close failed")).when(watch2).close();
 
-        manager.getActiveWatches().add(watch1);
-        manager.getActiveWatches().add(watch2);
-        manager.getActiveWatches().add(watch3);
+        manager.addWatch(watch1);
+        manager.addWatch(watch2);
+        manager.addWatch(watch3);
 
         manager.close();
 
         verify(watch1).close();
         verify(watch2).close();
         verify(watch3).close();
-        assertTrue(manager.getActiveWatches().isEmpty());
-        assertTrue(manager.getLastKnownState().isEmpty());
+        assertEquals(0, manager.watchCount());
     }
 
     @Test
@@ -89,14 +88,14 @@ class ResourceSubscriptionManagerTest {
         Mockito.doThrow(new RuntimeException("fail1")).when(watch1).close();
         Mockito.doThrow(new RuntimeException("fail2")).when(watch2).close();
 
-        manager.getActiveWatches().add(watch1);
-        manager.getActiveWatches().add(watch2);
+        manager.addWatch(watch1);
+        manager.addWatch(watch2);
 
         manager.close();
 
         verify(watch1).close();
         verify(watch2).close();
-        assertTrue(manager.getActiveWatches().isEmpty());
+        assertEquals(0, manager.watchCount());
     }
 
     @Test
@@ -107,9 +106,9 @@ class ResourceSubscriptionManagerTest {
 
     @Test
     void testCloseClearsLastKnownState() {
-        manager.getLastKnownState().put("strimzi://test/uri", "{}");
+        manager.putState("strimzi://test/uri", "{}");
         manager.close();
-        assertTrue(manager.getLastKnownState().isEmpty());
+        assertFalse(manager.containsState("strimzi://test/uri"));
     }
 
     // ---- 2b: Watch reconnection ----
@@ -187,7 +186,7 @@ class ResourceSubscriptionManagerTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     void testReconcileRemovesOrphanedKafkaEntry() {
         String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
-        manager.getLastKnownState().put(uri, "{}");
+        manager.putState(uri, "{}");
 
         MixedOperation kafkaOp = mock(MixedOperation.class);
         Mockito.doReturn(kafkaOp).when(kubernetesClient).resources(Kafka.class);
@@ -199,14 +198,14 @@ class ResourceSubscriptionManagerTest {
 
         manager.reconcileState();
 
-        assertFalse(manager.getLastKnownState().containsKey(uri));
+        assertFalse(manager.containsState(uri));
     }
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     void testReconcileKeepsExistingResource() {
         String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
-        manager.getLastKnownState().put(uri, "{}");
+        manager.putState(uri, "{}");
 
         MixedOperation kafkaOp = mock(MixedOperation.class);
         Mockito.doReturn(kafkaOp).when(kubernetesClient).resources(Kafka.class);
@@ -218,41 +217,41 @@ class ResourceSubscriptionManagerTest {
 
         manager.reconcileState();
 
-        assertTrue(manager.getLastKnownState().containsKey(uri));
+        assertTrue(manager.containsState(uri));
     }
 
     @Test
     void testReconcileSkipsWhenShuttingDown() {
         manager.setShuttingDown(true);
         String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
-        manager.getLastKnownState().put(uri, "{}");
+        manager.putState(uri, "{}");
 
         manager.reconcileState();
 
-        assertTrue(manager.getLastKnownState().containsKey(uri));
+        assertTrue(manager.containsState(uri));
     }
 
     @Test
     void testReconcileHandlesUnparsableUri() {
-        manager.getLastKnownState().put("invalid-uri", "{}");
+        manager.putState("invalid-uri", "{}");
 
         manager.reconcileState();
 
-        assertTrue(manager.getLastKnownState().containsKey("invalid-uri"));
+        assertTrue(manager.containsState("invalid-uri"));
     }
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     void testReconcileHandlesKubernetesApiFailure() {
         String uri = "strimzi://kafka.strimzi.io/namespaces/kafka/kafkas/my-cluster/status";
-        manager.getLastKnownState().put(uri, "{}");
+        manager.putState(uri, "{}");
 
         when(kubernetesClient.resources(Kafka.class))
             .thenThrow(new RuntimeException("API unavailable"));
 
         manager.reconcileState();
 
-        assertTrue(manager.getLastKnownState().containsKey(uri));
+        assertTrue(manager.containsState(uri));
     }
 
     @Test
@@ -270,7 +269,7 @@ class ResourceSubscriptionManagerTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     void testReconcileRemovesOrphanedTopicEntry() {
         String uri = "strimzi://kafka.strimzi.io/namespaces/prod/kafkatopics/my-topic/status";
-        manager.getLastKnownState().put(uri, "{}");
+        manager.putState(uri, "{}");
 
         MixedOperation topicOp = mock(MixedOperation.class);
         Mockito.doReturn(topicOp).when(kubernetesClient).resources(KafkaTopic.class);
@@ -282,14 +281,14 @@ class ResourceSubscriptionManagerTest {
 
         manager.reconcileState();
 
-        assertFalse(manager.getLastKnownState().containsKey(uri));
+        assertFalse(manager.containsState(uri));
     }
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     void testReconcileChecksOperatorDeployment() {
         String uri = "strimzi://operator.strimzi.io/namespaces/kafka/clusteroperator/strimzi-co/status";
-        manager.getLastKnownState().put(uri, "{}");
+        manager.putState(uri, "{}");
 
         AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
         when(kubernetesClient.apps()).thenReturn(appsApi);
@@ -303,6 +302,6 @@ class ResourceSubscriptionManagerTest {
 
         manager.reconcileState();
 
-        assertTrue(manager.getLastKnownState().containsKey(uri));
+        assertTrue(manager.containsState(uri));
     }
 }

--- a/strimzi-mcp/src/test/resources/application.properties
+++ b/strimzi-mcp/src/test/resources/application.properties
@@ -7,5 +7,8 @@ quarkus.kubernetes-client.namespace=test
 # Disable resource watches in tests (no live cluster)
 mcp.resource-watches.enabled=false
 
+# Disable scheduler in tests (no live cluster)
+quarkus.scheduler.enabled=false
+
 # Log configuration for tests
 mcp.log.tail-lines=200


### PR DESCRIPTION
## Description

* Wrap each watch.close() in individual try-catch during shutdown                                                                                                                             
* Add exponential backoff reconnection (1s-60s, max 10 attempts) when onClose fires with a non-null cause                                                                                                                             
* Add Scheduled periodic reconciliation (every 5m) that removes orphaned lastKnownState entries by checking K8s API for existence                                                                                                                           
* Add quarkus-scheduler dependency for Scheduled support   

## Type of change

* Bug fix (non-breaking change which fixes an issue)

