### PR TITLE
Add metrics aggregation with hierarchical levels

### DIFF
--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/AggregatedTimeSeries.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/AggregatedTimeSeries.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.common.util.metrics.MetricLabelFilter;
+import io.streamshub.mcp.common.util.metrics.TimeSeriesCompressor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * A metric time series that aggregates samples across dimensions based on an
+ * {@link AggregationLevel}. Samples that differ only in stripped labels (e.g.,
+ * different pods at BROKER level) have their values averaged together.
+ *
+ * @param name        the metric name
+ * @param labels      the remaining labels after aggregation
+ * @param dataPoints  the averaged [epochSeconds, value] pairs (compressed)
+ * @param summary     summary statistics computed from the averaged data
+ * @param sourceCount the number of distinct source series that were averaged
+ * @param compressed  true if constant-value runs were collapsed, null otherwise
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AggregatedTimeSeries(
+    @JsonProperty("name") String name,
+    @JsonProperty("labels") Map<String, String> labels,
+    @JsonProperty("data_points") List<List<Object>> dataPoints,
+    @JsonProperty("summary") TimeSeriesSummary summary,
+    @JsonProperty("source_count") int sourceCount,
+    @JsonProperty("compressed") Boolean compressed
+) {
+
+    /**
+     * Groups and aggregates metric samples by name and labels at the given
+     * aggregation level. Samples that share the same name and aggregated labels
+     * have their values averaged per timestamp.
+     *
+     * @param samples the metric samples to aggregate
+     * @param level   the aggregation level controlling which labels are stripped
+     * @return a list of aggregated time series
+     */
+    public static List<AggregatedTimeSeries> fromSamples(final List<MetricSample> samples,
+                                                          final AggregationLevel level) {
+        if (samples == null || samples.isEmpty()) {
+            return List.of();
+        }
+
+        // Group samples by aggregation key (name + filtered labels)
+        Map<String, List<MetricSample>> groups = new LinkedHashMap<>();
+        Map<String, Map<String, String>> groupLabels = new LinkedHashMap<>();
+
+        for (MetricSample sample : samples) {
+            Map<String, String> filtered = MetricLabelFilter.labelsForAggregation(sample.labels(), level);
+            String key = sample.name() + "|" + filtered;
+            groups.computeIfAbsent(key, k -> new ArrayList<>()).add(sample);
+            groupLabels.putIfAbsent(key, filtered);
+        }
+
+        List<AggregatedTimeSeries> result = new ArrayList<>();
+
+        for (Map.Entry<String, List<MetricSample>> entry : groups.entrySet()) {
+            List<MetricSample> groupSamples = entry.getValue();
+            Map<String, String> labels = groupLabels.get(entry.getKey());
+            String metricName = groupSamples.getFirst().name();
+
+            // Sub-group by timestamp, average values at each timestamp
+            Map<Long, List<Double>> byTimestamp = new TreeMap<>();
+            for (MetricSample s : groupSamples) {
+                long epoch = s.timestamp() != null ? s.timestamp().getEpochSecond() : 0L;
+                byTimestamp.computeIfAbsent(epoch, k -> new ArrayList<>()).add(s.value());
+            }
+
+            List<List<Object>> dataPoints = new ArrayList<>();
+            int maxSources = 0;
+            for (Map.Entry<Long, List<Double>> tsEntry : byTimestamp.entrySet()) {
+                List<Double> values = tsEntry.getValue();
+                double avg = values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+                dataPoints.add(List.of(tsEntry.getKey(), avg));
+                maxSources = Math.max(maxSources, values.size());
+            }
+
+            TimeSeriesSummary summary = TimeSeriesSummary.of(dataPoints);
+            List<List<Object>> compressed = TimeSeriesCompressor.compress(dataPoints);
+            Boolean wasCompressed = compressed.size() < dataPoints.size() ? Boolean.TRUE : null;
+
+            result.add(new AggregatedTimeSeries(metricName, labels, compressed, summary,
+                maxSources, wasCompressed));
+        }
+
+        return List.copyOf(result);
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/AggregationLevel.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/AggregationLevel.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import java.util.Locale;
+
+/**
+ * Controls how metric samples are aggregated before being returned to the client.
+ * Each level names the dimension to group by; dimensions below that level are
+ * averaged out.
+ */
+public enum AggregationLevel {
+
+    /**
+     * Full detail: keep pod + topic + partition. No averaging.
+     */
+    PARTITION,
+
+    /**
+     * Keep pod + topic, average across partitions.
+     */
+    TOPIC,
+
+    /**
+     * Keep pod only, average across topics and partitions.
+     */
+    BROKER,
+
+    /**
+     * Average across all dimensions. Single value per metric + intrinsic labels.
+     */
+    CLUSTER;
+
+    /**
+     * Clamps this level to a ceiling: if this level is finer (lower ordinal)
+     * than the ceiling, the ceiling is returned; otherwise this level is kept.
+     *
+     * @param ceiling the finest meaningful level for a given category
+     * @return the clamped level
+     */
+    public AggregationLevel clampTo(final AggregationLevel ceiling) {
+        return this.ordinal() < ceiling.ordinal() ? ceiling : this;
+    }
+
+    /**
+     * Parses a string to an aggregation level (case-insensitive).
+     * Returns {@link #BROKER} if the input is null or blank.
+     *
+     * @param value the level name
+     * @return the parsed level, or BROKER as default
+     */
+    public static AggregationLevel fromString(final String value) {
+        if (value == null || value.isBlank()) {
+            return BROKER;
+        }
+        return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilter.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilter.java
@@ -4,6 +4,9 @@
  */
 package io.streamshub.mcp.common.util.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
+
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +26,20 @@ public final class MetricLabelFilter {
         "container",
         "prometheus",
         "service"
+    );
+
+    private static final Set<String> POD_IDENTITY_LABELS = Set.of(
+        "pod", "kubernetes_pod_name", "strimzi_io_pod_name", "node_name", "node_ip"
+    );
+
+    private static final Set<String> CANONICAL_LABELS = Set.of("pod", "topic", "partition");
+
+    private static final Set<String> TOPIC_PARTITION_LABELS = Set.of(
+        "topic", "partition"
+    );
+
+    private static final Set<String> PARTITION_LABELS = Set.of(
+        "partition"
     );
 
     private MetricLabelFilter() {
@@ -46,6 +63,76 @@ public final class MetricLabelFilter {
                 filtered.put(entry.getKey(), entry.getValue());
             }
         }
-        return filtered;
+        return deduplicateByValue(filtered);
+    }
+
+    /**
+     * Filters labels for aggregation at the given level. Always strips internal labels,
+     * then strips additional labels based on the aggregation level:
+     * <ul>
+     *   <li>PARTITION — no extra stripping (full detail)</li>
+     *   <li>TOPIC — strips partition labels</li>
+     *   <li>BROKER — strips topic + partition labels</li>
+     *   <li>CLUSTER — strips topic + partition + pod identity labels</li>
+     * </ul>
+     *
+     * @param labels the original label map (may be null)
+     * @param level  the aggregation level
+     * @return a new map with the appropriate labels removed
+     */
+    public static Map<String, String> labelsForAggregation(final Map<String, String> labels,
+                                                            final AggregationLevel level) {
+        if (labels == null || labels.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> filtered = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            String key = entry.getKey();
+            if (INTERNAL_LABELS.contains(key)) {
+                continue;
+            }
+            if (shouldStripForLevel(key, level)) {
+                continue;
+            }
+            filtered.put(key, entry.getValue());
+        }
+        return deduplicateByValue(filtered);
+    }
+
+    static Map<String, String> deduplicateByValue(final Map<String, String> labels) {
+        if (labels == null || labels.size() <= 1) {
+            return labels == null ? Map.of() : labels;
+        }
+
+        Set<String> canonicalValues = new HashSet<>();
+        for (String canonical : CANONICAL_LABELS) {
+            String val = labels.get(canonical);
+            if (val != null) {
+                canonicalValues.add(val);
+            }
+        }
+
+        if (canonicalValues.isEmpty()) {
+            return labels;
+        }
+
+        Map<String, String> result = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            if (CANONICAL_LABELS.contains(entry.getKey())
+                    || !canonicalValues.contains(entry.getValue())) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    private static boolean shouldStripForLevel(final String key, final AggregationLevel level) {
+        return switch (level) {
+            case PARTITION -> false;
+            case TOPIC -> PARTITION_LABELS.contains(key);
+            case BROKER -> TOPIC_PARTITION_LABELS.contains(key);
+            case CLUSTER -> TOPIC_PARTITION_LABELS.contains(key) || POD_IDENTITY_LABELS.contains(key);
+        };
     }
 }

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregatedTimeSeriesTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregatedTimeSeriesTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AggregatedTimeSeries}.
+ */
+class AggregatedTimeSeriesTest {
+
+    AggregatedTimeSeriesTest() {
+    }
+
+    @Test
+    void emptyInputReturnsEmptyList() {
+        assertTrue(AggregatedTimeSeries.fromSamples(List.of(), AggregationLevel.BROKER).isEmpty());
+    }
+
+    @Test
+    void nullInputReturnsEmptyList() {
+        assertTrue(AggregatedTimeSeries.fromSamples(null, AggregationLevel.BROKER).isEmpty());
+    }
+
+    @Test
+    void partitionLevelKeepsAllLabels() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "0"), 10.0),
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "1"), 20.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.PARTITION);
+
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).sourceCount());
+        assertEquals(1, result.get(1).sourceCount());
+        assertTrue(result.get(0).labels().containsKey("partition"));
+        assertTrue(result.get(0).labels().containsKey("topic"));
+        assertTrue(result.get(0).labels().containsKey("pod"));
+    }
+
+    @Test
+    void topicLevelAveragesAcrossPartitions() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "0"), 10.0),
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "1"), 20.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.TOPIC);
+
+        assertEquals(1, result.size());
+        AggregatedTimeSeries series = result.getFirst();
+        assertEquals("m", series.name());
+        assertEquals(2, series.sourceCount());
+        assertEquals(15.0, series.summary().avg(), 0.001);
+        assertTrue(series.labels().containsKey("topic"));
+        assertTrue(series.labels().containsKey("pod"));
+        assertTrue(!series.labels().containsKey("partition"));
+    }
+
+    @Test
+    void brokerLevelAveragesAcrossTopicsAndPartitions() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "0"), 10.0),
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "1"), 20.0),
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t2", "partition", "0"), 30.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.BROKER);
+
+        assertEquals(1, result.size());
+        AggregatedTimeSeries series = result.getFirst();
+        assertEquals(3, series.sourceCount());
+        assertEquals(20.0, series.summary().avg(), 0.001);
+        assertTrue(series.labels().containsKey("pod"));
+        assertTrue(!series.labels().containsKey("topic"));
+        assertTrue(!series.labels().containsKey("partition"));
+    }
+
+    @Test
+    void brokerLevelKeepsPerBrokerDistinction() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1"), 10.0),
+            MetricSample.of("m", Map.of("pod", "pod-1", "topic", "t1"), 30.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.BROKER);
+
+        assertEquals(2, result.size());
+        assertEquals("pod-0", result.get(0).labels().get("pod"));
+        assertEquals("pod-1", result.get(1).labels().get("pod"));
+        assertEquals(10.0, result.get(0).summary().latest(), 0.001);
+        assertEquals(30.0, result.get(1).summary().latest(), 0.001);
+    }
+
+    @Test
+    void clusterLevelAveragesAcrossAllDimensions() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t1", "partition", "0"), 10.0),
+            MetricSample.of("m", Map.of("pod", "pod-1", "topic", "t1", "partition", "0"), 20.0),
+            MetricSample.of("m", Map.of("pod", "pod-0", "topic", "t2", "partition", "0"), 30.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.CLUSTER);
+
+        assertEquals(1, result.size());
+        AggregatedTimeSeries series = result.getFirst();
+        assertEquals(3, series.sourceCount());
+        assertEquals(20.0, series.summary().avg(), 0.001);
+        assertTrue(!series.labels().containsKey("pod"));
+        assertTrue(!series.labels().containsKey("topic"));
+        assertTrue(!series.labels().containsKey("partition"));
+    }
+
+    @Test
+    void intrinsicLabelsPreservedAtAllLevels() {
+        Map<String, String> labels = Map.of(
+            "pod", "pod-0", "topic", "t1", "partition", "0",
+            "type", "producer-metrics", "quantile", "0.99"
+        );
+        List<MetricSample> samples = List.of(MetricSample.of("m", labels, 42.0));
+
+        for (AggregationLevel level : AggregationLevel.values()) {
+            List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, level);
+            assertEquals(1, result.size());
+            assertEquals("producer-metrics", result.getFirst().labels().get("type"));
+            assertEquals("0.99", result.getFirst().labels().get("quantile"));
+        }
+    }
+
+    @Test
+    void nullTimestampsUseEpochZero() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0"), 5.0),
+            MetricSample.of("m", Map.of("pod", "pod-1"), 15.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.CLUSTER);
+
+        assertEquals(1, result.size());
+        assertEquals(0L, result.getFirst().dataPoints().getFirst().getFirst());
+        assertEquals(10.0, result.getFirst().summary().avg(), 0.001);
+    }
+
+    @Test
+    void rangeDataWithMultipleTimestampsAveragedPerTimestamp() {
+        Instant t1 = Instant.ofEpochSecond(1000);
+        Instant t2 = Instant.ofEpochSecond(1060);
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0"), 10.0, t1),
+            MetricSample.of("m", Map.of("pod", "pod-1"), 20.0, t1),
+            MetricSample.of("m", Map.of("pod", "pod-0"), 30.0, t2),
+            MetricSample.of("m", Map.of("pod", "pod-1"), 40.0, t2)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.CLUSTER);
+
+        assertEquals(1, result.size());
+        AggregatedTimeSeries series = result.getFirst();
+        assertEquals(2, series.dataPoints().size());
+        assertEquals(15.0, ((Number) series.dataPoints().get(0).get(1)).doubleValue(), 0.001);
+        assertEquals(35.0, ((Number) series.dataPoints().get(1).get(1)).doubleValue(), 0.001);
+        assertEquals(2, series.sourceCount());
+    }
+
+    @Test
+    void summaryComputedFromAveragedData() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("m", Map.of("pod", "pod-0"), 100.0),
+            MetricSample.of("m", Map.of("pod", "pod-1"), 200.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.CLUSTER);
+
+        assertNotNull(result.getFirst().summary());
+        assertEquals(150.0, result.getFirst().summary().latest(), 0.001);
+        assertEquals(150.0, result.getFirst().summary().min(), 0.001);
+        assertEquals(150.0, result.getFirst().summary().max(), 0.001);
+    }
+
+    @Test
+    void differentMetricNamesProduceSeparateSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0),
+            MetricSample.of("metric_b", Map.of("pod", "pod-0"), 2.0)
+        );
+
+        List<AggregatedTimeSeries> result = AggregatedTimeSeries.fromSamples(samples, AggregationLevel.CLUSTER);
+
+        assertEquals(2, result.size());
+        assertEquals("metric_a", result.get(0).name());
+        assertEquals("metric_b", result.get(1).name());
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregationLevelTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregationLevelTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.dto.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link AggregationLevel}.
+ */
+class AggregationLevelTest {
+
+    AggregationLevelTest() {
+    }
+
+    @Test
+    void fromStringNullDefaultsToBroker() {
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString(null));
+    }
+
+    @Test
+    void fromStringBlankDefaultsToBroker() {
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString(""));
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString("   "));
+    }
+
+    @Test
+    void fromStringParsesValidValues() {
+        assertEquals(AggregationLevel.PARTITION, AggregationLevel.fromString("partition"));
+        assertEquals(AggregationLevel.TOPIC, AggregationLevel.fromString("topic"));
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString("broker"));
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.fromString("cluster"));
+    }
+
+    @Test
+    void fromStringIsCaseInsensitive() {
+        assertEquals(AggregationLevel.PARTITION, AggregationLevel.fromString("PARTITION"));
+        assertEquals(AggregationLevel.TOPIC, AggregationLevel.fromString("Topic"));
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString("bRoKeR"));
+    }
+
+    @Test
+    void fromStringInvalidThrows() {
+        assertThrows(IllegalArgumentException.class, () -> AggregationLevel.fromString("invalid"));
+    }
+
+    @Test
+    void clampToFinerThanCeilingReturnsCeiling() {
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.PARTITION.clampTo(AggregationLevel.BROKER));
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.TOPIC.clampTo(AggregationLevel.BROKER));
+        assertEquals(AggregationLevel.TOPIC, AggregationLevel.PARTITION.clampTo(AggregationLevel.TOPIC));
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.PARTITION.clampTo(AggregationLevel.CLUSTER));
+    }
+
+    @Test
+    void clampToCoarserThanCeilingKeepsOriginal() {
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.CLUSTER.clampTo(AggregationLevel.BROKER));
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.CLUSTER.clampTo(AggregationLevel.PARTITION));
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.BROKER.clampTo(AggregationLevel.TOPIC));
+    }
+
+    @Test
+    void clampToSameLevelReturnsSame() {
+        assertEquals(AggregationLevel.BROKER, AggregationLevel.BROKER.clampTo(AggregationLevel.BROKER));
+        assertEquals(AggregationLevel.PARTITION, AggregationLevel.PARTITION.clampTo(AggregationLevel.PARTITION));
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.CLUSTER.clampTo(AggregationLevel.CLUSTER));
+    }
+}

--- a/common/src/test/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilterTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilterTest.java
@@ -4,12 +4,14 @@
  */
 package io.streamshub.mcp.common.util.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -84,5 +86,146 @@ class MetricLabelFilterTest {
         assertEquals("kafka-system", result.get("namespace"));
         assertEquals("broker-0", result.get("pod"));
         assertEquals("Kafka", result.get("kind"));
+    }
+
+    @Test
+    void partitionLevelKeepsEverything() {
+        Map<String, String> labels = allLabels();
+        Map<String, String> result = MetricLabelFilter.labelsForAggregation(labels, AggregationLevel.PARTITION);
+        assertTrue(result.containsKey("pod"));
+        assertTrue(result.containsKey("topic"));
+        assertTrue(result.containsKey("partition"));
+        assertTrue(result.containsKey("type"));
+        assertFalse(result.containsKey("__name__"));
+        assertFalse(result.containsKey("kubernetes_pod_name"));
+        assertFalse(result.containsKey("strimzi_io_pod_name"));
+    }
+
+    @Test
+    void topicLevelStripsPartition() {
+        Map<String, String> labels = allLabels();
+        Map<String, String> result = MetricLabelFilter.labelsForAggregation(labels, AggregationLevel.TOPIC);
+        assertTrue(result.containsKey("pod"));
+        assertTrue(result.containsKey("topic"));
+        assertFalse(result.containsKey("partition"));
+        assertTrue(result.containsKey("type"));
+        assertFalse(result.containsKey("kubernetes_pod_name"));
+        assertFalse(result.containsKey("strimzi_io_pod_name"));
+    }
+
+    @Test
+    void brokerLevelStripsTopicAndPartition() {
+        Map<String, String> labels = allLabels();
+        Map<String, String> result = MetricLabelFilter.labelsForAggregation(labels, AggregationLevel.BROKER);
+        assertTrue(result.containsKey("pod"));
+        assertFalse(result.containsKey("topic"));
+        assertFalse(result.containsKey("partition"));
+        assertTrue(result.containsKey("type"));
+        assertFalse(result.containsKey("kubernetes_pod_name"));
+        assertFalse(result.containsKey("strimzi_io_pod_name"));
+    }
+
+    @Test
+    void clusterLevelStripsTopicPartitionAndPodIdentity() {
+        Map<String, String> labels = allLabels();
+        Map<String, String> result = MetricLabelFilter.labelsForAggregation(labels, AggregationLevel.CLUSTER);
+        assertFalse(result.containsKey("pod"));
+        assertFalse(result.containsKey("kubernetes_pod_name"));
+        assertFalse(result.containsKey("strimzi_io_pod_name"));
+        assertFalse(result.containsKey("node_name"));
+        assertFalse(result.containsKey("node_ip"));
+        assertFalse(result.containsKey("topic"));
+        assertFalse(result.containsKey("partition"));
+        assertTrue(result.containsKey("type"));
+        assertTrue(result.containsKey("namespace"));
+    }
+
+    @Test
+    void labelsForAggregationWithNullReturnsEmpty() {
+        assertTrue(MetricLabelFilter.labelsForAggregation(null, AggregationLevel.BROKER).isEmpty());
+    }
+
+    @Test
+    void labelsForAggregationAlwaysStripsInternalLabels() {
+        Map<String, String> labels = Map.of("__name__", "test", "job", "kafka", "type", "producer");
+        for (AggregationLevel level : AggregationLevel.values()) {
+            Map<String, String> result = MetricLabelFilter.labelsForAggregation(labels, level);
+            assertFalse(result.containsKey("__name__"));
+            assertFalse(result.containsKey("job"));
+            assertTrue(result.containsKey("type"));
+        }
+    }
+
+    @Test
+    void duplicateValuesAreStrippedByFilterLabels() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("pod", "broker-0");
+        labels.put("kubernetes_pod_name", "broker-0");
+        labels.put("strimzi_io_pod_name", "broker-0");
+        labels.put("namespace", "kafka-system");
+
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertTrue(result.containsKey("pod"));
+        assertFalse(result.containsKey("kubernetes_pod_name"));
+        assertFalse(result.containsKey("strimzi_io_pod_name"));
+        assertTrue(result.containsKey("namespace"));
+    }
+
+    @Test
+    void canonicalLabelsAreNeverStripped() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("pod", "broker-0");
+        labels.put("topic", "my-topic");
+        labels.put("partition", "0");
+        labels.put("other_pod", "broker-0");
+        labels.put("other_topic", "my-topic");
+
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertTrue(result.containsKey("pod"));
+        assertTrue(result.containsKey("topic"));
+        assertTrue(result.containsKey("partition"));
+        assertFalse(result.containsKey("other_pod"));
+        assertFalse(result.containsKey("other_topic"));
+    }
+
+    @Test
+    void uniqueValuesAreKept() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("pod", "broker-0");
+        labels.put("strimzi_io_cluster", "my-cluster");
+        labels.put("strimzi_io_kind", "Kafka");
+        labels.put("namespace", "kafka-system");
+
+        Map<String, String> result = MetricLabelFilter.filterLabels(labels);
+        assertEquals(4, result.size());
+        assertTrue(result.containsKey("strimzi_io_cluster"));
+        assertTrue(result.containsKey("strimzi_io_kind"));
+        assertTrue(result.containsKey("namespace"));
+    }
+
+    @Test
+    void deduplicateByValueWithNoCanonicalLabels() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("strimzi_io_cluster", "my-cluster");
+        labels.put("namespace", "kafka-system");
+
+        Map<String, String> result = MetricLabelFilter.deduplicateByValue(labels);
+        assertEquals(2, result.size());
+    }
+
+    private static Map<String, String> allLabels() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("__name__", "test_metric");
+        labels.put("job", "kafka");
+        labels.put("pod", "broker-0");
+        labels.put("kubernetes_pod_name", "broker-0");
+        labels.put("strimzi_io_pod_name", "broker-0");
+        labels.put("node_name", "worker-1");
+        labels.put("node_ip", "10.0.0.1");
+        labels.put("topic", "my-topic");
+        labels.put("partition", "0");
+        labels.put("type", "producer-metrics");
+        labels.put("namespace", "kafka-system");
+        return labels;
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -241,6 +241,31 @@ public final class StrimziToolsPrompts {
         "Kafka cluster name to filter users."
             + " Omit to list users across all clusters.";
 
+    /**
+     * Aggregation level parameter description for metrics tools.
+     */
+    public static final String AGGREGATION_DESC =
+        "Aggregation level: 'partition' (full per-pod/topic/partition detail),"
+            + " 'topic' (per-pod/topic, avg across partitions),"
+            + " 'broker' (per-pod, avg across topics+partitions, default),"
+            + " or 'cluster' (single avg across all dimensions)."
+            + " Aggregation works on topic/partition dimensions."
+            + " The server automatically adjusts to the finest level supported by the"
+            + " requested category (e.g., 'partition' on a broker-only category becomes 'broker')."
+            + " For performance metrics (which have request type, not topic/partition),"
+            + " use requestTypes to control cardinality instead.";
+
+    /**
+     * Request types filter parameter description for Kafka metrics.
+     */
+    public static final String REQUEST_TYPES_DESC =
+        "Comma-separated list of Kafka request types to include"
+            + " (e.g., 'Produce,Fetch,FindCoordinator')."
+            + " Filters performance metrics that have a 'request' label."
+            + " Omit to include all request types."
+            + " Common types: Produce, Fetch, FetchConsumer, FetchFollower,"
+            + " FindCoordinator, Metadata, JoinGroup, SyncGroup, Heartbeat.";
+
     private StrimziToolsPrompts() {
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaExporterMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaExporterMetricCategories.java
@@ -4,7 +4,10 @@
  */
 package io.streamshub.mcp.strimzi.config.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
+
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -92,6 +95,23 @@ public final class KafkaExporterMetricCategories {
     }
 
     /**
+     * Returns the finest meaningful aggregation level for the given category.
+     *
+     * @param category the category name (case-insensitive)
+     * @return the max granularity, defaults to BROKER for null/unknown
+     */
+    public static AggregationLevel maxGranularity(final String category) {
+        if (category == null) {
+            return AggregationLevel.BROKER;
+        }
+        String lower = category.toLowerCase(Locale.ROOT);
+        if (CONSUMER_LAG.equals(lower) || PARTITIONS.equals(lower)) {
+            return AggregationLevel.PARTITION;
+        }
+        return AggregationLevel.BROKER;
+    }
+
+    /**
      * Resolves a category name to its list of metric names.
      *
      * @param category the category name (case-insensitive)
@@ -101,7 +121,7 @@ public final class KafkaExporterMetricCategories {
         if (category == null) {
             return List.of();
         }
-        return CATEGORIES.getOrDefault(category.toLowerCase(java.util.Locale.ROOT), List.of());
+        return CATEGORIES.getOrDefault(category.toLowerCase(Locale.ROOT), List.of());
     }
 
     /**
@@ -124,7 +144,7 @@ public final class KafkaExporterMetricCategories {
             return null;
         }
         String result = categories.stream()
-            .map(c -> c.toLowerCase(java.util.Locale.ROOT))
+            .map(c -> c.toLowerCase(Locale.ROOT))
             .filter(DESCRIPTIONS::containsKey)
             .map(DESCRIPTIONS::get)
             .collect(Collectors.joining("\n\n"));

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategories.java
@@ -4,7 +4,10 @@
  */
 package io.streamshub.mcp.strimzi.config.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
+
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -131,6 +134,19 @@ public final class KafkaMetricCategories {
     }
 
     /**
+     * Returns the finest meaningful aggregation level for the given category.
+     *
+     * @param category the category name (case-insensitive)
+     * @return the max granularity, defaults to BROKER for null/unknown
+     */
+    public static AggregationLevel maxGranularity(final String category) {
+        if (category != null && THROUGHPUT.equals(category.toLowerCase(Locale.ROOT))) {
+            return AggregationLevel.TOPIC;
+        }
+        return AggregationLevel.BROKER;
+    }
+
+    /**
      * Resolves a category name to its list of metric names.
      *
      * @param category the category name (case-insensitive)
@@ -140,7 +156,7 @@ public final class KafkaMetricCategories {
         if (category == null) {
             return List.of();
         }
-        return CATEGORIES.getOrDefault(category.toLowerCase(java.util.Locale.ROOT), List.of());
+        return CATEGORIES.getOrDefault(category.toLowerCase(Locale.ROOT), List.of());
     }
 
     /**
@@ -163,7 +179,7 @@ public final class KafkaMetricCategories {
             return null;
         }
         String result = categories.stream()
-            .map(c -> c.toLowerCase(java.util.Locale.ROOT))
+            .map(c -> c.toLowerCase(Locale.ROOT))
             .filter(DESCRIPTIONS::containsKey)
             .map(DESCRIPTIONS::get)
             .collect(Collectors.joining("\n\n"));

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategories.java
@@ -4,6 +4,8 @@
  */
 package io.streamshub.mcp.strimzi.config.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,6 +88,17 @@ public final class StrimziOperatorMetricCategories {
 
     private StrimziOperatorMetricCategories() {
         // Utility class — no instantiation
+    }
+
+    /**
+     * Returns the finest meaningful aggregation level for the given category.
+     * All operator categories aggregate at cluster level.
+     *
+     * @param category the category name (ignored — always returns CLUSTER)
+     * @return CLUSTER for all categories
+     */
+    public static AggregationLevel maxGranularity(final String category) {
+        return AggregationLevel.CLUSTER;
     }
 
     /**

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaExporterMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaExporterMetricsResponse.java
@@ -6,25 +6,27 @@ package io.streamshub.mcp.strimzi.dto.metrics;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
-import io.streamshub.mcp.common.dto.metrics.MetricTimeSeries;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Response containing metrics data from a Kafka Exporter.
- * For instant queries, metrics are returned as a flat list in {@code metrics}.
- * For range queries, metrics are grouped into compact time series in {@code timeSeries}.
+ * Metrics are always grouped and aggregated into time series based on the
+ * configured {@link AggregationLevel}.
  *
  * @param clusterName    the Kafka cluster name
  * @param namespace      the Kubernetes namespace
  * @param provider       the metrics provider used
  * @param categories     the metric categories requested
  * @param metricCount    the number of distinct metric names in the response
- * @param sampleCount    the total number of metric samples
- * @param metrics        the flat list of metric samples (instant queries)
- * @param timeSeries     the grouped time series (range queries)
+ * @param sampleCount    the total number of metric samples before aggregation
+ * @param aggregation    the aggregation level used
+ * @param timeSeries     the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp      the time this result was generated
  * @param message        a human-readable summary of the result
@@ -37,16 +39,15 @@ public record KafkaExporterMetricsResponse(
     @JsonProperty("categories") List<String> categories,
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
-    @JsonProperty("metrics") List<MetricSample> metrics,
-    @JsonProperty("time_series") List<MetricTimeSeries> timeSeries,
+    @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
     @JsonProperty("message") String message
 ) {
 
     /**
-     * Creates a response with metric data. If samples have timestamps (range query),
-     * groups them into compact time series. Otherwise returns a flat metrics list.
+     * Creates a response with aggregated metric data.
      *
      * @param clusterName    the Kafka cluster name
      * @param namespace      the Kubernetes namespace
@@ -54,12 +55,14 @@ public record KafkaExporterMetricsResponse(
      * @param categories     the requested categories
      * @param samples        the metric samples
      * @param interpretation brief guide for interpreting the returned metrics
-     * @return a response with the metric data
+     * @param level          the aggregation level
+     * @return a response with the aggregated metric data
      */
     public static KafkaExporterMetricsResponse of(final String clusterName, final String namespace,
                                                     final String provider, final List<String> categories,
                                                     final List<MetricSample> samples,
-                                                    final String interpretation) {
+                                                    final String interpretation,
+                                                    final AggregationLevel level) {
         long metricCount = samples.stream()
             .map(MetricSample::name)
             .distinct()
@@ -68,16 +71,12 @@ public record KafkaExporterMetricsResponse(
         String msg = String.format("Retrieved %d samples across %d metrics from Kafka Exporter for cluster '%s'",
             samples.size(), metricCount, clusterName);
 
-        boolean isRangeData = !samples.isEmpty() && samples.getFirst().timestamp() != null;
-
-        if (isRangeData) {
-            List<MetricTimeSeries> series = MetricTimeSeries.fromSamples(samples);
-            return new KafkaExporterMetricsResponse(clusterName, namespace, provider, categories,
-                metricCount, samples.size(), null, series, interpretation, Instant.now(), msg);
-        }
+        List<AggregatedTimeSeries> series = samples.isEmpty()
+            ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
         return new KafkaExporterMetricsResponse(clusterName, namespace, provider, categories,
-            metricCount, samples.size(), samples, null, interpretation, Instant.now(), msg);
+            metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
+            series, interpretation, Instant.now(), msg);
     }
 
     /**
@@ -91,6 +90,6 @@ public record KafkaExporterMetricsResponse(
     public static KafkaExporterMetricsResponse empty(final String clusterName, final String namespace,
                                                       final String message) {
         return new KafkaExporterMetricsResponse(clusterName, namespace, null, List.of(),
-            0, 0, List.of(), null, null, Instant.now(), message);
+            0, 0, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponse.java
@@ -6,25 +6,27 @@ package io.streamshub.mcp.strimzi.dto.metrics;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
-import io.streamshub.mcp.common.dto.metrics.MetricTimeSeries;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Response containing metrics data from a Kafka cluster.
- * For instant queries, metrics are returned as a flat list in {@code metrics}.
- * For range queries, metrics are grouped into compact time series in {@code timeSeries}.
+ * Metrics are always grouped and aggregated into time series based on the
+ * configured {@link AggregationLevel}.
  *
  * @param clusterName    the Kafka cluster name
  * @param namespace      the Kubernetes namespace
  * @param provider       the metrics provider used
  * @param categories     the metric categories requested
  * @param metricCount    the number of distinct metric names in the response
- * @param sampleCount    the total number of metric samples
- * @param metrics        the flat list of metric samples (instant queries)
- * @param timeSeries     the grouped time series (range queries)
+ * @param sampleCount    the total number of metric samples before aggregation
+ * @param aggregation    the aggregation level used
+ * @param timeSeries     the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp      the time this result was generated
  * @param message        a human-readable summary of the result
@@ -37,16 +39,15 @@ public record KafkaMetricsResponse(
     @JsonProperty("categories") List<String> categories,
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
-    @JsonProperty("metrics") List<MetricSample> metrics,
-    @JsonProperty("time_series") List<MetricTimeSeries> timeSeries,
+    @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
     @JsonProperty("message") String message
 ) {
 
     /**
-     * Creates a response with metric data. If samples have timestamps (range query),
-     * groups them into compact time series. Otherwise returns a flat metrics list.
+     * Creates a response with aggregated metric data.
      *
      * @param clusterName    the Kafka cluster name
      * @param namespace      the Kubernetes namespace
@@ -54,12 +55,14 @@ public record KafkaMetricsResponse(
      * @param categories     the requested categories
      * @param samples        the metric samples
      * @param interpretation brief guide for interpreting the returned metrics
-     * @return a response with the metric data
+     * @param level          the aggregation level
+     * @return a response with the aggregated metric data
      */
     public static KafkaMetricsResponse of(final String clusterName, final String namespace,
                                            final String provider, final List<String> categories,
                                            final List<MetricSample> samples,
-                                           final String interpretation) {
+                                           final String interpretation,
+                                           final AggregationLevel level) {
         long metricCount = samples.stream()
             .map(MetricSample::name)
             .distinct()
@@ -68,16 +71,43 @@ public record KafkaMetricsResponse(
         String msg = String.format("Retrieved %d samples across %d metrics from cluster '%s'",
             samples.size(), metricCount, clusterName);
 
-        boolean isRangeData = !samples.isEmpty() && samples.getFirst().timestamp() != null;
-
-        if (isRangeData) {
-            List<MetricTimeSeries> series = MetricTimeSeries.fromSamples(samples);
-            return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
-                metricCount, samples.size(), null, series, interpretation, Instant.now(), msg);
-        }
+        List<AggregatedTimeSeries> series = samples.isEmpty()
+            ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
         return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
-            metricCount, samples.size(), samples, null, interpretation, Instant.now(), msg);
+            metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
+            series, interpretation, Instant.now(), msg);
+    }
+
+    /**
+     * Creates a response from pre-grouped time series (avoids re-aggregating).
+     *
+     * @param clusterName    the Kafka cluster name
+     * @param namespace      the Kubernetes namespace
+     * @param provider       the metrics provider name
+     * @param categories     the requested categories
+     * @param series         the pre-grouped time series
+     * @param interpretation brief guide for interpreting the returned metrics
+     * @return a response wrapping the provided time series
+     */
+    public static KafkaMetricsResponse ofTimeSeries(final String clusterName, final String namespace,
+                                                     final String provider, final List<String> categories,
+                                                     final List<AggregatedTimeSeries> series,
+                                                     final String interpretation) {
+        long metricCount = series.stream()
+            .map(AggregatedTimeSeries::name)
+            .distinct()
+            .count();
+        int sampleCount = series.stream()
+            .mapToInt(ts -> ts.summary() != null
+                ? ts.summary().originalDataPointCount() : ts.dataPoints().size())
+            .sum();
+
+        String msg = String.format("Retrieved %d samples across %d metrics from cluster '%s'",
+            sampleCount, metricCount, clusterName);
+
+        return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
+            metricCount, sampleCount, null, series, interpretation, Instant.now(), msg);
     }
 
     /**
@@ -91,6 +121,6 @@ public record KafkaMetricsResponse(
     public static KafkaMetricsResponse empty(final String clusterName, final String namespace,
                                               final String message) {
         return new KafkaMetricsResponse(clusterName, namespace, null, List.of(),
-            0, 0, List.of(), null, null, Instant.now(), message);
+            0, 0, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponse.java
@@ -6,16 +6,18 @@ package io.streamshub.mcp.strimzi.dto.metrics;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
-import io.streamshub.mcp.common.dto.metrics.MetricTimeSeries;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Response containing metrics data from Strimzi operators.
- * For instant queries, metrics are returned as a flat list in {@code metrics}.
- * For range queries, metrics are grouped into compact time series in {@code timeSeries}.
+ * Metrics are always grouped and aggregated into time series based on the
+ * configured {@link AggregationLevel}.
  *
  * @param operatorName  the operator deployment name
  * @param clusterName   the Kafka cluster name (present when entity operator metrics are included)
@@ -23,9 +25,9 @@ import java.util.List;
  * @param provider      the metrics provider used
  * @param categories    the metric categories requested
  * @param metricCount   the number of distinct metric names in the response
- * @param sampleCount   the total number of metric samples
- * @param metrics       the flat list of metric samples (instant queries)
- * @param timeSeries    the grouped time series (range queries)
+ * @param sampleCount   the total number of metric samples before aggregation
+ * @param aggregation   the aggregation level used
+ * @param timeSeries    the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp     the time this result was generated
  * @param message       a human-readable summary of the result
@@ -39,16 +41,15 @@ public record StrimziOperatorMetricsResponse(
     @JsonProperty("categories") List<String> categories,
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
-    @JsonProperty("metrics") List<MetricSample> metrics,
-    @JsonProperty("time_series") List<MetricTimeSeries> timeSeries,
+    @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
     @JsonProperty("message") String message
 ) {
 
     /**
-     * Creates a response with metric data. If samples have timestamps (range query),
-     * groups them into compact time series. Otherwise returns a flat metrics list.
+     * Creates a response with aggregated metric data.
      *
      * @param operatorName   the operator deployment name
      * @param clusterName    the Kafka cluster name (null if no entity operator metrics)
@@ -57,13 +58,15 @@ public record StrimziOperatorMetricsResponse(
      * @param categories     the requested categories
      * @param samples        the metric samples
      * @param interpretation brief guide for interpreting the returned metrics
-     * @return a response with the metric data
+     * @param level          the aggregation level
+     * @return a response with the aggregated metric data
      */
     public static StrimziOperatorMetricsResponse of(final String operatorName, final String clusterName,
                                                      final String namespace,
                                                      final String provider, final List<String> categories,
                                                      final List<MetricSample> samples,
-                                                     final String interpretation) {
+                                                     final String interpretation,
+                                                     final AggregationLevel level) {
         long metricCount = samples.stream()
             .map(MetricSample::name)
             .distinct()
@@ -75,16 +78,12 @@ public record StrimziOperatorMetricsResponse(
             : String.format("Retrieved %d samples across %d metrics from operator '%s'",
                 samples.size(), metricCount, operatorName);
 
-        boolean isRangeData = !samples.isEmpty() && samples.getFirst().timestamp() != null;
-
-        if (isRangeData) {
-            List<MetricTimeSeries> series = MetricTimeSeries.fromSamples(samples);
-            return new StrimziOperatorMetricsResponse(operatorName, clusterName, namespace, provider, categories,
-                metricCount, samples.size(), null, series, interpretation, Instant.now(), msg);
-        }
+        List<AggregatedTimeSeries> series = samples.isEmpty()
+            ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
         return new StrimziOperatorMetricsResponse(operatorName, clusterName, namespace, provider, categories,
-            metricCount, samples.size(), samples, null, interpretation, Instant.now(), msg);
+            metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
+            series, interpretation, Instant.now(), msg);
     }
 
     /**
@@ -98,6 +97,6 @@ public record StrimziOperatorMetricsResponse(
     public static StrimziOperatorMetricsResponse empty(final String operatorName, final String namespace,
                                                         final String message) {
         return new StrimziOperatorMetricsResponse(operatorName, null, namespace, null, List.of(),
-            0, 0, List.of(), null, null, Instant.now(), message);
+            0, 0, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaClusterDiagnosticService.java
@@ -410,7 +410,7 @@ public class KafkaClusterDiagnosticService {
                                        final McpLog mcpLog) {
         try {
             KafkaMetricsResponse result = kafkaMetricsService.getKafkaMetrics(
-                namespace, clusterName, "replication", null, null, null, null, null);
+                namespace, clusterName, "replication", null, null, null, null, null, null, null);
             completed.add(STEP_METRICS);
             DiagnosticHelper.sendClientNotification(mcpLog, "Retrieved Kafka replication metrics");
             return result;

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaMetricsDiagnosticService.java
@@ -14,7 +14,7 @@ import io.quarkiverse.mcp.server.Sampling;
 import io.quarkiverse.mcp.server.SamplingMessage;
 import io.quarkiverse.mcp.server.SamplingResponse;
 import io.quarkiverse.mcp.server.ToolCallException;
-import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
 import io.streamshub.mcp.common.service.DiagnosticHelper;
 import io.streamshub.mcp.common.util.InputUtils;
 import io.streamshub.mcp.common.util.NamespaceElicitationHelper;
@@ -258,7 +258,7 @@ public class KafkaMetricsDiagnosticService {
         KafkaMetricsResponse allMetrics;
         try {
             allMetrics = kafkaMetricsService.getKafkaMetrics(
-                namespace, clusterName, null, allNames, rangeMinutes, startTime, endTime, stepSeconds);
+                namespace, clusterName, null, allNames, rangeMinutes, startTime, endTime, stepSeconds, null, null);
         } catch (Exception e) {
             LOG.warnf("Failed to gather Kafka metrics: %s", e.getMessage());
             for (String cat : categoryMetricNames.keySet()) {
@@ -272,17 +272,17 @@ public class KafkaMetricsDiagnosticService {
         for (Map.Entry<String, List<String>> entry : categoryMetricNames.entrySet()) {
             String category = entry.getKey();
             Set<String> names = new HashSet<>(entry.getValue());
-            List<MetricSample> categorySamples = allMetrics.metrics() != null
-                ? allMetrics.metrics().stream()
-                    .filter(s -> names.contains(s.name()))
+            List<AggregatedTimeSeries> categorySeries = allMetrics.timeSeries() != null
+                ? allMetrics.timeSeries().stream()
+                    .filter(ts -> names.contains(ts.name()))
                     .toList()
                 : List.of();
 
             String interpretation = KafkaMetricCategories.interpretation(List.of(category));
-            KafkaMetricsResponse categoryResponse = KafkaMetricsResponse.of(
+            KafkaMetricsResponse categoryResponse = KafkaMetricsResponse.ofTimeSeries(
                 allMetrics.clusterName(), allMetrics.namespace(),
                 allMetrics.provider(), List.of(category),
-                categorySamples, interpretation);
+                categorySeries, interpretation);
             results.put(category, categoryResponse);
             completed.add(categoryStepName(category));
         }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/OperatorMetricsDiagnosticService.java
@@ -236,7 +236,7 @@ public class OperatorMetricsDiagnosticService {
         try {
             StrimziOperatorMetricsResponse result = operatorMetricsService.getOperatorMetrics(
                 namespace, operatorName, clusterName, category,
-                null, rangeMinutes, startTime, endTime, stepSeconds);
+                null, rangeMinutes, startTime, endTime, stepSeconds, null);
             completed.add(stepName);
             DiagnosticHelper.sendClientNotification(mcpLog,
                 String.format("Retrieved Strimzi operator %s metrics", category));

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaExporterMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaExporterMetricsService.java
@@ -6,6 +6,7 @@ package io.streamshub.mcp.strimzi.service.metrics;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import io.streamshub.mcp.common.dto.metrics.PodTarget;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
@@ -63,6 +64,7 @@ public class KafkaExporterMetricsService {
      * @param startTime    absolute start time in ISO 8601 format (optional, use with endTime)
      * @param endTime      absolute end time in ISO 8601 format (optional, use with startTime)
      * @param stepSeconds  range query step interval (optional, uses default)
+     * @param aggregation  aggregation level (optional, defaults to "broker")
      * @return the Kafka Exporter metrics response
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -73,7 +75,8 @@ public class KafkaExporterMetricsService {
                                                                   final Integer rangeMinutes,
                                                                   final String startTime,
                                                                   final String endTime,
-                                                                  final Integer stepSeconds) {
+                                                                  final Integer stepSeconds,
+                                                                  final String aggregation) {
         String ns = InputUtils.normalizeInput(namespace);
         String name = InputUtils.normalizeInput(clusterName);
         String cat = InputUtils.normalizeInput(category);
@@ -147,7 +150,12 @@ public class KafkaExporterMetricsService {
         }
         String interpretation = KafkaExporterMetricCategories.interpretation(effectiveCategories);
 
+        AggregationLevel level = AggregationLevel.fromString(aggregation);
+        if (cat != null || metricNames == null || metricNames.isBlank()) {
+            String effectiveCat = cat != null ? cat : DEFAULT_CATEGORY;
+            level = level.clampTo(KafkaExporterMetricCategories.maxGranularity(effectiveCat));
+        }
         return KafkaExporterMetricsResponse.of(name, resolvedNs,
-            metricsQueryService.providerName(), categories, samples, interpretation);
+            metricsQueryService.providerName(), categories, samples, interpretation, level);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
@@ -6,6 +6,7 @@ package io.streamshub.mcp.strimzi.service.metrics;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import io.streamshub.mcp.common.dto.metrics.PodTarget;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
@@ -24,9 +25,11 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Service for retrieving Kafka cluster metrics via pluggable providers.
@@ -61,6 +64,8 @@ public class KafkaMetricsService {
      * @param startTime    absolute start time in ISO 8601 format (optional, use with endTime)
      * @param endTime      absolute end time in ISO 8601 format (optional, use with startTime)
      * @param stepSeconds  range query step interval (optional, uses default)
+     * @param aggregation  aggregation level (optional, defaults to "broker")
+     * @param requestTypes comma-separated request types to filter (optional)
      * @return the metrics response
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -71,7 +76,9 @@ public class KafkaMetricsService {
                                                  final Integer rangeMinutes,
                                                  final String startTime,
                                                  final String endTime,
-                                                 final Integer stepSeconds) {
+                                                 final Integer stepSeconds,
+                                                 final String aggregation,
+                                                 final String requestTypes) {
         String ns = InputUtils.normalizeInput(namespace);
         String name = InputUtils.normalizeInput(clusterName);
         String cat = InputUtils.normalizeInput(category);
@@ -139,6 +146,8 @@ public class KafkaMetricsService {
         List<MetricSample> samples = metricsQueryService.queryMetrics(
             podTargets, labelMatchers, resolvedMetrics, rangeMinutes, startTime, endTime, stepSeconds);
 
+        samples = filterByRequestTypes(samples, requestTypes);
+
         // Build interpretation from effective categories
         List<String> effectiveCategories = new ArrayList<>(categories);
         if (effectiveCategories.isEmpty() && (metricNames == null || metricNames.isBlank())) {
@@ -146,7 +155,35 @@ public class KafkaMetricsService {
         }
         String interpretation = KafkaMetricCategories.interpretation(effectiveCategories);
 
+        AggregationLevel level = AggregationLevel.fromString(aggregation);
+        if (cat != null || metricNames == null || metricNames.isBlank()) {
+            String effectiveCat = cat != null ? cat : DEFAULT_CATEGORY;
+            level = level.clampTo(KafkaMetricCategories.maxGranularity(effectiveCat));
+        }
         return KafkaMetricsResponse.of(name, resolvedNs,
-            metricsQueryService.providerName(), categories, samples, interpretation);
+            metricsQueryService.providerName(), categories, samples, interpretation, level);
+    }
+
+    private static List<MetricSample> filterByRequestTypes(final List<MetricSample> samples,
+                                                            final String requestTypes) {
+        if (requestTypes == null || requestTypes.isBlank()) {
+            return samples;
+        }
+        Set<String> types = new HashSet<>();
+        for (String t : requestTypes.split(",")) {
+            String trimmed = t.trim();
+            if (!trimmed.isEmpty()) {
+                types.add(trimmed);
+            }
+        }
+        if (types.isEmpty()) {
+            return samples;
+        }
+        return samples.stream()
+            .filter(s -> {
+                String req = s.labels() != null ? s.labels().get("request") : null;
+                return req == null || types.contains(req);
+            })
+            .toList();
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
@@ -6,6 +6,7 @@ package io.streamshub.mcp.strimzi.service.metrics;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.mcp.server.ToolCallException;
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import io.streamshub.mcp.common.dto.metrics.PodTarget;
 import io.streamshub.mcp.common.service.metrics.MetricsQueryService;
@@ -60,6 +61,7 @@ public class StrimziOperatorMetricsService {
      * @param startTime    absolute start time in ISO 8601 format (optional, use with endTime)
      * @param endTime      absolute end time in ISO 8601 format (optional, use with startTime)
      * @param stepSeconds  range query step interval (optional, uses default)
+     * @param aggregation  aggregation level (optional, defaults to "broker")
      * @return the operator metrics response
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -71,7 +73,8 @@ public class StrimziOperatorMetricsService {
                                                        final Integer rangeMinutes,
                                                        final String startTime,
                                                        final String endTime,
-                                                       final Integer stepSeconds) {
+                                                       final Integer stepSeconds,
+                                                       final String aggregation) {
         String ns = InputUtils.normalizeInput(namespace);
         String name = InputUtils.normalizeInput(operatorName);
         String cluster = InputUtils.normalizeInput(clusterName);
@@ -100,19 +103,21 @@ public class StrimziOperatorMetricsService {
             cluster != null ? " with entity operator for Kafka cluster '" + cluster + "'" : "",
             metricsQueryService.providerName());
 
-        List<PodTarget> podTargets = buildPodTargets(coPods, eoPods);
-        Map<String, String> labelMatchers = buildLabelMatchers(coPods, eoPods, cluster);
-
-        List<MetricSample> samples = metricsQueryService.queryMetrics(
-            podTargets, labelMatchers, resolvedMetrics, rangeMinutes, startTime, endTime, stepSeconds);
+        List<MetricSample> samples = queryByNamespace(
+            coPods, eoPods, resolvedMetrics, rangeMinutes, startTime, endTime, stepSeconds);
 
         String interpretation = buildInterpretation(categories, metricNames);
         String resolvedNs = !coPods.isEmpty()
             ? coPods.getFirst().getMetadata().getNamespace()
             : eoPods.getFirst().getMetadata().getNamespace();
 
+        AggregationLevel level = AggregationLevel.fromString(aggregation);
+        if (cat != null || metricNames == null || metricNames.isBlank()) {
+            String effectiveCat = cat != null ? cat : DEFAULT_CATEGORY;
+            level = level.clampTo(StrimziOperatorMetricCategories.maxGranularity(effectiveCat));
+        }
         return StrimziOperatorMetricsResponse.of(resolvedName, cluster, resolvedNs,
-            metricsQueryService.providerName(), categories, samples, interpretation);
+            metricsQueryService.providerName(), categories, samples, interpretation, level);
     }
 
     private void validatePodsFound(final List<Pod> coPods, final List<Pod> eoPods, final String namespace) {
@@ -146,17 +151,46 @@ public class StrimziOperatorMetricsService {
         return targets;
     }
 
-    private Map<String, String> buildLabelMatchers(final List<Pod> coPods, final List<Pod> eoPods,
-                                                    final String cluster) {
-        Map<String, String> matchers = new LinkedHashMap<>();
-        String ns = !coPods.isEmpty()
-            ? coPods.getFirst().getMetadata().getNamespace()
-            : eoPods.getFirst().getMetadata().getNamespace();
-        matchers.put("namespace", ns);
-        if (cluster != null) {
-            matchers.put("strimzi_io_cluster", cluster);
+    /**
+     * Queries CO and EO metrics separately to handle different namespaces and
+     * avoid label mismatches (operator metrics don't carry strimzi_io_cluster).
+     */
+    private List<MetricSample> queryByNamespace(final List<Pod> coPods, final List<Pod> eoPods,
+                                                 final List<String> metricNames,
+                                                 final Integer rangeMinutes, final String startTime,
+                                                 final String endTime, final Integer stepSeconds) {
+        String coNamespace = !coPods.isEmpty()
+            ? coPods.getFirst().getMetadata().getNamespace() : null;
+        String eoNamespace = !eoPods.isEmpty()
+            ? eoPods.getFirst().getMetadata().getNamespace() : null;
+
+        boolean sameNamespace = eoPods.isEmpty() || coPods.isEmpty()
+            || coNamespace.equals(eoNamespace);
+
+        if (sameNamespace) {
+            List<PodTarget> targets = buildPodTargets(coPods, eoPods);
+            Map<String, String> matchers = new LinkedHashMap<>();
+            matchers.put("namespace", coNamespace != null ? coNamespace : eoNamespace);
+            return metricsQueryService.queryMetrics(
+                targets, matchers, metricNames, rangeMinutes, startTime, endTime, stepSeconds);
         }
-        return matchers;
+
+        List<MetricSample> allSamples = new ArrayList<>();
+
+        List<PodTarget> coTargets = buildPodTargets(coPods, List.of());
+        Map<String, String> coMatchers = new LinkedHashMap<>();
+        coMatchers.put("namespace", coNamespace);
+        allSamples.addAll(metricsQueryService.queryMetrics(
+            coTargets, coMatchers, metricNames, rangeMinutes, startTime, endTime, stepSeconds));
+
+        List<PodTarget> eoTargets = buildPodTargets(List.of(), eoPods);
+        Map<String, String> eoMatchers = new LinkedHashMap<>();
+        eoMatchers.put("namespace", eoNamespace);
+        eoMatchers.put("pod", eoPods.getFirst().getMetadata().getName());
+        allSamples.addAll(metricsQueryService.queryMetrics(
+            eoTargets, eoMatchers, metricNames, rangeMinutes, startTime, endTime, stepSeconds));
+
+        return allSamples;
     }
 
     private String buildInterpretation(final List<String> categories, final String metricNames) {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsService.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Service for retrieving Strimzi operator metrics via pluggable providers.
@@ -165,7 +166,7 @@ public class StrimziOperatorMetricsService {
             ? eoPods.getFirst().getMetadata().getNamespace() : null;
 
         boolean sameNamespace = eoPods.isEmpty() || coPods.isEmpty()
-            || coNamespace.equals(eoNamespace);
+            || Objects.equals(coNamespace, eoNamespace);
 
         if (sameNamespace) {
             List<PodTarget> targets = buildPodTargets(coPods, eoPods);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/metrics/MetricsTools.java
@@ -52,6 +52,8 @@ public class MetricsTools {
      * @param startTime    optional absolute start time in ISO 8601 format
      * @param endTime      optional absolute end time in ISO 8601 format
      * @param stepSeconds  optional range query step in seconds
+     * @param aggregation   optional aggregation level
+     * @param requestTypes  optional comma-separated request types to filter
      * @return the metrics response
      */
     @WithSpan("tool.get_kafka_metrics")
@@ -98,10 +100,19 @@ public class MetricsTools {
         @ToolArg(
             description = StrimziToolsPrompts.STEP_SECONDS_DESC,
             required = false
-        ) final Integer stepSeconds
+        ) final Integer stepSeconds,
+        @ToolArg(
+            description = StrimziToolsPrompts.AGGREGATION_DESC,
+            required = false
+        ) final String aggregation,
+        @ToolArg(
+            description = StrimziToolsPrompts.REQUEST_TYPES_DESC,
+            required = false
+        ) final String requestTypes
     ) {
         return kafkaMetricsService.getKafkaMetrics(
-            namespace, clusterName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds);
+            namespace, clusterName, category, metricNames, rangeMinutes, startTime, endTime,
+            stepSeconds, aggregation, requestTypes);
     }
 
     /**
@@ -115,6 +126,7 @@ public class MetricsTools {
      * @param startTime    optional absolute start time in ISO 8601 format
      * @param endTime      optional absolute end time in ISO 8601 format
      * @param stepSeconds  optional range query step in seconds
+     * @param aggregation  optional aggregation level
      * @return the Kafka Exporter metrics response
      */
     @WithSpan("tool.get_kafka_exporter_metrics")
@@ -161,10 +173,14 @@ public class MetricsTools {
         @ToolArg(
             description = StrimziToolsPrompts.STEP_SECONDS_DESC,
             required = false
-        ) final Integer stepSeconds
+        ) final Integer stepSeconds,
+        @ToolArg(
+            description = StrimziToolsPrompts.AGGREGATION_DESC,
+            required = false
+        ) final String aggregation
     ) {
         return kafkaExporterMetricsService.getKafkaExporterMetrics(
-            namespace, clusterName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds);
+            namespace, clusterName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds, aggregation);
     }
 
     /**
@@ -181,6 +197,7 @@ public class MetricsTools {
      * @param startTime    optional absolute start time in ISO 8601 format
      * @param endTime      optional absolute end time in ISO 8601 format
      * @param stepSeconds  optional range query step in seconds
+     * @param aggregation  optional aggregation level
      * @return the operator metrics response
      */
     @WithSpan("tool.get_strimzi_operator_metrics")
@@ -233,9 +250,13 @@ public class MetricsTools {
         @ToolArg(
             description = StrimziToolsPrompts.STEP_SECONDS_DESC,
             required = false
-        ) final Integer stepSeconds
+        ) final Integer stepSeconds,
+        @ToolArg(
+            description = StrimziToolsPrompts.AGGREGATION_DESC,
+            required = false
+        ) final String aggregation
     ) {
         return strimziOperatorMetricsService.getOperatorMetrics(
-            namespace, operatorName, clusterName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds);
+            namespace, operatorName, clusterName, category, metricNames, rangeMinutes, startTime, endTime, stepSeconds, aggregation);
     }
 }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/KafkaExporterMetricCategoriesTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/KafkaExporterMetricCategoriesTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.config.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link KafkaExporterMetricCategories}.
+ */
+class KafkaExporterMetricCategoriesTest {
+
+    KafkaExporterMetricCategoriesTest() {
+    }
+
+    @Test
+    void resolveValidCategoryReturnsMetrics() {
+        List<String> metrics = KafkaExporterMetricCategories.resolve("consumer_lag");
+        assertFalse(metrics.isEmpty());
+        assertTrue(metrics.contains("kafka_consumergroup_lag"));
+    }
+
+    @Test
+    void resolveUnknownCategoryReturnsEmpty() {
+        assertTrue(KafkaExporterMetricCategories.resolve("nonexistent").isEmpty());
+    }
+
+    @Test
+    void resolveNullReturnsEmpty() {
+        assertTrue(KafkaExporterMetricCategories.resolve(null).isEmpty());
+    }
+
+    @Test
+    void allCategoriesReturnsThreeCategories() {
+        Set<String> categories = KafkaExporterMetricCategories.allCategories();
+        assertEquals(3, categories.size());
+        assertTrue(categories.contains("consumer_lag"));
+        assertTrue(categories.contains("partitions"));
+        assertTrue(categories.contains("resources"));
+    }
+
+    @Test
+    void interpretationWithValidCategoryReturnsGuide() {
+        String interpretation = KafkaExporterMetricCategories.interpretation(List.of("consumer_lag"));
+        assertNotNull(interpretation);
+        assertTrue(interpretation.contains("kafka_consumergroup_lag"));
+    }
+
+    @Test
+    void interpretationWithNullReturnsNull() {
+        assertNull(KafkaExporterMetricCategories.interpretation(null));
+    }
+
+    @Test
+    void interpretationWithEmptyListReturnsNull() {
+        assertNull(KafkaExporterMetricCategories.interpretation(List.of()));
+    }
+
+    @Test
+    void maxGranularityConsumerLagReturnsPartition() {
+        assertEquals(AggregationLevel.PARTITION, KafkaExporterMetricCategories.maxGranularity("consumer_lag"));
+        assertEquals(AggregationLevel.PARTITION, KafkaExporterMetricCategories.maxGranularity("CONSUMER_LAG"));
+    }
+
+    @Test
+    void maxGranularityPartitionsReturnsPartition() {
+        assertEquals(AggregationLevel.PARTITION, KafkaExporterMetricCategories.maxGranularity("partitions"));
+    }
+
+    @Test
+    void maxGranularityResourcesReturnsBroker() {
+        assertEquals(AggregationLevel.BROKER, KafkaExporterMetricCategories.maxGranularity("resources"));
+    }
+
+    @Test
+    void maxGranularityNullReturnsBroker() {
+        assertEquals(AggregationLevel.BROKER, KafkaExporterMetricCategories.maxGranularity(null));
+    }
+
+    @Test
+    void maxGranularityUnknownReturnsBroker() {
+        assertEquals(AggregationLevel.BROKER, KafkaExporterMetricCategories.maxGranularity("nonexistent"));
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategoriesTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/KafkaMetricCategoriesTest.java
@@ -4,6 +4,7 @@
  */
 package io.streamshub.mcp.strimzi.config.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -90,5 +91,28 @@ class KafkaMetricCategoriesTest {
     @Test
     void interpretationWithUnknownCategoryReturnsNull() {
         assertNull(KafkaMetricCategories.interpretation(List.of("nonexistent")));
+    }
+
+    @Test
+    void maxGranularityThroughputReturnsTopic() {
+        assertEquals(AggregationLevel.TOPIC, KafkaMetricCategories.maxGranularity("throughput"));
+        assertEquals(AggregationLevel.TOPIC, KafkaMetricCategories.maxGranularity("THROUGHPUT"));
+    }
+
+    @Test
+    void maxGranularityOtherCategoriesReturnsBroker() {
+        assertEquals(AggregationLevel.BROKER, KafkaMetricCategories.maxGranularity("replication"));
+        assertEquals(AggregationLevel.BROKER, KafkaMetricCategories.maxGranularity("performance"));
+        assertEquals(AggregationLevel.BROKER, KafkaMetricCategories.maxGranularity("resources"));
+    }
+
+    @Test
+    void maxGranularityNullReturnsBroker() {
+        assertEquals(AggregationLevel.BROKER, KafkaMetricCategories.maxGranularity(null));
+    }
+
+    @Test
+    void maxGranularityUnknownReturnsBroker() {
+        assertEquals(AggregationLevel.BROKER, KafkaMetricCategories.maxGranularity("nonexistent"));
     }
 }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategoriesTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/config/metrics/StrimziOperatorMetricCategoriesTest.java
@@ -4,6 +4,7 @@
  */
 package io.streamshub.mcp.strimzi.config.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -79,5 +80,22 @@ class StrimziOperatorMetricCategoriesTest {
     @Test
     void interpretationWithUnknownCategoryReturnsNull() {
         assertNull(StrimziOperatorMetricCategories.interpretation(List.of("nonexistent")));
+    }
+
+    @Test
+    void maxGranularityAlwaysReturnsCluster() {
+        assertEquals(AggregationLevel.CLUSTER, StrimziOperatorMetricCategories.maxGranularity("reconciliation"));
+        assertEquals(AggregationLevel.CLUSTER, StrimziOperatorMetricCategories.maxGranularity("resources"));
+        assertEquals(AggregationLevel.CLUSTER, StrimziOperatorMetricCategories.maxGranularity("jvm"));
+    }
+
+    @Test
+    void maxGranularityNullReturnsCluster() {
+        assertEquals(AggregationLevel.CLUSTER, StrimziOperatorMetricCategories.maxGranularity(null));
+    }
+
+    @Test
+    void maxGranularityUnknownReturnsCluster() {
+        assertEquals(AggregationLevel.CLUSTER, StrimziOperatorMetricCategories.maxGranularity("nonexistent"));
     }
 }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponseTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponseTest.java
@@ -4,6 +4,7 @@
  */
 package io.streamshub.mcp.strimzi.dto.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import org.junit.jupiter.api.Test;
 
@@ -25,24 +26,24 @@ class KafkaMetricsResponseTest {
     }
 
     @Test
-    void ofWithInstantDataPopulatesMetricsNotTimeSeries() {
+    void ofAlwaysPopulatesTimeSeries() {
         List<MetricSample> samples = List.of(
             MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0),
             MetricSample.of("metric_a", Map.of("pod", "pod-1"), 2.0)
         );
 
         KafkaMetricsResponse response = KafkaMetricsResponse.of(
-            "my-cluster", "kafka", "pod-scraping", List.of("replication"), samples, null);
+            "my-cluster", "kafka", "pod-scraping", List.of("replication"),
+            samples, null, AggregationLevel.BROKER);
 
-        assertNotNull(response.metrics());
-        assertEquals(2, response.metrics().size());
-        assertNull(response.timeSeries());
+        assertNotNull(response.timeSeries());
         assertEquals(2, response.sampleCount());
         assertEquals(1, response.metricCount());
+        assertEquals("broker", response.aggregation());
     }
 
     @Test
-    void ofWithRangeDataPopulatesTimeSeriesNotMetrics() {
+    void ofWithRangeDataPopulatesTimeSeries() {
         Instant now = Instant.now();
         List<MetricSample> samples = List.of(
             MetricSample.of("metric_a", Map.of("pod", "pod-0"), 1.0, now),
@@ -50,22 +51,22 @@ class KafkaMetricsResponseTest {
         );
 
         KafkaMetricsResponse response = KafkaMetricsResponse.of(
-            "my-cluster", "kafka", "prometheus", List.of("throughput"), samples, null);
+            "my-cluster", "kafka", "prometheus", List.of("throughput"),
+            samples, null, AggregationLevel.BROKER);
 
-        assertNull(response.metrics());
         assertNotNull(response.timeSeries());
         assertEquals(1, response.timeSeries().size());
         assertEquals(2, response.sampleCount());
     }
 
     @Test
-    void ofWithEmptySamplesReturnsEmptyMetrics() {
+    void ofWithEmptySamplesReturnsEmptyTimeSeries() {
         KafkaMetricsResponse response = KafkaMetricsResponse.of(
-            "my-cluster", "kafka", "pod-scraping", List.of(), List.of(), null);
+            "my-cluster", "kafka", "pod-scraping", List.of(),
+            List.of(), null, AggregationLevel.BROKER);
 
-        assertNotNull(response.metrics());
-        assertTrue(response.metrics().isEmpty());
-        assertNull(response.timeSeries());
+        assertNotNull(response.timeSeries());
+        assertTrue(response.timeSeries().isEmpty());
         assertEquals(0, response.sampleCount());
         assertEquals(0, response.metricCount());
     }
@@ -79,7 +80,8 @@ class KafkaMetricsResponseTest {
         );
 
         KafkaMetricsResponse response = KafkaMetricsResponse.of(
-            "my-cluster", "kafka", "pod-scraping", List.of(), samples, null);
+            "my-cluster", "kafka", "pod-scraping", List.of(),
+            samples, null, AggregationLevel.BROKER);
 
         assertEquals(2, response.metricCount());
         assertEquals(3, response.sampleCount());
@@ -88,7 +90,8 @@ class KafkaMetricsResponseTest {
     @Test
     void ofPassesThroughInterpretation() {
         KafkaMetricsResponse response = KafkaMetricsResponse.of(
-            "my-cluster", "kafka", "pod-scraping", List.of(), List.of(), "test interpretation");
+            "my-cluster", "kafka", "pod-scraping", List.of(),
+            List.of(), "test interpretation", AggregationLevel.BROKER);
 
         assertEquals("test interpretation", response.interpretation());
     }
@@ -105,5 +108,24 @@ class KafkaMetricsResponseTest {
         assertEquals(0, response.metricCount());
         assertNull(response.interpretation());
         assertNotNull(response.timestamp());
+    }
+
+    @Test
+    void ofTimeSeriesCreatesResponseFromPreGroupedSeries() {
+        List<MetricSample> samples = List.of(
+            MetricSample.of("metric_a", Map.of("pod", "pod-0"), 10.0),
+            MetricSample.of("metric_a", Map.of("pod", "pod-1"), 20.0)
+        );
+        var series = io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries
+            .fromSamples(samples, AggregationLevel.CLUSTER);
+
+        KafkaMetricsResponse response = KafkaMetricsResponse.ofTimeSeries(
+            "my-cluster", "kafka", "prometheus", List.of("replication"),
+            series, "guide");
+
+        assertNotNull(response.timeSeries());
+        assertEquals(1, response.timeSeries().size());
+        assertEquals(1, response.metricCount());
+        assertEquals("guide", response.interpretation());
     }
 }

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponseTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponseTest.java
@@ -4,6 +4,7 @@
  */
 package io.streamshub.mcp.strimzi.dto.metrics;
 
+import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
 import org.junit.jupiter.api.Test;
 
@@ -25,24 +26,24 @@ class StrimziOperatorMetricsResponseTest {
     }
 
     @Test
-    void ofWithInstantDataPopulatesMetricsNotTimeSeries() {
+    void ofAlwaysPopulatesTimeSeries() {
         List<MetricSample> samples = List.of(
             MetricSample.of("strimzi_reconciliations_total", Map.of(), 100.0)
         );
 
         StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
             "cluster-operator", null, "strimzi", "pod-scraping",
-            List.of("reconciliation"), samples, null);
+            List.of("reconciliation"), samples, null, AggregationLevel.BROKER);
 
-        assertNotNull(response.metrics());
-        assertEquals(1, response.metrics().size());
-        assertNull(response.timeSeries());
+        assertNotNull(response.timeSeries());
+        assertEquals(1, response.timeSeries().size());
         assertEquals(1, response.sampleCount());
         assertEquals(1, response.metricCount());
+        assertEquals("broker", response.aggregation());
     }
 
     @Test
-    void ofWithRangeDataPopulatesTimeSeriesNotMetrics() {
+    void ofWithRangeDataPopulatesTimeSeries() {
         Instant now = Instant.now();
         List<MetricSample> samples = List.of(
             MetricSample.of("strimzi_reconciliations_total", Map.of(), 100.0, now),
@@ -51,23 +52,21 @@ class StrimziOperatorMetricsResponseTest {
 
         StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
             "cluster-operator", null, "strimzi", "prometheus",
-            List.of("reconciliation"), samples, null);
+            List.of("reconciliation"), samples, null, AggregationLevel.BROKER);
 
-        assertNull(response.metrics());
         assertNotNull(response.timeSeries());
         assertEquals(1, response.timeSeries().size());
         assertEquals(2, response.sampleCount());
     }
 
     @Test
-    void ofWithEmptySamplesReturnsEmptyMetrics() {
+    void ofWithEmptySamplesReturnsEmptyTimeSeries() {
         StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
             "cluster-operator", null, "strimzi", "pod-scraping",
-            List.of(), List.of(), null);
+            List.of(), List.of(), null, AggregationLevel.BROKER);
 
-        assertNotNull(response.metrics());
-        assertTrue(response.metrics().isEmpty());
-        assertNull(response.timeSeries());
+        assertNotNull(response.timeSeries());
+        assertTrue(response.timeSeries().isEmpty());
         assertEquals(0, response.sampleCount());
     }
 
@@ -75,7 +74,7 @@ class StrimziOperatorMetricsResponseTest {
     void ofPassesThroughInterpretation() {
         StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
             "cluster-operator", null, "strimzi", "pod-scraping",
-            List.of(), List.of(), "test interpretation");
+            List.of(), List.of(), "test interpretation", AggregationLevel.BROKER);
 
         assertEquals("test interpretation", response.interpretation());
     }
@@ -84,7 +83,7 @@ class StrimziOperatorMetricsResponseTest {
     void ofWithClusterNameIncludesClusterInResponse() {
         StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
             "cluster-operator", "my-cluster", "strimzi", "pod-scraping",
-            List.of(), List.of(), null);
+            List.of(), List.of(), null, AggregationLevel.BROKER);
 
         assertEquals("my-cluster", response.clusterName());
         assertTrue(response.message().contains("my-cluster"));
@@ -94,7 +93,7 @@ class StrimziOperatorMetricsResponseTest {
     void ofWithoutClusterNameExcludesClusterFromMessage() {
         StrimziOperatorMetricsResponse response = StrimziOperatorMetricsResponse.of(
             "cluster-operator", null, "strimzi", "pod-scraping",
-            List.of(), List.of(), null);
+            List.of(), List.of(), null, AggregationLevel.BROKER);
 
         assertNull(response.clusterName());
         assertTrue(response.message().contains("operator 'cluster-operator'"));

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaExporterMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaExporterMetricsServiceTest.java
@@ -76,7 +76,7 @@ class KafkaExporterMetricsServiceTest {
     void missingClusterNameThrows() {
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> kafkaExporterMetricsService.getKafkaExporterMetrics(
-                "kafka", null, null, null, null, null, null, null));
+                "kafka", null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Cluster name is required"));
     }
 
@@ -87,7 +87,7 @@ class KafkaExporterMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> kafkaExporterMetricsService.getKafkaExporterMetrics(
-                "kafka", "missing", null, null, null, null, null, null));
+                "kafka", "missing", null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("not found in namespace"));
     }
 
@@ -101,7 +101,7 @@ class KafkaExporterMetricsServiceTest {
             .thenReturn(List.of());
 
         KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
-            "kafka", "my-cluster", null, null, null, null, null, null);
+            "kafka", "my-cluster", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals(0, response.sampleCount());
@@ -126,7 +126,7 @@ class KafkaExporterMetricsServiceTest {
             .thenReturn(samples);
 
         KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
-            "kafka", "my-cluster", "consumer_lag", null, null, null, null, null);
+            "kafka", "my-cluster", "consumer_lag", null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -147,7 +147,7 @@ class KafkaExporterMetricsServiceTest {
             .thenReturn(List.of(exporterPod));
 
         KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
-            "kafka", "my-cluster", null, null, null, null, null, null);
+            "kafka", "my-cluster", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -161,7 +161,7 @@ class KafkaExporterMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> kafkaExporterMetricsService.getKafkaExporterMetrics(
-                "kafka", "my-cluster", "invalid", null, null, null, null, null));
+                "kafka", "my-cluster", "invalid", null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Unknown metric category"));
     }
 
@@ -177,7 +177,7 @@ class KafkaExporterMetricsServiceTest {
             .thenReturn(List.of(exporterPod));
 
         KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
-            "kafka", "my-cluster", null, "kafka_consumergroup_lag,custom_metric", null, null, null, null);
+            "kafka", "my-cluster", null, "kafka_consumergroup_lag,custom_metric", null, null, null, null, null);
 
         assertNotNull(response);
     }
@@ -196,7 +196,7 @@ class KafkaExporterMetricsServiceTest {
             .thenReturn(List.of());
 
         KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
-            "kafka", "my-cluster", "consumer_lag", null, 60, null, null, 15);
+            "kafka", "my-cluster", "consumer_lag", null, 60, null, null, 15, null);
 
         assertNotNull(response);
     }
@@ -220,10 +220,44 @@ class KafkaExporterMetricsServiceTest {
             .thenReturn(samples);
 
         KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
-            "kafka", "my-cluster", "consumer_lag", null, null, null, null, null);
+            "kafka", "my-cluster", "consumer_lag", null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals(1, response.sampleCount());
+    }
+
+    @Test
+    void aggregationNotClampedForConsumerLagAtPartitionLevel() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createExporterPod("my-cluster-kafka-exporter-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
+            "kafka", "my-cluster", "consumer_lag", null, null, null, null, null, "partition");
+
+        assertEquals("partition", response.aggregation());
+    }
+
+    @Test
+    void aggregationClampedToBrokerForResourcesCategory() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createExporterPod("my-cluster-kafka-exporter-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaExporterMetricsResponse response = kafkaExporterMetricsService.getKafkaExporterMetrics(
+            "kafka", "my-cluster", "resources", null, null, null, null, null, "partition");
+
+        assertEquals("broker", response.aggregation());
     }
 
     private Kafka createKafka(final String name, final String namespace) {

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
@@ -75,7 +75,7 @@ class KafkaMetricsServiceTest {
     @Test
     void missingClusterNameThrows() {
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics("kafka", null, null, null, null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", null, null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Cluster name is required"));
     }
 
@@ -85,7 +85,7 @@ class KafkaMetricsServiceTest {
             .thenThrow(new ToolCallException("Kafka cluster 'missing' not found in namespace kafka"));
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics("kafka", "missing", null, null, null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", "missing", null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("not found in namespace"));
     }
 
@@ -95,7 +95,7 @@ class KafkaMetricsServiceTest {
             .thenThrow(new ToolCallException("Kafka cluster 'missing' not found in any namespace"));
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics(null, "missing", null, null, null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics(null, "missing", null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("not found in any namespace"));
     }
 
@@ -106,7 +106,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(kafka);
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics("kafka", "my-cluster", "invalid", null, null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics("kafka", "my-cluster", "invalid", null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Unknown metric category"));
     }
 
@@ -120,7 +120,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of());
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", null, null, null, null, null, null);
+            "kafka", "my-cluster", null, null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals(0, response.sampleCount());
@@ -145,7 +145,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(samples);
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", "replication", null, null, null, null, null);
+            "kafka", "my-cluster", "replication", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -166,7 +166,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", null, null, null, null, null, null);
+            "kafka", "my-cluster", null, null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -184,7 +184,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", null, "custom_metric_a,custom_metric_b", null, null, null, null);
+            "kafka", "my-cluster", null, "custom_metric_a,custom_metric_b", null, null, null, null, null, null);
 
         assertNotNull(response);
     }
@@ -196,7 +196,7 @@ class KafkaMetricsServiceTest {
                 "Multiple clusters named 'my-cluster' found in namespaces: kafka-a, kafka-b. Please specify namespace."));
 
         ToolCallException ex = assertThrows(ToolCallException.class,
-            () -> kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null, null, null));
+            () -> kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Multiple clusters"));
     }
 
@@ -214,7 +214,7 @@ class KafkaMetricsServiceTest {
             .thenReturn(List.of());
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", "replication", null, 60, null, null, 15);
+            "kafka", "my-cluster", "replication", null, 60, null, null, 15, null, null);
 
         assertNotNull(response);
     }
@@ -233,7 +233,7 @@ class KafkaMetricsServiceTest {
         // Provide a metric name that's already in the replication category
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
             "kafka", "my-cluster", "replication",
-            "kafka_server_replicamanager_underreplicatedpartitions,custom_metric", null, null, null, null);
+            "kafka_server_replicamanager_underreplicatedpartitions,custom_metric", null, null, null, null, null, null);
 
         assertNotNull(response);
     }
@@ -258,10 +258,151 @@ class KafkaMetricsServiceTest {
             .thenReturn(samples);
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
-            "kafka", "my-cluster", "replication", null, null, null, null, null);
+            "kafka", "my-cluster", "replication", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals(1, response.sampleCount());
+    }
+
+    @Test
+    void requestTypesFilterKeepsMatchingAndNonRequestSamples() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce", "quantile", "0.99"), 5.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Fetch", "quantile", "0.99"), 3.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Metadata", "quantile", "0.99"), 1.0),
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("namespace", "kafka"), 0.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "performance", null, null, null, null, null, null, "Produce,Fetch");
+
+        assertNotNull(response);
+        assertEquals(3, response.sampleCount());
+    }
+
+    @Test
+    void requestTypesFilterNullPassesAllThrough() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce"), 5.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Metadata"), 1.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "performance", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void aggregationClampedToBrokerForReplicationCategory() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null, null, null, "partition", null);
+
+        assertEquals("broker", response.aggregation());
+    }
+
+    @Test
+    void aggregationNotClampedForThroughputAtTopicLevel() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "throughput", null, null, null, null, null, "topic", null);
+
+        assertEquals("topic", response.aggregation());
+    }
+
+    @Test
+    void aggregationClampedToTopicForThroughputAtPartitionLevel() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "throughput", null, null, null, null, null, "partition", null);
+
+        assertEquals("topic", response.aggregation());
+    }
+
+    @Test
+    void aggregationNotClampedWhenExplicitMetricNamesOnly() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", null, "custom_metric", null, null, null, null, "partition", null);
+
+        assertEquals("partition", response.aggregation());
+    }
+
+    @Test
+    void aggregationClusterAlwaysPassesThrough() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null, null, null, "cluster", null);
+
+        assertEquals("cluster", response.aggregation());
     }
 
     private Kafka createKafka(final String name, final String namespace) {

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/StrimziOperatorMetricsServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +77,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                "kafka-system", null, null, null, null, null, null, null, null));
+                "kafka-system", null, null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
     }
 
@@ -87,7 +88,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                null, null, null, null, null, null, null, null, null));
+                null, null, null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
     }
 
@@ -98,7 +99,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                "kafka-system", "strimzi-cluster-operator", null, null, null, null, null, null, null));
+                "kafka-system", "strimzi-cluster-operator", null, null, null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("No Strimzi operator pods found"));
     }
 
@@ -110,7 +111,7 @@ class StrimziOperatorMetricsServiceTest {
 
         ToolCallException ex = assertThrows(ToolCallException.class,
             () -> strimziOperatorMetricsService.getOperatorMetrics(
-                "kafka-system", null, null, "invalid", null, null, null, null, null));
+                "kafka-system", null, null, "invalid", null, null, null, null, null, null));
         assertTrue(ex.getMessage().contains("Unknown metric category"));
     }
 
@@ -127,7 +128,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(samples);
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, null, "reconciliation", null, null, null, null, null);
+            "kafka-system", null, null, "reconciliation", null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("cluster-operator", response.operatorName());
@@ -144,7 +145,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, null, null, null, null, null, null, null);
+            "kafka-system", null, null, null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("kafka-system", response.namespace());
@@ -157,7 +158,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(pod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, null, null, "strimzi_resources,strimzi_resource_state", null, null, null, null);
+            "kafka-system", null, null, null, "strimzi_resources,strimzi_resource_state", null, null, null, null, null);
 
         assertNotNull(response);
     }
@@ -170,7 +171,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(pod1, pod2));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null);
 
         assertNotNull(response);
     }
@@ -182,7 +183,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(matchingPod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", "my-operator", null, null, null, null, null, null, null);
+            "kafka-system", "my-operator", null, null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-operator", response.operatorName());
@@ -197,7 +198,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of());
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, null, "reconciliation", null, 30, null, null, 10);
+            "kafka-system", null, null, "reconciliation", null, 30, null, null, 10, null);
 
         assertNotNull(response);
     }
@@ -216,26 +217,31 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(eoPod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            null, null, "my-cluster", null, null, null, null, null, null);
+            null, null, "my-cluster", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
 
-        // Verify pod targets include CO (1 target) + EO (2 targets: UO port + TO port)
+        // Different namespaces → 2 separate queries (CO + EO)
         ArgumentCaptor<List<PodTarget>> targetsCaptor = ArgumentCaptor.forClass(List.class);
-        verify(metricsQueryService).queryMetrics(targetsCaptor.capture(), anyMap(), anyList(),
-            any(), any(), any(), any());
-        List<PodTarget> targets = targetsCaptor.getValue();
-        assertEquals(3, targets.size());
+        ArgumentCaptor<Map<String, String>> matchersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(metricsQueryService, times(2)).queryMetrics(targetsCaptor.capture(),
+            matchersCaptor.capture(), anyList(), any(), any(), any(), any());
 
-        // CO target has no explicit port
-        assertNull(targets.get(0).port());
-        assertEquals("strimzi-system", targets.get(0).namespace());
+        // First call: CO targets with CO namespace
+        List<PodTarget> coTargets = targetsCaptor.getAllValues().get(0);
+        assertEquals(1, coTargets.size());
+        assertNull(coTargets.get(0).port());
+        assertEquals("strimzi-system", coTargets.get(0).namespace());
+        assertEquals("strimzi-system", matchersCaptor.getAllValues().get(0).get("namespace"));
 
-        // EO targets have explicit ports
-        assertEquals(StrimziConstants.EntityOperator.USER_OPERATOR_PORT, targets.get(1).port());
-        assertEquals(StrimziConstants.EntityOperator.TOPIC_OPERATOR_PORT, targets.get(2).port());
-        assertEquals("kafka-prod", targets.get(1).namespace());
+        // Second call: EO targets with EO namespace + pod filter
+        List<PodTarget> eoTargets = targetsCaptor.getAllValues().get(1);
+        assertEquals(2, eoTargets.size());
+        assertEquals(StrimziConstants.EntityOperator.USER_OPERATOR_PORT, eoTargets.get(0).port());
+        assertEquals(StrimziConstants.EntityOperator.TOPIC_OPERATOR_PORT, eoTargets.get(1).port());
+        assertEquals("kafka-prod", matchersCaptor.getAllValues().get(1).get("namespace"));
+        assertEquals("my-cluster-entity-operator-xyz", matchersCaptor.getAllValues().get(1).get("pod"));
     }
 
     @Test
@@ -247,7 +253,7 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of());
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, "my-cluster", null, null, null, null, null, null);
+            "kafka-system", null, "my-cluster", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("my-cluster", response.clusterName());
@@ -255,6 +261,7 @@ class StrimziOperatorMetricsServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void clusterNameWithDifferentNamespacesCOandEO() {
         Pod coPod = createPod("strimzi-cluster-operator-abc", "strimzi-system");
         when(strimziOperatorService.findClusterOperatorPods(null, null))
@@ -265,15 +272,22 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(eoPod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            null, null, "my-cluster", null, null, null, null, null, null);
+            null, null, "my-cluster", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("strimzi-system", response.namespace());
+
+        // Different namespaces → 2 separate queries
+        ArgumentCaptor<Map<String, String>> matchersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(metricsQueryService, times(2)).queryMetrics(anyList(),
+            matchersCaptor.capture(), anyList(), any(), any(), any(), any());
+        assertEquals("strimzi-system", matchersCaptor.getAllValues().get(0).get("namespace"));
+        assertEquals("kafka-prod", matchersCaptor.getAllValues().get(1).get("namespace"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void clusterNameAddsLabelMatcherForPrometheus() {
+    void clusterNameWithNoEOPodsQueriesByNamespaceOnly() {
         Pod coPod = createPod("strimzi-cluster-operator-abc", "kafka-system");
         when(strimziOperatorService.findClusterOperatorPods("kafka-system", null))
             .thenReturn(List.of(coPod));
@@ -281,16 +295,18 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of());
 
         strimziOperatorMetricsService.getOperatorMetrics(
-            "kafka-system", null, "my-cluster", null, null, null, null, null, null);
+            "kafka-system", null, "my-cluster", null, null, null, null, null, null, null);
 
         ArgumentCaptor<Map<String, String>> matchersCaptor = ArgumentCaptor.forClass(Map.class);
         verify(metricsQueryService).queryMetrics(anyList(), matchersCaptor.capture(), anyList(),
             any(), any(), any(), any());
         Map<String, String> matchers = matchersCaptor.getValue();
-        assertEquals("my-cluster", matchers.get("strimzi_io_cluster"));
+        assertEquals("kafka-system", matchers.get("namespace"));
+        assertNull(matchers.get("strimzi_io_cluster"));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void entityOperatorOnlyWhenNoCOPodsFound() {
         when(strimziOperatorService.findClusterOperatorPods(null, null))
             .thenReturn(List.of());
@@ -300,10 +316,41 @@ class StrimziOperatorMetricsServiceTest {
             .thenReturn(List.of(eoPod));
 
         StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
-            null, null, "my-cluster", null, null, null, null, null, null);
+            null, null, "my-cluster", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals("kafka-prod", response.namespace());
+
+        ArgumentCaptor<Map<String, String>> matchersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(metricsQueryService).queryMetrics(anyList(), matchersCaptor.capture(), anyList(),
+            any(), any(), any(), any());
+        Map<String, String> matchers = matchersCaptor.getValue();
+        assertEquals("kafka-prod", matchers.get("namespace"));
+        assertNull(matchers.get("strimzi_io_cluster"));
+    }
+
+    @Test
+    void aggregationClampedToClusterForReconciliationCategory() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(strimziOperatorService.findClusterOperatorPods("kafka-system", null))
+            .thenReturn(List.of(pod));
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", null, null, "reconciliation", null, null, null, null, null, "broker");
+
+        assertEquals("cluster", response.aggregation());
+    }
+
+    @Test
+    void aggregationClampedToClusterForDefaultCategory() {
+        Pod pod = createPod("strimzi-cluster-operator-abc123", "kafka-system");
+        when(strimziOperatorService.findClusterOperatorPods("kafka-system", null))
+            .thenReturn(List.of(pod));
+
+        StrimziOperatorMetricsResponse response = strimziOperatorMetricsService.getOperatorMetrics(
+            "kafka-system", null, null, null, null, null, null, null, null, null);
+
+        assertEquals("cluster", response.aggregation());
     }
 
     private Pod createPod(final String name, final String namespace) {

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/MetricsToolsTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/MetricsToolsTest.java
@@ -417,9 +417,10 @@ class MetricsToolsTest {
 
     @Test
     void testGetKafkaMetrics() {
-        when(kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null, null, null))
+        when(kafkaMetricsService.getKafkaMetrics(null, "my-cluster", null, null, null, null, null, null, null, null))
             .thenReturn(KafkaMetricsResponse.of("my-cluster", "kafka", "pod-scraping",
-                List.of("replication"), List.of(), null));
+                List.of("replication"), List.of(), null,
+                io.streamshub.mcp.common.dto.metrics.AggregationLevel.BROKER));
 
         client.when()
             .toolsCall("get_kafka_metrics", Map.of("clusterName", "my-cluster"), response -> {
@@ -433,9 +434,10 @@ class MetricsToolsTest {
 
     @Test
     void testGetStrimziOperatorMetrics() {
-        when(strimziOperatorMetricsService.getOperatorMetrics(null, null, null, null, null, null, null, null, null))
+        when(strimziOperatorMetricsService.getOperatorMetrics(null, null, null, null, null, null, null, null, null, null))
             .thenReturn(StrimziOperatorMetricsResponse.of("cluster-operator", null, "kafka-system",
-                "pod-scraping", List.of("reconciliation"), List.of(), null));
+                "pod-scraping", List.of("reconciliation"), List.of(), null,
+                io.streamshub.mcp.common.dto.metrics.AggregationLevel.BROKER));
 
         client.when()
             .toolsCall("get_strimzi_operator_metrics", Map.of(), response -> {


### PR DESCRIPTION
## Description

Adds metrics aggregation options. This should significantly improve token usage as before we put all metrics for performance as they are - around 11k of items per simple request. This mechanism aggregates metrics based on passed level so user can request different level of details.

## Type of change

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
