### PR TITLE
Various fixes like ipv6, input validation and log deduplication

### DIFF
--- a/common/src/main/java/io/streamshub/mcp/common/service/PodsService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/PodsService.java
@@ -164,6 +164,14 @@ public class PodsService {
         PodSpec spec = pod.getSpec();
         PodStatus podStatus = pod.getStatus();
 
+        if (spec == null) {
+            String name = metadata.getName();
+            String phase = podStatus != null ? podStatus.getPhase() : KubernetesConstants.PodPhases.UNKNOWN;
+            return PodSummaryResponse.PodInfo.summary(name, phase, false,
+                determineComponentFromPodInfo(name, metadata.getLabels() != null ? metadata.getLabels() : Map.of()),
+                0, 0);
+        }
+
         String podName = metadata.getName();
         String phase = podStatus != null ? podStatus.getPhase() : KubernetesConstants.PodPhases.UNKNOWN;
         Map<String, String> podLabels = metadata.getLabels() != null ? metadata.getLabels() : Map.of();

--- a/common/src/main/java/io/streamshub/mcp/common/service/log/LogCollectionService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/log/LogCollectionService.java
@@ -15,10 +15,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Orchestrator for collecting logs from multiple Kubernetes pods.
@@ -71,6 +69,10 @@ public class LogCollectionService {
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public PodLogsResult collectLogs(final String namespace, final List<Pod> pods,
                                      final LogCollectionParams options) {
+        if (options.tailLines() <= 0) {
+            throw new IllegalArgumentException("tailLines must be positive, got: " + options.tailLines());
+        }
+
         List<String> podNames = pods.stream()
             .map(pod -> pod.getMetadata().getName())
             .toList();
@@ -98,14 +100,9 @@ public class LogCollectionService {
                     options.startTime(), options.endTime());
 
                 if (podLog != null && !podLog.isEmpty()) {
-                    String[] lines = podLog.split("\n");
-
-                    if (lines.length > options.tailLines()) {
-                        hasMore = true;
-                        String[] trimmed = new String[options.tailLines()];
-                        System.arraycopy(lines, lines.length - options.tailLines(), trimmed, 0, options.tailLines());
-                        lines = trimmed;
-                    }
+                    String trimmedLog = tailLines(podLog, options.tailLines());
+                    hasMore = hasMore || trimmedLog.length() < podLog.length();
+                    String[] lines = trimmedLog.split("\n");
 
                     totalLines += lines.length;
 
@@ -137,27 +134,66 @@ public class LogCollectionService {
     }
 
     /**
-     * Deduplicate log lines by grouping identical consecutive or repeated lines.
-     * When the same line appears multiple times, it is shown once with a
-     * {@code [repeated N times]} suffix.
+     * Extract the last {@code count} lines from a log string by scanning
+     * backward for newline characters. Avoids splitting the entire string
+     * into an array when only the tail is needed.
+     *
+     * @param log   the full log string
+     * @param count the maximum number of lines to keep
+     * @return the tail portion of the log, or the full log if it has fewer lines
+     */
+    static String tailLines(final String log, final int count) {
+        int end = log.length();
+        if (end > 0 && log.charAt(end - 1) == '\n') {
+            end--;
+        }
+        int newlinesSeen = 0;
+        for (int i = end - 1; i >= 0; i--) {
+            if (log.charAt(i) == '\n') {
+                newlinesSeen++;
+                if (newlinesSeen == count) {
+                    return log.substring(i + 1);
+                }
+            }
+        }
+        return log;
+    }
+
+    /**
+     * Deduplicate consecutive identical log lines. When the same line appears
+     * multiple times in a row, it is shown once with a {@code [repeated N times]}
+     * suffix. Non-consecutive duplicates are preserved to maintain chronological order.
      *
      * @param lines the list of log lines to deduplicate
      * @return the deduplicated log output as a string
      */
-    private String deduplicateLines(final List<String> lines) {
-        Map<String, Integer> lineCounts = new LinkedHashMap<>();
-        for (String line : lines) {
-            lineCounts.merge(line, 1, Integer::sum);
-        }
-
+    String deduplicateLines(final List<String> lines) {
         StringBuilder output = new StringBuilder();
-        for (Map.Entry<String, Integer> entry : lineCounts.entrySet()) {
-            output.append(entry.getKey());
-            if (entry.getValue() > 1) {
-                output.append(" [repeated ").append(entry.getValue()).append(" times]");
+        String previous = null;
+        int count = 0;
+
+        for (String line : lines) {
+            if (line.equals(previous)) {
+                count++;
+            } else {
+                if (previous != null) {
+                    appendLine(output, previous, count);
+                }
+                previous = line;
+                count = 1;
             }
-            output.append("\n");
+        }
+        if (previous != null) {
+            appendLine(output, previous, count);
         }
         return output.toString();
+    }
+
+    private static void appendLine(final StringBuilder output, final String line, final int count) {
+        output.append(line);
+        if (count > 1) {
+            output.append(" [repeated ").append(count).append(" times]");
+        }
+        output.append("\n");
     }
 }

--- a/common/src/test/java/io/streamshub/mcp/common/service/PodsServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/PodsServiceTest.java
@@ -93,6 +93,22 @@ class PodsServiceTest {
     }
 
     @Test
+    void testExtractPodSummaryNullSpec() {
+        Pod pod = new Pod();
+        ObjectMeta metadata = new ObjectMeta();
+        metadata.setName("no-spec-pod");
+        metadata.setNamespace("kafka");
+        metadata.setLabels(Map.of());
+        pod.setMetadata(metadata);
+
+        PodSummaryResponse.PodInfo info = podsService.extractPodSummary("kafka", pod);
+
+        assertNotNull(info);
+        assertEquals("no-spec-pod", info.name());
+        assertFalse(info.ready());
+    }
+
+    @Test
     void testDescribePodNullNamespaceThrows() {
         assertThrows(IllegalArgumentException.class, () ->
             podsService.describePod(null, "my-pod"));

--- a/common/src/test/java/io/streamshub/mcp/common/service/log/LogCollectionServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/log/LogCollectionServiceTest.java
@@ -92,6 +92,20 @@ class LogCollectionServiceTest {
     }
 
     @Test
+    void testCollectLogsRejectsZeroTailLines() {
+        LogCollectionParams options = LogCollectionParams.of(null, null, 0, null);
+        assertThrows(IllegalArgumentException.class, () ->
+            logCollectionService.collectLogs("kafka", List.of(createSimplePod("pod-1")), options));
+    }
+
+    @Test
+    void testCollectLogsRejectsNegativeTailLines() {
+        LogCollectionParams options = LogCollectionParams.of(null, null, -5, null);
+        assertThrows(IllegalArgumentException.class, () ->
+            logCollectionService.collectLogs("kafka", List.of(createSimplePod("pod-1")), options));
+    }
+
+    @Test
     void testCollectLogsEmptyPodList() {
         LogCollectionParams options = LogCollectionParams.of(null, null, 100, null);
         PodLogsResult result = logCollectionService.collectLogs("kafka", List.of(), options);
@@ -99,6 +113,61 @@ class LogCollectionServiceTest {
         assertNotNull(result);
         assertTrue(result.podNames().isEmpty());
         assertEquals(0, result.totalLines());
+    }
+
+    // ---- 4a: tailLines tests ----
+
+    @Test
+    void testTailLinesReturnsLastNLines() {
+        String log = "line1\nline2\nline3\nline4\nline5\n";
+        String result = LogCollectionService.tailLines(log, 2);
+        assertEquals("line4\nline5\n", result);
+    }
+
+    @Test
+    void testTailLinesReturnsFullLogWhenFewerLines() {
+        String log = "line1\nline2\n";
+        String result = LogCollectionService.tailLines(log, 10);
+        assertEquals(log, result);
+    }
+
+    @Test
+    void testTailLinesHandlesSingleLine() {
+        String log = "only-line";
+        String result = LogCollectionService.tailLines(log, 5);
+        assertEquals("only-line", result);
+    }
+
+    // ---- 4c: deduplication tests ----
+
+    @Test
+    void testDeduplicateConsecutiveDuplicates() {
+        String result = logCollectionService.deduplicateLines(List.of("A", "A", "B"));
+        assertEquals("A [repeated 2 times]\nB\n", result);
+    }
+
+    @Test
+    void testDeduplicatePreservesNonConsecutive() {
+        String result = logCollectionService.deduplicateLines(List.of("A", "B", "A"));
+        assertEquals("A\nB\nA\n", result);
+    }
+
+    @Test
+    void testDeduplicateSingleLines() {
+        String result = logCollectionService.deduplicateLines(List.of("A", "B", "C"));
+        assertEquals("A\nB\nC\n", result);
+    }
+
+    @Test
+    void testDeduplicateAllIdentical() {
+        String result = logCollectionService.deduplicateLines(List.of("A", "A", "A"));
+        assertEquals("A [repeated 3 times]\n", result);
+    }
+
+    @Test
+    void testDeduplicateEmptyList() {
+        String result = logCollectionService.deduplicateLines(List.of());
+        assertEquals("", result);
     }
 
     private Pod createSimplePod(final String name) {

--- a/common/src/test/java/io/streamshub/mcp/common/util/InputUtilsTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/util/InputUtilsTest.java
@@ -4,10 +4,14 @@
  */
 package io.streamshub.mcp.common.util;
 
+import io.quarkiverse.mcp.server.ToolCallException;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link InputUtils} input normalization.
@@ -66,5 +70,49 @@ class InputUtilsTest {
     @Test
     void testNormalizeLiteralNullWithWhitespace() {
         assertNull(InputUtils.normalizeInput("  null  "));
+    }
+
+    // ---- validateK8sName tests ----
+
+    @Test
+    void testValidateK8sNameAcceptsValidNames() {
+        assertDoesNotThrow(() -> InputUtils.validateK8sName("my-cluster", "name"));
+        assertDoesNotThrow(() -> InputUtils.validateK8sName("kafka.prod.v2", "name"));
+        assertDoesNotThrow(() -> InputUtils.validateK8sName("a", "name"));
+        assertDoesNotThrow(() -> InputUtils.validateK8sName("cluster-01", "name"));
+    }
+
+    @Test
+    void testValidateK8sNameAcceptsNull() {
+        assertDoesNotThrow(() -> InputUtils.validateK8sName(null, "name"));
+    }
+
+    @Test
+    void testValidateK8sNameRejectsUppercase() {
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> InputUtils.validateK8sName("My-Cluster", "cluster name"));
+        assertTrue(ex.getMessage().contains("lowercase"));
+    }
+
+    @Test
+    void testValidateK8sNameRejectsSpecialChars() {
+        assertThrows(ToolCallException.class,
+            () -> InputUtils.validateK8sName("my_cluster", "name"));
+        assertThrows(ToolCallException.class,
+            () -> InputUtils.validateK8sName("my cluster", "name"));
+    }
+
+    @Test
+    void testValidateK8sNameRejectsTooLong() {
+        String longName = "a".repeat(254);
+        ToolCallException ex = assertThrows(ToolCallException.class,
+            () -> InputUtils.validateK8sName(longName, "name"));
+        assertTrue(ex.getMessage().contains("maximum length"));
+    }
+
+    @Test
+    void testValidateK8sNameRejectsStartingWithDash() {
+        assertThrows(ToolCallException.class,
+            () -> InputUtils.validateK8sName("-invalid", "name"));
     }
 }

--- a/docs/strimzi-mcp/configuration.md
+++ b/docs/strimzi-mcp/configuration.md
@@ -75,6 +75,8 @@ Use Grafana Loki for centralized log collection and historical log queries.
 | Property | Default | Description |
 |----------|---------|-------------|
 | `quarkus.rest-client.loki.url` | `http://localhost:3100` | Loki endpoint URL |
+| `quarkus.rest-client.loki.connect-timeout` | `5000` | Connection timeout in milliseconds |
+| `quarkus.rest-client.loki.read-timeout` | `30000` | Read timeout in milliseconds |
 | `mcp.log.loki.auth-mode` | `none` | Authentication mode: `none`, `basic`, or `serviceaccount` |
 | `mcp.log.loki.sa-token-path` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | Path to ServiceAccount token |
 
@@ -159,6 +161,8 @@ Use Prometheus for centralized metrics with long-term retention.
 | Property | Default | Description |
 |----------|---------|-------------|
 | `quarkus.rest-client.prometheus.url` | `http://localhost:9090` | Prometheus endpoint URL |
+| `quarkus.rest-client.prometheus.connect-timeout` | `5000` | Connection timeout in milliseconds |
+| `quarkus.rest-client.prometheus.read-timeout` | `30000` | Read timeout in milliseconds |
 | `mcp.metrics.prometheus.auth-mode` | `none` | Authentication mode: `none`, `basic`, or `serviceaccount` |
 | `mcp.metrics.prometheus.sa-token-path` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | Path to ServiceAccount token |
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/resource/ResourceSubscriptionManager.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -615,9 +616,13 @@ public class ResourceSubscriptionManager implements Closeable {
         final String description,
         final String json
     ) {
-        String previous = lastKnownState.put(uri, json);
+        AtomicBoolean changed = new AtomicBoolean();
+        lastKnownState.compute(uri, (key, previous) -> {
+            changed.set(!json.equals(previous));
+            return json;
+        });
 
-        if (json.equals(previous)) {
+        if (!changed.get()) {
             LOG.debugf(
                 "No change detected for resource: %s", uri);
             return;

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/DrainCleanerService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/DrainCleanerService.java
@@ -96,6 +96,8 @@ public class DrainCleanerService {
         if (name == null) {
             throw new ToolCallException("Drain cleaner name is required");
         }
+        InputUtils.validateK8sName(name, "drain cleaner name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting Strimzi Drain Cleaner name=%s in namespace=%s", name, ns != null ? ns : "auto");
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaNodePoolService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaNodePoolService.java
@@ -89,6 +89,8 @@ public class KafkaNodePoolService {
         if (nodePoolName == null) {
             throw new ToolCallException("NodePool name is required");
         }
+        InputUtils.validateK8sName(nodePoolName, "node pool name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting node pool=%s for cluster=%s in namespace=%s",
             nodePoolName, clusterName, ns != null ? ns : "auto");

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaService.java
@@ -102,6 +102,8 @@ public class KafkaService {
         if (normalizedName == null) {
             throw new ToolCallException("Cluster name is required");
         }
+        InputUtils.validateK8sName(normalizedName, "cluster name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting Kafka cluster name=%s (namespace=%s)", normalizedName, ns != null ? ns : "auto");
 
@@ -240,7 +242,7 @@ public class KafkaService {
                     addr.getPort(),
                     listener.getName(),
                     listenerTypesByName.getOrDefault(listener.getName(), KubernetesConstants.UNKNOWN),
-                    String.format("%s:%d", addr.getHost(), addr.getPort())
+                    formatHostPort(addr.getHost(), addr.getPort())
                 )))
             .toList();
     }
@@ -451,7 +453,7 @@ public class KafkaService {
                 if (listener.getAddresses() != null && !listener.getAddresses().isEmpty()) {
                     ListenerAddress addr = listener.getAddresses().getFirst();
                     if (addr.getHost() != null && addr.getPort() != null) {
-                        bootstrapAddress = String.format("%s:%d", addr.getHost(), addr.getPort());
+                        bootstrapAddress = formatHostPort(addr.getHost(), addr.getPort());
                     }
                 }
                 return ListenerInfo.of(
@@ -460,6 +462,13 @@ public class KafkaService {
                     bootstrapAddress);
             })
             .toList();
+    }
+
+    private static String formatHostPort(final String host, final int port) {
+        if (host.contains(":")) {
+            return String.format("[%s]:%d", host, port);
+        }
+        return String.format("%s:%d", host, port);
     }
 
     private boolean extractExternalAccess(final Kafka kafka) {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaTopicService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaTopicService.java
@@ -34,6 +34,9 @@ public class KafkaTopicService {
     @ConfigProperty(name = "mcp.topics.default-page-size", defaultValue = "100")
     int defaultPageSize;
 
+    @ConfigProperty(name = "mcp.topics.max-list-size", defaultValue = "5000")
+    int maxTopicListSize;
+
     KafkaTopicService() {
     }
 
@@ -70,6 +73,12 @@ public class KafkaTopicService {
                 KafkaTopic.class, ResourceLabels.STRIMZI_CLUSTER_LABEL, normalizedClusterName);
         }
 
+        if (topics.size() > maxTopicListSize) {
+            LOG.warnf("Topic list for cluster %s truncated from %d to %d",
+                normalizedClusterName, topics.size(), maxTopicListSize);
+            topics = topics.subList(0, maxTopicListSize);
+        }
+
         int total = topics.size();
         int fromIndex = Math.min(effectiveOffset, total);
         int toIndex = Math.min(effectiveOffset + effectiveLimit, total);
@@ -96,6 +105,8 @@ public class KafkaTopicService {
         if (topicName == null) {
             throw new ToolCallException("Topic name is required");
         }
+        InputUtils.validateK8sName(topicName, "topic name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting topic=%s for cluster=%s in namespace=%s", topicName, clusterName, ns != null ? ns : "auto");
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaUserService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/KafkaUserService.java
@@ -94,6 +94,8 @@ public class KafkaUserService {
         if (normalizedName == null) {
             throw new ToolCallException("User name is required");
         }
+        InputUtils.validateK8sName(normalizedName, "user name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting KafkaUser name=%s (namespace=%s)", normalizedName, ns != null ? ns : "auto");
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/StrimziOperatorService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/StrimziOperatorService.java
@@ -83,6 +83,8 @@ public class StrimziOperatorService {
         if (operatorName == null) {
             throw new ToolCallException("Operator name is required");
         }
+        InputUtils.validateK8sName(operatorName, "operator name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting Strimzi operator name=%s in namespace=%s", operatorName, ns != null ? ns : "auto");
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectService.java
@@ -90,6 +90,8 @@ public class KafkaConnectService {
         if (normalizedName == null) {
             throw new ToolCallException("KafkaConnect cluster name is required");
         }
+        InputUtils.validateK8sName(normalizedName, "connect cluster name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting KafkaConnect cluster name=%s (namespace=%s)", normalizedName, ns != null ? ns : "auto");
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectorService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectorService.java
@@ -87,6 +87,8 @@ public class KafkaConnectorService {
         if (normalizedName == null) {
             throw new ToolCallException("Connector name is required");
         }
+        InputUtils.validateK8sName(normalizedName, "connector name");
+        InputUtils.validateK8sName(ns, "namespace");
 
         LOG.infof("Getting KafkaConnector name=%s (namespace=%s)", normalizedName, ns != null ? ns : "auto");
 

--- a/strimzi-mcp/src/main/resources/application.properties
+++ b/strimzi-mcp/src/main/resources/application.properties
@@ -35,6 +35,8 @@ mcp.log.tail-lines=200
 # Loki config (only when provider=loki)
 quarkus.rest-client.loki.url=http://localhost:3100
 quarkus.rest-client.loki.scope=jakarta.inject.Singleton
+quarkus.rest-client.loki.connect-timeout=5000
+quarkus.rest-client.loki.read-timeout=30000
 #quarkus.tls.trust-all=true
 mcp.log.loki.auth-mode=none
 mcp.log.loki.sa-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
@@ -69,6 +71,8 @@ mcp.metrics.default-step-seconds=60
 # Prometheus config (only when provider=prometheus)
 quarkus.rest-client.prometheus.url=http://localhost:9090
 quarkus.rest-client.prometheus.scope=jakarta.inject.Singleton
+quarkus.rest-client.prometheus.connect-timeout=5000
+quarkus.rest-client.prometheus.read-timeout=30000
 mcp.metrics.prometheus.auth-mode=none
 mcp.metrics.prometheus.sa-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
 


### PR DESCRIPTION
## Description

- Validate K8s resource names in all service get methods and reject invalid tailLines values
- Guard PodsService against null PodSpec                                                                                                                                                                               
- Replace full log split with backward newline scan to avoid large array allocations
- Cap topic list size (configurable, default 5000) to prevent OOM on large clusters                                                                                                                                    
- Fix log deduplication to only collapse consecutive identical lines, preserving chronological order                                                                                                                   
- Add connect/read timeouts for Prometheus and Loki REST clients                                                                                                                                                       
- Fix IPv6 bootstrap address formatting

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
