### PR TITLE
Find drain cleaner also in other namespaces

### DIFF
--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AssessUpgradeReadinessPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AssessUpgradeReadinessPrompt.java
@@ -190,7 +190,8 @@ public class AssessUpgradeReadinessPrompt {
             this can cause a cascade of failures.
 
             ## Step 7: Drain Cleaner readiness [GO/NO-GO]
-            Use `check_drain_cleaner_readiness` to verify drain cleaner status.
+            Use `check_drain_cleaner_readiness` **without passing a namespace** to verify drain cleaner \
+            status. The drain cleaner is typically deployed in a different namespace than the Kafka cluster.
 
             **GO conditions**:
             - Drain Cleaner deployed and ready (ensures graceful pod evictions)

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/DiagnoseClusterIssuePrompt.java
@@ -101,7 +101,9 @@ public class DiagnoseClusterIssuePrompt {
             - Certificate renewal reconciliations (every 30 days)
 
             ## Step 2: Check Strimzi Drain Cleaner [HIGH - graceful eviction handling]
-            Use `check_drain_cleaner_readiness` to assess drain cleaner production readiness.
+            Use `check_drain_cleaner_readiness` **without passing a namespace** to assess drain cleaner \
+            production readiness. The drain cleaner is typically deployed in a different namespace than \
+            the Kafka cluster.
 
             If drain cleaner is NOT deployed:
             - Node drains will cause abrupt pod terminations instead of graceful rolling updates
@@ -117,8 +119,8 @@ public class DiagnoseClusterIssuePrompt {
             or replicas out of sync, drain cleaner status is likely the root cause.**
 
             If drain cleaner IS deployed and the symptom involves evictions:
-            Use `get_drain_cleaner_logs` to check for eviction interception activity, \
-            pod annotation events, and errors during node drains.
+            Use `get_drain_cleaner_logs` **without passing a namespace** to check for eviction \
+            interception activity, pod annotation events, and errors during node drains.
 
             ## Step 3: Check KafkaNodePool statuses [HIGH - broker availability]
             Use `list_kafka_node_pools` to list all node pools for this cluster.


### PR DESCRIPTION
## Description

Prompt template sometimes do not find drain cleaner because it tries to find it in same namesapce as kafka. So this isa fix for that.

## Type of change


* Bug fix (non-breaking change which fixes an issue)

