### PR TITLE
Improve MirrorMaker2 dev environment with namespace isolation and verification consumer

### DIFF
--- a/dev/manifests/strimzi/kafka-mirror-maker/000-Namespace.yaml
+++ b/dev/manifests/strimzi/kafka-mirror-maker/000-Namespace.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: strimzi-kafka-mirror
+  labels:
+    app: strimzi
+    mcp: strimzi
+    system: strimzi
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: strimzi-mirror-maker
+  labels:
+    app: strimzi
+    mcp: strimzi
+    system: strimzi

--- a/dev/manifests/strimzi/kafka-mirror-maker/010-Kafka-mirror.yaml
+++ b/dev/manifests/strimzi/kafka-mirror-maker/010-Kafka-mirror.yaml
@@ -2,10 +2,10 @@
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
-  name: secondary-combined
-  namespace: strimzi-kafka
+  name: mirror-combined
+  namespace: strimzi-kafka-mirror
   labels:
-    strimzi.io/cluster: mcp-cluster-secondary
+    strimzi.io/cluster: mcp-cluster-mirror
     mcp: strimzi
     system: strimzi
 spec:
@@ -24,8 +24,8 @@ spec:
 apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
-  name: mcp-cluster-secondary
-  namespace: strimzi-kafka
+  name: mcp-cluster-mirror
+  namespace: strimzi-kafka-mirror
   labels:
     mcp: strimzi
     system: strimzi

--- a/dev/manifests/strimzi/kafka-mirror-maker/030-KafkaMirrorMaker2.yaml
+++ b/dev/manifests/strimzi/kafka-mirror-maker/030-KafkaMirrorMaker2.yaml
@@ -3,7 +3,7 @@ apiVersion: kafka.strimzi.io/v1
 kind: KafkaMirrorMaker2
 metadata:
   name: mcp-mirror-maker
-  namespace: strimzi-kafka
+  namespace: strimzi-mirror-maker
   labels:
     mcp: strimzi
     system: strimzi
@@ -11,26 +11,31 @@ spec:
   version: 4.2.0
   replicas: 1
   target:
-    alias: mcp-cluster
-    bootstrapServers: mcp-cluster-kafka-bootstrap:9777
-    tls:
-      trustedCertificates:
-        - secretName: mcp-cluster-cluster-ca-cert
-          pattern: "*.crt"
-    authentication:
-      type: scram-sha-512
-      username: mm2-user
-      passwordSecret:
-        secretName: mm2-user
-        password: password
+    alias: mcp-cluster-mirror
+    bootstrapServers: mcp-cluster-mirror-kafka-bootstrap.strimzi-kafka-mirror.svc:9092
     groupId: mcp-mirror-maker
     configStorageTopic: mirrormaker2-cluster-configs
     statusStorageTopic: mirrormaker2-cluster-status
     offsetStorageTopic: mirrormaker2-cluster-offsets
+    config:
+      # -1 means it will use the default replication factor configured in the broker
+      config.storage.replication.factor: -1
+      offset.storage.replication.factor: -1
+      status.storage.replication.factor: -1
   mirrors:
     - source:
-        alias: mcp-cluster-secondary
-        bootstrapServers: mcp-cluster-secondary-kafka-bootstrap:9092
+        alias: mcp-cluster
+        bootstrapServers: mcp-cluster-kafka-bootstrap.strimzi-kafka.svc:9777
+        tls:
+          trustedCertificates:
+            - secretName: mcp-cluster-cluster-ca-cert
+              pattern: "*.crt"
+        authentication:
+          type: scram-sha-512
+          username: mm2-user
+          passwordSecret:
+            secretName: mm2-user
+            password: password
       sourceConnector:
         tasksMax: 1
         config:
@@ -49,5 +54,5 @@ spec:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 1000m
+      memory: 1024Mi

--- a/dev/manifests/strimzi/kafka-mirror-maker/040-KafkaTopic-source.yaml
+++ b/dev/manifests/strimzi/kafka-mirror-maker/040-KafkaTopic-source.yaml
@@ -5,12 +5,12 @@ metadata:
   name: source-orders
   namespace: strimzi-kafka
   labels:
-    strimzi.io/cluster: mcp-cluster-secondary
+    strimzi.io/cluster: mcp-cluster
     mcp: strimzi
     system: strimzi
 spec:
   partitions: 3
-  replicas: 1
+  replicas: 3
   config:
     retention.ms: 86400000
 ---
@@ -20,11 +20,11 @@ metadata:
   name: source-events
   namespace: strimzi-kafka
   labels:
-    strimzi.io/cluster: mcp-cluster-secondary
+    strimzi.io/cluster: mcp-cluster
     mcp: strimzi
     system: strimzi
 spec:
   partitions: 3
-  replicas: 1
+  replicas: 3
   config:
     retention.ms: 86400000

--- a/dev/manifests/strimzi/kafka-mirror-maker/050-MirrorConsumer.yaml
+++ b/dev/manifests/strimzi/kafka-mirror-maker/050-MirrorConsumer.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mirror-consumer
+  namespace: strimzi-kafka-mirror
+  labels:
+    app: mirror-consumer
+    mcp: strimzi
+    system: strimzi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mirror-consumer
+  template:
+    metadata:
+      labels:
+        app: mirror-consumer
+    spec:
+      containers:
+        - name: mirror-consumer
+          image: quay.io/strimzi-test-clients/test-clients:latest-kafka-4.2.0
+          env:
+            - name: CLIENT_TYPE
+              value: KafkaConsumer
+            - name: BOOTSTRAP_SERVERS
+              value: mcp-cluster-mirror-kafka-bootstrap:9092
+            - name: TOPIC
+              value: mcp-cluster.mcp-test-topic
+            - name: GROUP_ID
+              value: mirror-verify-group
+            - name: MESSAGE_COUNT
+              value: "999999999"

--- a/dev/manifests/strimzi/kafka-mirror-maker/kustomization.yaml
+++ b/dev/manifests/strimzi/kafka-mirror-maker/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - 010-Kafka-secondary.yaml
+  - 000-Namespace.yaml
+  - 010-Kafka-mirror.yaml
   - 020-KafkaUser-mm2.yaml
   - 030-KafkaMirrorMaker2.yaml
   - 040-KafkaTopic-source.yaml
+  - 050-MirrorConsumer.yaml

--- a/dev/scripts/dev-deploy.sh
+++ b/dev/scripts/dev-deploy.sh
@@ -128,6 +128,11 @@ if [ "$LOKI" = true ] || [ "$PROMETHEUS" = true ]; then
 fi
 
 if [ "$LOKI" = true ]; then
+    echo "==> Granting Loki RBAC to service account $SA_NAME"
+    kubectl create clusterrolebinding "${SA_NAME}-logging-application-view" \
+        --clusterrole=cluster-logging-application-view \
+        --serviceaccount="${DEPLOY_NS}:${SA_NAME}" \
+        --dry-run=client -o yaml | kubectl apply -f -
     echo "==> Configuring Loki log provider"
     kubectl -n "$DEPLOY_NS" set env "$DEPLOY_TARGET" \
         MCP_LOG_PROVIDER="${MCP_LOG_PROVIDER:-streamshub-loki}" \

--- a/dev/scripts/setup-strimzi.sh
+++ b/dev/scripts/setup-strimzi.sh
@@ -10,6 +10,9 @@ STRIMZI_DIR="$SCRIPT_DIR/../manifests/strimzi"
 OPERATOR_NS="strimzi"
 KAFKA_NS="strimzi-kafka"
 CLUSTER_NAME="mcp-cluster"
+MIRROR_NS="strimzi-kafka-mirror"
+MIRROR_MAKER_NS="strimzi-mirror-maker"
+MIRROR_CLUSTER="mcp-cluster-mirror"
 
 INSTALL_PROMETHEUS=false
 INSTALL_LOKI=false
@@ -30,6 +33,17 @@ log_info()    { echo -e "${BLUE}[INFO]  $1${NC}"; }
 log_success() { echo -e "${GREEN}[OK]    $1${NC}"; }
 log_warning() { echo -e "${YELLOW}[WARN]  $1${NC}"; }
 log_error()   { echo -e "${RED}[ERROR] $1${NC}"; }
+
+copy_secret() {
+    local secret_name="$1"
+    local source_ns="$2"
+    local target_ns="$3"
+    log_info "Copying secret '$secret_name' from $source_ns to $target_ns..."
+    kubectl get secret "$secret_name" -n "$source_ns" -o json \
+        | jq 'del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp,
+              .metadata.managedFields, .metadata.ownerReferences, .metadata.namespace)' \
+        | kubectl apply -n "$target_ns" -f -
+}
 
 check_kubectl() {
     if ! command -v kubectl &> /dev/null; then
@@ -158,15 +172,8 @@ teardown_bridge() {
 }
 
 deploy_mirror_maker() {
-    log_info "Deploying secondary Kafka cluster and MirrorMaker2..."
+    log_info "Deploying mirror cluster, MirrorMaker2, and verification consumer..."
     kubectl apply -k "$STRIMZI_DIR/kafka-mirror-maker/"
-
-    log_info "Waiting for secondary cluster to be ready (this may take a few minutes)..."
-    kubectl wait kafka/mcp-cluster-secondary \
-        --for=condition=Ready \
-        -n "$KAFKA_NS" \
-        --timeout=600s
-    log_success "Secondary Kafka cluster is ready"
 
     log_info "Waiting for MirrorMaker2 user to be ready..."
     kubectl wait kafkauser/mm2-user \
@@ -174,18 +181,32 @@ deploy_mirror_maker() {
         -n "$KAFKA_NS" \
         --timeout=120s
 
+    copy_secret "mcp-cluster-cluster-ca-cert" "$KAFKA_NS" "$MIRROR_MAKER_NS"
+    copy_secret "mm2-user" "$KAFKA_NS" "$MIRROR_MAKER_NS"
+
+    log_info "Waiting for mirror cluster to be ready (this may take a few minutes)..."
+    kubectl wait kafka/"$MIRROR_CLUSTER" \
+        --for=condition=Ready \
+        -n "$MIRROR_NS" \
+        --timeout=600s
+    log_success "Mirror Kafka cluster is ready"
+
     log_info "Waiting for MirrorMaker2 to be ready..."
     kubectl wait kafkamirrormaker2/mcp-mirror-maker \
         --for=condition=Ready \
-        -n "$KAFKA_NS" \
+        -n "$MIRROR_MAKER_NS" \
         --timeout=300s
     log_success "MirrorMaker2 is ready"
+
+    log_info "Mirror consumer deployed — check logs with: kubectl logs -n $MIRROR_NS deployment/mirror-consumer"
 }
 
 teardown_mirror_maker() {
-    log_info "Removing MirrorMaker2 and secondary cluster..."
+    log_info "Removing MirrorMaker2, mirror cluster, and verification consumer..."
     kubectl delete -k "$STRIMZI_DIR/kafka-mirror-maker/" --ignore-not-found
-    log_success "MirrorMaker2 and secondary cluster removed"
+    kubectl delete namespace "$MIRROR_NS" --ignore-not-found --timeout=60s 2>/dev/null || true
+    kubectl delete namespace "$MIRROR_MAKER_NS" --ignore-not-found --timeout=60s 2>/dev/null || true
+    log_success "MirrorMaker2 and mirror cluster removed"
 }
 
 deploy_test_clients() {
@@ -295,8 +316,9 @@ deploy() {
         echo "KafkaBridge:         mcp-bridge"
     fi
     if [ "$INSTALL_MIRROR_MAKER" = true ]; then
-        echo "Secondary cluster:   mcp-cluster-secondary"
-        echo "MirrorMaker2:        mcp-mirror-maker"
+        echo "Mirror cluster:      $MIRROR_CLUSTER (ns: $MIRROR_NS)"
+        echo "MirrorMaker2:        mcp-mirror-maker (ns: $MIRROR_MAKER_NS)"
+        echo "Mirror consumer:     mirror-consumer (ns: $MIRROR_NS)"
     fi
     if [ "$INSTALL_TEST_CLIENTS" = true ]; then
         echo "Test clients:        kafka-producer, kafka-consumer, http-producer, http-consumer"
@@ -320,7 +342,9 @@ deploy() {
         echo "  kubectl get kafkabridge -n $KAFKA_NS"
     fi
     if [ "$INSTALL_MIRROR_MAKER" = true ]; then
-        echo "  kubectl get kafkamirrormaker2 -n $KAFKA_NS"
+        echo "  kubectl get kafka -n $MIRROR_NS"
+        echo "  kubectl get kafkamirrormaker2 -n $MIRROR_MAKER_NS"
+        echo "  kubectl logs -n $MIRROR_NS deployment/mirror-consumer"
     fi
 }
 
@@ -446,7 +470,7 @@ case "$COMMAND" in
         echo "  --loki           Also deploy/remove Loki for log collection (OpenShift only)"
         echo "  --drain-cleaner  Also deploy/remove Strimzi Drain Cleaner"
         echo "  --bridge         Also deploy/remove KafkaBridge (HTTP REST API to Kafka)"
-        echo "  --mirror-maker   Also deploy/remove secondary Kafka cluster + MirrorMaker2"
+        echo "  --mirror-maker   Also deploy/remove mirror Kafka cluster + MirrorMaker2 (separate namespaces)"
         echo "  --test-clients   Also deploy/remove test clients (Kafka + HTTP producers/consumers)"
         ;;
     *)


### PR DESCRIPTION
## Description

Renames existing Kafka mirror cluster and move it and KMM2 instance into separated namespaces to better reflect production-like environments. CA secrets copy into target namespaces is handled via setup script.

## Type of change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
