### PR TITLE
Improve log collection error handling with LogQueryException

### DIFF
--- a/common/src/main/java/io/streamshub/mcp/common/service/log/LogCollectionService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/log/LogCollectionService.java
@@ -123,7 +123,8 @@ public class LogCollectionService {
                 }
             } catch (Exception e) {
                 LOG.debugf("Could not retrieve logs from pod %s: %s", podName, e.getMessage());
-                allLogs.append("=== Pod: ").append(podName).append(" === (logs unavailable)\n");
+                allLogs.append("=== Pod: ").append(podName)
+                    .append(" === (logs unavailable: ").append(e.getMessage()).append(")\n");
             }
             if (options.progressCallback() != null) {
                 options.progressCallback().accept(podIndex, pods.size());

--- a/common/src/main/java/io/streamshub/mcp/common/service/log/LogQueryException.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/log/LogQueryException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.service.log;
+
+/**
+ * Thrown when a log provider fails to query logs from the backing store.
+ */
+public class LogQueryException extends RuntimeException {
+
+    /**
+     * Creates a new log query exception.
+     *
+     * @param message description of the query failure
+     * @param cause   the underlying exception
+     */
+    public LogQueryException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/loki-log-provider/src/main/java/io/streamshub/mcp/loki/LokiLogProvider.java
+++ b/loki-log-provider/src/main/java/io/streamshub/mcp/loki/LokiLogProvider.java
@@ -6,6 +6,7 @@ package io.streamshub.mcp.loki;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.streamshub.mcp.common.service.log.LogCollectorProvider;
+import io.streamshub.mcp.common.service.log.LogQueryException;
 import io.streamshub.mcp.loki.config.LokiConfig;
 import io.streamshub.mcp.loki.service.LokiClient;
 import io.streamshub.mcp.loki.util.LogQLSanitizer;
@@ -87,7 +88,8 @@ public class LokiLogProvider implements LogCollectorProvider {
             return extractLogLines(response);
         } catch (Exception e) {
             LOG.warnf("Failed to query Loki for pod %s/%s: %s", namespace, podName, e.getMessage());
-            return null;
+            throw new LogQueryException(
+                String.format("Loki query failed for pod %s/%s: %s", namespace, podName, e.getMessage()), e);
         }
     }
 


### PR DESCRIPTION
## Description

When MCP lost access to Loki and didn't retreive the logs it just logged warning without propagating the error and AI assistant simply thinks that there are no errors logs in case if search for error logs. This PR resolves it.

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
