### PR TITLE
Improve metrics with common label extraction, rate conversion, and response size optimization

### DIFF
--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/AggregationLevel.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/AggregationLevel.java
@@ -46,14 +46,14 @@ public enum AggregationLevel {
 
     /**
      * Parses a string to an aggregation level (case-insensitive).
-     * Returns {@link #BROKER} if the input is null or blank.
+     * Returns {@link #CLUSTER} if the input is null or blank.
      *
      * @param value the level name
-     * @return the parsed level, or BROKER as default
+     * @return the parsed level, or CLUSTER as default
      */
     public static AggregationLevel fromString(final String value) {
         if (value == null || value.isBlank()) {
-            return BROKER;
+            return CLUSTER;
         }
         return valueOf(value.toUpperCase(Locale.ROOT));
     }

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummary.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummary.java
@@ -12,27 +12,31 @@ import java.util.List;
 /**
  * Summary statistics for a metric time series. Provides a compact overview of
  * the data without requiring the LLM to process every individual data point.
+ * For single-point series (instant queries), only {@code latest} and
+ * {@code originalDataPointCount} are populated; other fields are null to
+ * reduce response size.
  *
- * @param min                    the minimum value in the series
- * @param max                    the maximum value in the series
- * @param avg                    the average value across all data points
+ * @param min                    the minimum value in the series (null for single-point)
+ * @param max                    the maximum value in the series (null for single-point)
+ * @param avg                    the average value across all data points (null for single-point)
  * @param latest                 the most recent value in the series
- * @param delta                  the change from first to last value (last - first)
+ * @param delta                  the change from first to last value (null for single-point)
  * @param originalDataPointCount the number of data points before compression
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record TimeSeriesSummary(
-    @JsonProperty("min") double min,
-    @JsonProperty("max") double max,
-    @JsonProperty("avg") double avg,
+    @JsonProperty("min") Double min,
+    @JsonProperty("max") Double max,
+    @JsonProperty("avg") Double avg,
     @JsonProperty("latest") double latest,
-    @JsonProperty("delta") double delta,
+    @JsonProperty("delta") Double delta,
     @JsonProperty("original_data_point_count") int originalDataPointCount
 ) {
 
     /**
      * Computes summary statistics from a list of time-value data points.
      * Each data point is a {@code [epochSeconds, value]} list.
+     * For single-point series, only {@code latest} is populated.
      *
      * @param dataPoints the raw data points to summarize
      * @return the computed summary, or null if the list is empty
@@ -42,11 +46,16 @@ public record TimeSeriesSummary(
             return null;
         }
 
+        double lastVal = extractValue(dataPoints.getLast());
+
+        if (dataPoints.size() == 1) {
+            return new TimeSeriesSummary(null, null, null, lastVal, null, 1);
+        }
+
         double minVal = Double.MAX_VALUE;
         double maxVal = -Double.MAX_VALUE;
         double sum = 0.0;
         double firstVal = extractValue(dataPoints.getFirst());
-        double lastVal = firstVal;
 
         for (List<Object> dp : dataPoints) {
             double val = extractValue(dp);
@@ -57,7 +66,6 @@ public record TimeSeriesSummary(
                 maxVal = val;
             }
             sum += val;
-            lastVal = val;
         }
 
         double avg = sum / dataPoints.size();

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/CommonLabelExtractor.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/CommonLabelExtractor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extracts labels that are identical across all time series in a response,
+ * factoring them into a shared {@code commonLabels} map and stripping them
+ * from individual series to reduce response size.
+ */
+public final class CommonLabelExtractor {
+
+    private CommonLabelExtractor() {
+    }
+
+    /**
+     * Result of common label extraction.
+     *
+     * @param commonLabels   labels shared by all time series (key→value identical across every series)
+     * @param strippedSeries the time series with common labels removed from each
+     */
+    public record Result(
+        Map<String, String> commonLabels,
+        List<AggregatedTimeSeries> strippedSeries
+    ) {
+    }
+
+    /**
+     * Extracts common labels from a list of aggregated time series.
+     *
+     * @param series the time series to process
+     * @return the extraction result with common labels and stripped series
+     */
+    public static Result extract(final List<AggregatedTimeSeries> series) {
+        if (series == null || series.isEmpty()) {
+            return new Result(Map.of(), series == null ? List.of() : series);
+        }
+
+        if (series.size() == 1) {
+            Map<String, String> labels = series.getFirst().labels();
+            if (labels == null || labels.isEmpty()) {
+                return new Result(Map.of(), series);
+            }
+            Map<String, String> common = new LinkedHashMap<>(labels);
+            AggregatedTimeSeries stripped = new AggregatedTimeSeries(
+                series.getFirst().name(), Map.of(),
+                series.getFirst().dataPoints(), series.getFirst().summary(),
+                series.getFirst().sourceCount(), series.getFirst().compressed());
+            return new Result(common, List.of(stripped));
+        }
+
+        // Find labels present in ALL series with identical values
+        Map<String, String> candidate = new LinkedHashMap<>();
+        Map<String, String> firstLabels = series.getFirst().labels();
+        if (firstLabels != null) {
+            candidate.putAll(firstLabels);
+        }
+
+        for (int i = 1; i < series.size() && !candidate.isEmpty(); i++) {
+            Map<String, String> labels = series.get(i).labels();
+            if (labels == null || labels.isEmpty()) {
+                candidate.clear();
+                break;
+            }
+            candidate.entrySet().removeIf(entry ->
+                !entry.getValue().equals(labels.get(entry.getKey())));
+        }
+
+        if (candidate.isEmpty()) {
+            return new Result(Map.of(), series);
+        }
+
+        // Strip common labels from each series
+        List<AggregatedTimeSeries> stripped = new ArrayList<>(series.size());
+        for (AggregatedTimeSeries ts : series) {
+            Map<String, String> remaining = new LinkedHashMap<>();
+            if (ts.labels() != null) {
+                for (Map.Entry<String, String> entry : ts.labels().entrySet()) {
+                    if (!candidate.containsKey(entry.getKey())) {
+                        remaining.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+            stripped.add(new AggregatedTimeSeries(
+                ts.name(), remaining, ts.dataPoints(), ts.summary(),
+                ts.sourceCount(), ts.compressed()));
+        }
+
+        return new Result(Map.copyOf(candidate), List.copyOf(stripped));
+    }
+}

--- a/common/src/main/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilter.java
+++ b/common/src/main/java/io/streamshub/mcp/common/util/metrics/MetricLabelFilter.java
@@ -28,8 +28,17 @@ public final class MetricLabelFilter {
         "service"
     );
 
+    private static final Set<String> ROLE_LABELS = Set.of(
+        "strimzi_io_broker_role",
+        "strimzi_io_controller_role"
+    );
+
     private static final Set<String> POD_IDENTITY_LABELS = Set.of(
         "pod", "kubernetes_pod_name", "strimzi_io_pod_name", "node_name", "node_ip"
+    );
+
+    private static final Set<String> POOL_IDENTITY_LABELS = Set.of(
+        "strimzi_io_controller_name", "strimzi_io_pool_name"
     );
 
     private static final Set<String> CANONICAL_LABELS = Set.of("pod", "topic", "partition");
@@ -89,7 +98,7 @@ public final class MetricLabelFilter {
         Map<String, String> filtered = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             String key = entry.getKey();
-            if (INTERNAL_LABELS.contains(key)) {
+            if (INTERNAL_LABELS.contains(key) || ROLE_LABELS.contains(key)) {
                 continue;
             }
             if (shouldStripForLevel(key, level)) {
@@ -132,7 +141,9 @@ public final class MetricLabelFilter {
             case PARTITION -> false;
             case TOPIC -> PARTITION_LABELS.contains(key);
             case BROKER -> TOPIC_PARTITION_LABELS.contains(key);
-            case CLUSTER -> TOPIC_PARTITION_LABELS.contains(key) || POD_IDENTITY_LABELS.contains(key);
+            case CLUSTER -> TOPIC_PARTITION_LABELS.contains(key)
+                || POD_IDENTITY_LABELS.contains(key)
+                || POOL_IDENTITY_LABELS.contains(key);
         };
     }
 }

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregatedTimeSeriesTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregatedTimeSeriesTest.java
@@ -62,7 +62,7 @@ class AggregatedTimeSeriesTest {
         AggregatedTimeSeries series = result.getFirst();
         assertEquals("m", series.name());
         assertEquals(2, series.sourceCount());
-        assertEquals(15.0, series.summary().avg(), 0.001);
+        assertEquals(15.0, series.summary().latest(), 0.001);
         assertTrue(series.labels().containsKey("topic"));
         assertTrue(series.labels().containsKey("pod"));
         assertTrue(!series.labels().containsKey("partition"));
@@ -81,7 +81,7 @@ class AggregatedTimeSeriesTest {
         assertEquals(1, result.size());
         AggregatedTimeSeries series = result.getFirst();
         assertEquals(3, series.sourceCount());
-        assertEquals(20.0, series.summary().avg(), 0.001);
+        assertEquals(20.0, series.summary().latest(), 0.001);
         assertTrue(series.labels().containsKey("pod"));
         assertTrue(!series.labels().containsKey("topic"));
         assertTrue(!series.labels().containsKey("partition"));
@@ -116,7 +116,7 @@ class AggregatedTimeSeriesTest {
         assertEquals(1, result.size());
         AggregatedTimeSeries series = result.getFirst();
         assertEquals(3, series.sourceCount());
-        assertEquals(20.0, series.summary().avg(), 0.001);
+        assertEquals(20.0, series.summary().latest(), 0.001);
         assertTrue(!series.labels().containsKey("pod"));
         assertTrue(!series.labels().containsKey("topic"));
         assertTrue(!series.labels().containsKey("partition"));
@@ -149,7 +149,7 @@ class AggregatedTimeSeriesTest {
 
         assertEquals(1, result.size());
         assertEquals(0L, result.getFirst().dataPoints().getFirst().getFirst());
-        assertEquals(10.0, result.getFirst().summary().avg(), 0.001);
+        assertEquals(10.0, result.getFirst().summary().latest(), 0.001);
     }
 
     @Test
@@ -184,8 +184,8 @@ class AggregatedTimeSeriesTest {
 
         assertNotNull(result.getFirst().summary());
         assertEquals(150.0, result.getFirst().summary().latest(), 0.001);
-        assertEquals(150.0, result.getFirst().summary().min(), 0.001);
-        assertEquals(150.0, result.getFirst().summary().max(), 0.001);
+        // single aggregated data point: min/max/avg are null
+        assertEquals(1, result.getFirst().summary().originalDataPointCount());
     }
 
     @Test

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregationLevelTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/AggregationLevelTest.java
@@ -18,14 +18,14 @@ class AggregationLevelTest {
     }
 
     @Test
-    void fromStringNullDefaultsToBroker() {
-        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString(null));
+    void fromStringNullDefaultsToCluster() {
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.fromString(null));
     }
 
     @Test
-    void fromStringBlankDefaultsToBroker() {
-        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString(""));
-        assertEquals(AggregationLevel.BROKER, AggregationLevel.fromString("   "));
+    void fromStringBlankDefaultsToCluster() {
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.fromString(""));
+        assertEquals(AggregationLevel.CLUSTER, AggregationLevel.fromString("   "));
     }
 
     @Test

--- a/common/src/test/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummaryTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/dto/metrics/TimeSeriesSummaryTest.java
@@ -30,16 +30,16 @@ class TimeSeriesSummaryTest {
     }
 
     @Test
-    void singleDataPointSummary() {
+    void singleDataPointSummaryHasOnlyLatest() {
         List<List<Object>> dataPoints = List.of(List.of(100L, 42.0));
 
         TimeSeriesSummary summary = TimeSeriesSummary.of(dataPoints);
 
-        assertEquals(42.0, summary.min());
-        assertEquals(42.0, summary.max());
-        assertEquals(42.0, summary.avg());
+        assertNull(summary.min());
+        assertNull(summary.max());
+        assertNull(summary.avg());
         assertEquals(42.0, summary.latest());
-        assertEquals(0.0, summary.delta());
+        assertNull(summary.delta());
         assertEquals(1, summary.originalDataPointCount());
     }
 

--- a/common/src/test/java/io/streamshub/mcp/common/util/metrics/CommonLabelExtractorTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/util/metrics/CommonLabelExtractorTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.common.util.metrics;
+
+import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CommonLabelExtractor}.
+ */
+class CommonLabelExtractorTest {
+
+    CommonLabelExtractorTest() {
+    }
+
+    @Test
+    void extractFromNullReturnsEmpty() {
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(null);
+        assertTrue(result.commonLabels().isEmpty());
+        assertNotNull(result.strippedSeries());
+        assertTrue(result.strippedSeries().isEmpty());
+    }
+
+    @Test
+    void extractFromEmptyListReturnsEmpty() {
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of());
+        assertTrue(result.commonLabels().isEmpty());
+        assertTrue(result.strippedSeries().isEmpty());
+    }
+
+    @Test
+    void extractFromSingleSeriesMovesAllLabelsToCommon() {
+        AggregatedTimeSeries ts = new AggregatedTimeSeries(
+            "metric_a", Map.of("namespace", "kafka", "pod", "pod-0"),
+            List.of(), null, 1, null);
+
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of(ts));
+
+        assertEquals(Map.of("namespace", "kafka", "pod", "pod-0"), result.commonLabels());
+        assertEquals(1, result.strippedSeries().size());
+        assertTrue(result.strippedSeries().getFirst().labels().isEmpty());
+    }
+
+    @Test
+    void extractFactorsOutSharedLabels() {
+        AggregatedTimeSeries ts1 = new AggregatedTimeSeries(
+            "metric_a", Map.of("namespace", "kafka", "pod", "pod-0"),
+            List.of(), null, 1, null);
+        AggregatedTimeSeries ts2 = new AggregatedTimeSeries(
+            "metric_a", Map.of("namespace", "kafka", "pod", "pod-1"),
+            List.of(), null, 1, null);
+
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of(ts1, ts2));
+
+        assertEquals(Map.of("namespace", "kafka"), result.commonLabels());
+        assertEquals(2, result.strippedSeries().size());
+        assertEquals(Map.of("pod", "pod-0"), result.strippedSeries().get(0).labels());
+        assertEquals(Map.of("pod", "pod-1"), result.strippedSeries().get(1).labels());
+    }
+
+    @Test
+    void extractNoCommonLabelsReturnsOriginal() {
+        AggregatedTimeSeries ts1 = new AggregatedTimeSeries(
+            "metric_a", Map.of("pod", "pod-0"),
+            List.of(), null, 1, null);
+        AggregatedTimeSeries ts2 = new AggregatedTimeSeries(
+            "metric_a", Map.of("pod", "pod-1"),
+            List.of(), null, 1, null);
+
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of(ts1, ts2));
+
+        assertTrue(result.commonLabels().isEmpty());
+        assertEquals(2, result.strippedSeries().size());
+        assertEquals(Map.of("pod", "pod-0"), result.strippedSeries().get(0).labels());
+        assertEquals(Map.of("pod", "pod-1"), result.strippedSeries().get(1).labels());
+    }
+
+    @Test
+    void extractAllLabelsCommonAcrossMultipleSeries() {
+        AggregatedTimeSeries ts1 = new AggregatedTimeSeries(
+            "metric_a", Map.of("namespace", "kafka", "cluster", "my-cluster"),
+            List.of(), null, 1, null);
+        AggregatedTimeSeries ts2 = new AggregatedTimeSeries(
+            "metric_b", Map.of("namespace", "kafka", "cluster", "my-cluster"),
+            List.of(), null, 1, null);
+
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of(ts1, ts2));
+
+        assertEquals(Map.of("namespace", "kafka", "cluster", "my-cluster"), result.commonLabels());
+        assertEquals(2, result.strippedSeries().size());
+        assertTrue(result.strippedSeries().get(0).labels().isEmpty());
+        assertTrue(result.strippedSeries().get(1).labels().isEmpty());
+    }
+
+    @Test
+    void extractHandlesSeriesWithNullLabels() {
+        AggregatedTimeSeries ts1 = new AggregatedTimeSeries(
+            "metric_a", Map.of("namespace", "kafka"),
+            List.of(), null, 1, null);
+        AggregatedTimeSeries ts2 = new AggregatedTimeSeries(
+            "metric_b", null,
+            List.of(), null, 1, null);
+
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of(ts1, ts2));
+
+        assertTrue(result.commonLabels().isEmpty());
+    }
+
+    @Test
+    void extractPreservesNonLabelFields() {
+        List<List<Object>> dataPoints = List.of(List.of(1000L, 42.0));
+        AggregatedTimeSeries ts = new AggregatedTimeSeries(
+            "metric_a", Map.of("namespace", "kafka"),
+            dataPoints, null, 3, Boolean.TRUE);
+
+        CommonLabelExtractor.Result result = CommonLabelExtractor.extract(List.of(ts));
+
+        AggregatedTimeSeries stripped = result.strippedSeries().getFirst();
+        assertEquals("metric_a", stripped.name());
+        assertEquals(dataPoints, stripped.dataPoints());
+        assertEquals(3, stripped.sourceCount());
+        assertEquals(Boolean.TRUE, stripped.compressed());
+    }
+}

--- a/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProvider.java
+++ b/metrics-prometheus/src/main/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProvider.java
@@ -41,6 +41,10 @@ public class PrometheusMetricsProvider implements MetricsProvider {
         // package-private no-arg constructor for CDI
     }
 
+    private static final String TOTAL_SUFFIX = "_total";
+    private static final String RATE_SUFFIX = "_rate_per_second";
+    private static final String DEFAULT_RATE_WINDOW = "5m";
+
     @Override
     public List<MetricSample> queryMetrics(final MetricsQueryParams params) {
         if (prometheusClientInstance.isUnsatisfied()) {
@@ -49,21 +53,74 @@ public class PrometheusMetricsProvider implements MetricsProvider {
         }
 
         PrometheusClient client = prometheusClientInstance.get();
-        String promql = buildPromQL(params.metricNames(), params.labelMatchers());
 
-        LOG.debugf("Executing PromQL query: %s", promql);
+        List<String> counterMetrics = new ArrayList<>();
+        List<String> gaugeMetrics = new ArrayList<>();
+        partitionMetrics(params.metricNames(), counterMetrics, gaugeMetrics);
 
-        PrometheusResponse response;
+        List<MetricSample> allSamples = new ArrayList<>();
+
+        if (!gaugeMetrics.isEmpty()) {
+            String promql = buildPromQL(gaugeMetrics, params.labelMatchers());
+            LOG.debugf("Executing PromQL query (gauges): %s", promql);
+            PrometheusResponse response = executeQuery(client, promql, params);
+            allSamples.addAll(convertResponse(response, params.maxSamples()));
+        }
+
+        if (!counterMetrics.isEmpty()) {
+            allSamples.addAll(queryCountersWithRate(client, counterMetrics, params));
+        }
+
+        return allSamples;
+    }
+
+    private List<MetricSample> queryCountersWithRate(final PrometheusClient client,
+                                                      final List<String> counterMetrics,
+                                                      final MetricsQueryParams params) {
+        String rateWindow = params.isRangeQuery()
+            ? params.stepSeconds() + "s"
+            : DEFAULT_RATE_WINDOW;
+        String rateFunc = params.isRangeQuery() ? "rate" : "irate";
+
+        List<MetricSample> result = new ArrayList<>();
+        for (String metric : counterMetrics) {
+            String inner = buildPromQL(List.of(metric), params.labelMatchers());
+            String promql = rateFunc + "(" + inner + "[" + rateWindow + "])";
+            LOG.debugf("Executing PromQL query (counter rate): %s", promql);
+
+            PrometheusResponse response = executeQuery(client, promql, params);
+            String renamedMetric = metric.substring(0, metric.length() - TOTAL_SUFFIX.length())
+                + RATE_SUFFIX;
+            result.addAll(convertResponseWithName(response, params.maxSamples(), renamedMetric));
+        }
+        return result;
+    }
+
+    private PrometheusResponse executeQuery(final PrometheusClient client,
+                                             final String promql,
+                                             final MetricsQueryParams params) {
         if (params.isRangeQuery()) {
             String start = String.valueOf(params.startTime().getEpochSecond());
             String end = String.valueOf(params.endTime().getEpochSecond());
             String step = params.stepSeconds() + "s";
-            response = client.rangeQuery(promql, start, end, step);
-        } else {
-            response = client.instantQuery(promql, null);
+            return client.rangeQuery(promql, start, end, step);
         }
+        return client.instantQuery(promql, null);
+    }
 
-        return convertResponse(response, params.maxSamples());
+    static void partitionMetrics(final List<String> metricNames,
+                                  final List<String> counters,
+                                  final List<String> gauges) {
+        if (metricNames == null) {
+            return;
+        }
+        for (String name : metricNames) {
+            if (name.endsWith(TOTAL_SUFFIX)) {
+                counters.add(name);
+            } else {
+                gauges.add(name);
+            }
+        }
     }
 
     /**
@@ -130,6 +187,44 @@ public class PrometheusMetricsProvider implements MetricsProvider {
             query.append(PromQLSanitizer.sanitizeLabelValue(entry.getValue()));
             query.append("\"");
         }
+    }
+
+    private List<MetricSample> convertResponseWithName(final PrometheusResponse response,
+                                                       final int maxSamples,
+                                                       final String metricName) {
+        if (response == null || response.data() == null || response.data().result() == null) {
+            return List.of();
+        }
+
+        if (!"success".equals(response.status())) {
+            LOG.warnf("Prometheus query returned non-success status: %s", response.status());
+            return List.of();
+        }
+
+        List<MetricSample> samples = new ArrayList<>();
+        boolean limitEnabled = maxSamples > 0;
+
+        for (PrometheusResponse.PrometheusResult result : response.data().result()) {
+            if (limitEnabled && samples.size() >= maxSamples) {
+                LOG.warnf("Prometheus query exceeded max-samples limit (%d), truncating results", maxSamples);
+                break;
+            }
+
+            Map<String, String> labels = result.metric();
+
+            if (result.values() != null) {
+                for (List<Object> valueEntry : result.values()) {
+                    if (limitEnabled && samples.size() >= maxSamples) {
+                        break;
+                    }
+                    addSample(samples, metricName, labels, valueEntry);
+                }
+            } else if (result.value() != null) {
+                addSample(samples, metricName, labels, result.value());
+            }
+        }
+
+        return samples;
     }
 
     private List<MetricSample> convertResponse(final PrometheusResponse response,

--- a/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProviderTest.java
+++ b/metrics-prometheus/src/test/java/io/streamshub/mcp/metrics/prometheus/service/PrometheusMetricsProviderTest.java
@@ -7,10 +7,12 @@ package io.streamshub.mcp.metrics.prometheus.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link PrometheusMetricsProvider} PromQL query building.
@@ -94,5 +96,53 @@ class PrometheusMetricsProviderTest {
         assertEquals(
             "metric_a{namespace=\"kafka\",pod=\"broker-0\"}",
             query);
+    }
+
+    @Test
+    void partitionMetricsSeparatesCountersAndGauges() {
+        List<String> counters = new ArrayList<>();
+        List<String> gauges = new ArrayList<>();
+
+        PrometheusMetricsProvider.partitionMetrics(
+            List.of("bytesin_total", "underreplicated", "messagesin_total", "jvm_heap"),
+            counters, gauges);
+
+        assertEquals(List.of("bytesin_total", "messagesin_total"), counters);
+        assertEquals(List.of("underreplicated", "jvm_heap"), gauges);
+    }
+
+    @Test
+    void partitionMetricsNullInput() {
+        List<String> counters = new ArrayList<>();
+        List<String> gauges = new ArrayList<>();
+
+        PrometheusMetricsProvider.partitionMetrics(null, counters, gauges);
+
+        assertTrue(counters.isEmpty());
+        assertTrue(gauges.isEmpty());
+    }
+
+    @Test
+    void partitionMetricsAllCounters() {
+        List<String> counters = new ArrayList<>();
+        List<String> gauges = new ArrayList<>();
+
+        PrometheusMetricsProvider.partitionMetrics(
+            List.of("a_total", "b_total"), counters, gauges);
+
+        assertEquals(List.of("a_total", "b_total"), counters);
+        assertTrue(gauges.isEmpty());
+    }
+
+    @Test
+    void partitionMetricsAllGauges() {
+        List<String> counters = new ArrayList<>();
+        List<String> gauges = new ArrayList<>();
+
+        PrometheusMetricsProvider.partitionMetrics(
+            List.of("gauge_a", "gauge_b"), counters, gauges);
+
+        assertTrue(counters.isEmpty());
+        assertEquals(List.of("gauge_a", "gauge_b"), gauges);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/config/StrimziToolsPrompts.java
@@ -289,8 +289,8 @@ public final class StrimziToolsPrompts {
     public static final String AGGREGATION_DESC =
         "Aggregation level: 'partition' (full per-pod/topic/partition detail),"
             + " 'topic' (per-pod/topic, avg across partitions),"
-            + " 'broker' (per-pod, avg across topics+partitions, default),"
-            + " or 'cluster' (single avg across all dimensions)."
+            + " 'broker' (per-pod, avg across topics+partitions),"
+            + " or 'cluster' (single avg across all dimensions, default)."
             + " Aggregation works on topic/partition dimensions."
             + " The server automatically adjusts to the finest level supported by the"
             + " requested category (e.g., 'partition' on a broker-only category becomes 'broker')."

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaBridgeMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaBridgeMetricsResponse.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
 import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.util.metrics.CommonLabelExtractor;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 /**
  * Response containing metrics data from a KafkaBridge.
  * Metrics are always grouped and aggregated into time series based on the
@@ -25,6 +27,7 @@ import java.util.Locale;
  * @param metricCount    the number of distinct metric names in the response
  * @param sampleCount    the total number of metric samples before aggregation
  * @param aggregation    the aggregation level used
+ * @param commonLabels   labels shared by all time series (factored out to reduce response size)
  * @param timeSeries     the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp      the time this result was generated
@@ -39,6 +42,7 @@ public record KafkaBridgeMetricsResponse(
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
     @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("common_labels") Map<String, String> commonLabels,
     @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
@@ -73,9 +77,12 @@ public record KafkaBridgeMetricsResponse(
         List<AggregatedTimeSeries> series = samples.isEmpty()
             ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
+        CommonLabelExtractor.Result extracted = CommonLabelExtractor.extract(series);
+        Map<String, String> common = extracted.commonLabels().isEmpty() ? null : extracted.commonLabels();
+
         return new KafkaBridgeMetricsResponse(bridgeName, namespace, provider, categories,
             metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
-            series, interpretation, Instant.now(), msg);
+            common, extracted.strippedSeries(), interpretation, Instant.now(), msg);
     }
 
     /**
@@ -89,6 +96,6 @@ public record KafkaBridgeMetricsResponse(
     public static KafkaBridgeMetricsResponse empty(final String bridgeName, final String namespace,
                                                      final String message) {
         return new KafkaBridgeMetricsResponse(bridgeName, namespace, null, List.of(),
-            0, 0, null, List.of(), null, Instant.now(), message);
+            0, 0, null, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaConnectMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaConnectMetricsResponse.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
 import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.util.metrics.CommonLabelExtractor;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 /**
  * Response containing metrics data from a KafkaConnect cluster.
  * Metrics are always grouped and aggregated into time series based on the
@@ -25,6 +27,7 @@ import java.util.Locale;
  * @param metricCount    the number of distinct metric names in the response
  * @param sampleCount    the total number of metric samples before aggregation
  * @param aggregation    the aggregation level used
+ * @param commonLabels   labels shared by all time series (factored out to reduce response size)
  * @param timeSeries     the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp      the time this result was generated
@@ -39,6 +42,7 @@ public record KafkaConnectMetricsResponse(
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
     @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("common_labels") Map<String, String> commonLabels,
     @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
@@ -73,9 +77,12 @@ public record KafkaConnectMetricsResponse(
         List<AggregatedTimeSeries> series = samples.isEmpty()
             ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
+        CommonLabelExtractor.Result extracted = CommonLabelExtractor.extract(series);
+        Map<String, String> common = extracted.commonLabels().isEmpty() ? null : extracted.commonLabels();
+
         return new KafkaConnectMetricsResponse(connectName, namespace, provider, categories,
             metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
-            series, interpretation, Instant.now(), msg);
+            common, extracted.strippedSeries(), interpretation, Instant.now(), msg);
     }
 
     /**
@@ -89,6 +96,6 @@ public record KafkaConnectMetricsResponse(
     public static KafkaConnectMetricsResponse empty(final String connectName, final String namespace,
                                                      final String message) {
         return new KafkaConnectMetricsResponse(connectName, namespace, null, List.of(),
-            0, 0, null, List.of(), null, Instant.now(), message);
+            0, 0, null, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaExporterMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaExporterMetricsResponse.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
 import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.util.metrics.CommonLabelExtractor;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 /**
  * Response containing metrics data from a Kafka Exporter.
  * Metrics are always grouped and aggregated into time series based on the
@@ -25,6 +27,7 @@ import java.util.Locale;
  * @param metricCount    the number of distinct metric names in the response
  * @param sampleCount    the total number of metric samples before aggregation
  * @param aggregation    the aggregation level used
+ * @param commonLabels   labels shared by all time series (factored out to reduce response size)
  * @param timeSeries     the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp      the time this result was generated
@@ -39,6 +42,7 @@ public record KafkaExporterMetricsResponse(
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
     @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("common_labels") Map<String, String> commonLabels,
     @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
@@ -73,9 +77,12 @@ public record KafkaExporterMetricsResponse(
         List<AggregatedTimeSeries> series = samples.isEmpty()
             ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
+        CommonLabelExtractor.Result extracted = CommonLabelExtractor.extract(series);
+        Map<String, String> common = extracted.commonLabels().isEmpty() ? null : extracted.commonLabels();
+
         return new KafkaExporterMetricsResponse(clusterName, namespace, provider, categories,
             metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
-            series, interpretation, Instant.now(), msg);
+            common, extracted.strippedSeries(), interpretation, Instant.now(), msg);
     }
 
     /**
@@ -89,6 +96,6 @@ public record KafkaExporterMetricsResponse(
     public static KafkaExporterMetricsResponse empty(final String clusterName, final String namespace,
                                                       final String message) {
         return new KafkaExporterMetricsResponse(clusterName, namespace, null, List.of(),
-            0, 0, null, List.of(), null, Instant.now(), message);
+            0, 0, null, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/KafkaMetricsResponse.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
 import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.util.metrics.CommonLabelExtractor;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 /**
  * Response containing metrics data from a Kafka cluster.
  * Metrics are always grouped and aggregated into time series based on the
@@ -25,6 +27,7 @@ import java.util.Locale;
  * @param metricCount    the number of distinct metric names in the response
  * @param sampleCount    the total number of metric samples before aggregation
  * @param aggregation    the aggregation level used
+ * @param commonLabels   labels shared by all time series (factored out to reduce response size)
  * @param timeSeries     the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp      the time this result was generated
@@ -39,6 +42,7 @@ public record KafkaMetricsResponse(
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
     @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("common_labels") Map<String, String> commonLabels,
     @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
@@ -73,9 +77,12 @@ public record KafkaMetricsResponse(
         List<AggregatedTimeSeries> series = samples.isEmpty()
             ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
+        CommonLabelExtractor.Result extracted = CommonLabelExtractor.extract(series);
+        Map<String, String> common = extracted.commonLabels().isEmpty() ? null : extracted.commonLabels();
+
         return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
             metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
-            series, interpretation, Instant.now(), msg);
+            common, extracted.strippedSeries(), interpretation, Instant.now(), msg);
     }
 
     /**
@@ -105,8 +112,12 @@ public record KafkaMetricsResponse(
         String msg = String.format("Retrieved %d samples across %d metrics from cluster '%s'",
             sampleCount, metricCount, clusterName);
 
+        CommonLabelExtractor.Result extracted = CommonLabelExtractor.extract(series);
+        Map<String, String> common = extracted.commonLabels().isEmpty() ? null : extracted.commonLabels();
+
         return new KafkaMetricsResponse(clusterName, namespace, provider, categories,
-            metricCount, sampleCount, null, series, interpretation, Instant.now(), msg);
+            metricCount, sampleCount, null, common, extracted.strippedSeries(),
+            interpretation, Instant.now(), msg);
     }
 
     /**
@@ -120,6 +131,6 @@ public record KafkaMetricsResponse(
     public static KafkaMetricsResponse empty(final String clusterName, final String namespace,
                                               final String message) {
         return new KafkaMetricsResponse(clusterName, namespace, null, List.of(),
-            0, 0, null, List.of(), null, Instant.now(), message);
+            0, 0, null, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/metrics/StrimziOperatorMetricsResponse.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamshub.mcp.common.dto.metrics.AggregatedTimeSeries;
 import io.streamshub.mcp.common.dto.metrics.AggregationLevel;
 import io.streamshub.mcp.common.dto.metrics.MetricSample;
+import io.streamshub.mcp.common.util.metrics.CommonLabelExtractor;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 /**
  * Response containing metrics data from Strimzi operators.
  * Metrics are always grouped and aggregated into time series based on the
@@ -26,6 +28,7 @@ import java.util.Locale;
  * @param metricCount   the number of distinct metric names in the response
  * @param sampleCount   the total number of metric samples before aggregation
  * @param aggregation   the aggregation level used
+ * @param commonLabels  labels shared by all time series (factored out to reduce response size)
  * @param timeSeries    the aggregated time series
  * @param interpretation brief guide for interpreting the returned metrics
  * @param timestamp     the time this result was generated
@@ -41,6 +44,7 @@ public record StrimziOperatorMetricsResponse(
     @JsonProperty("metric_count") long metricCount,
     @JsonProperty("sample_count") int sampleCount,
     @JsonProperty("aggregation") String aggregation,
+    @JsonProperty("common_labels") Map<String, String> commonLabels,
     @JsonProperty("time_series") List<AggregatedTimeSeries> timeSeries,
     @JsonProperty("interpretation") String interpretation,
     @JsonProperty("timestamp") Instant timestamp,
@@ -80,9 +84,12 @@ public record StrimziOperatorMetricsResponse(
         List<AggregatedTimeSeries> series = samples.isEmpty()
             ? List.of() : AggregatedTimeSeries.fromSamples(samples, level);
 
+        CommonLabelExtractor.Result extracted = CommonLabelExtractor.extract(series);
+        Map<String, String> common = extracted.commonLabels().isEmpty() ? null : extracted.commonLabels();
+
         return new StrimziOperatorMetricsResponse(operatorName, clusterName, namespace, provider, categories,
             metricCount, samples.size(), level.name().toLowerCase(Locale.ROOT),
-            series, interpretation, Instant.now(), msg);
+            common, extracted.strippedSeries(), interpretation, Instant.now(), msg);
     }
 
     /**
@@ -96,6 +103,6 @@ public record StrimziOperatorMetricsResponse(
     public static StrimziOperatorMetricsResponse empty(final String operatorName, final String namespace,
                                                         final String message) {
         return new StrimziOperatorMetricsResponse(operatorName, null, namespace, null, List.of(),
-            0, 0, null, List.of(), null, Instant.now(), message);
+            0, 0, null, null, List.of(), null, Instant.now(), message);
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsService.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 /**
  * Service for retrieving Kafka cluster metrics via pluggable providers.
  */
@@ -38,6 +39,7 @@ public class KafkaMetricsService {
 
     private static final Logger LOG = Logger.getLogger(KafkaMetricsService.class);
     private static final String DEFAULT_CATEGORY = KafkaMetricCategories.REPLICATION;
+    private static final Set<String> DEFAULT_QUANTILES = Set.of("0.50", "0.99");
 
     @Inject
     KubernetesResourceService k8sService;
@@ -145,6 +147,7 @@ public class KafkaMetricsService {
         List<MetricSample> samples = metricsQueryService.queryMetrics(
             podTargets, labelMatchers, resolvedMetrics, rangeMinutes, startTime, endTime, stepSeconds);
 
+        samples = filterByBrokerPods(samples, pods);
         samples = filterByRequestTypes(samples, requestTypes);
 
         // Build interpretation from effective categories
@@ -152,6 +155,13 @@ public class KafkaMetricsService {
         if (effectiveCategories.isEmpty() && (metricNames == null || metricNames.isBlank())) {
             effectiveCategories.add(DEFAULT_CATEGORY);
         }
+
+        // Apply default quantile filter and zero-value stripping for performance category
+        if (effectiveCategories.contains(KafkaMetricCategories.PERFORMANCE)) {
+            samples = filterByQuantiles(samples, DEFAULT_QUANTILES);
+            samples = filterZeroValues(samples);
+        }
+
         String interpretation = KafkaMetricCategories.interpretation(effectiveCategories);
 
         AggregationLevel level = AggregationLevel.fromString(aggregation);
@@ -161,6 +171,44 @@ public class KafkaMetricsService {
         }
         return KafkaMetricsResponse.of(name, resolvedNs,
             metricsQueryService.providerName(), categories, samples, interpretation, level);
+    }
+
+    private static List<MetricSample> filterByBrokerPods(final List<MetricSample> samples,
+                                                          final List<Pod> brokerPods) {
+        Set<String> brokerPodNames = brokerPods.stream()
+            .map(p -> p.getMetadata().getName())
+            .collect(Collectors.toSet());
+        return samples.stream()
+            .filter(s -> {
+                if (s.labels() == null) {
+                    return true;
+                }
+                // Filter by Prometheus metric label (reliable for both providers)
+                String brokerRole = s.labels().get("strimzi_io_broker_role");
+                if (brokerRole != null) {
+                    return "true".equals(brokerRole);
+                }
+                // Fallback: filter by pod name
+                String podLabel = s.labels().get("pod");
+                return podLabel == null || brokerPodNames.contains(podLabel);
+            })
+            .toList();
+    }
+
+    private static List<MetricSample> filterByQuantiles(final List<MetricSample> samples,
+                                                         final Set<String> quantiles) {
+        return samples.stream()
+            .filter(s -> {
+                String quantile = s.labels() != null ? s.labels().get("quantile") : null;
+                return quantile == null || quantiles.contains(quantile);
+            })
+            .toList();
+    }
+
+    private static List<MetricSample> filterZeroValues(final List<MetricSample> samples) {
+        return samples.stream()
+            .filter(s -> s.value() != 0.0)
+            .toList();
     }
 
     private static List<MetricSample> filterByRequestTypes(final List<MetricSample> samples,

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/metrics/KafkaMetricsServiceTest.java
@@ -281,8 +281,8 @@ class KafkaMetricsServiceTest {
                 Map.of("request", "Fetch", "quantile", "0.99"), 3.0),
             MetricSample.of("kafka_network_requestmetrics_totaltimems",
                 Map.of("request", "Metadata", "quantile", "0.99"), 1.0),
-            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
-                Map.of("namespace", "kafka"), 0.0));
+            MetricSample.of("kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent",
+                Map.of(), 0.8));
         when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
             .thenReturn(samples);
 
@@ -290,6 +290,7 @@ class KafkaMetricsServiceTest {
             "kafka", "my-cluster", "performance", null, null, null, null, null, null, "Produce,Fetch");
 
         assertNotNull(response);
+        // Produce + Fetch (matched by requestTypes) + idle gauge (no request label, passes through) = 3
         assertEquals(3, response.sampleCount());
     }
 
@@ -314,6 +315,200 @@ class KafkaMetricsServiceTest {
 
         KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
             "kafka", "my-cluster", "performance", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void controllerPodSamplesFilteredByBrokerRoleLabel() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod brokerPod = createPod("my-cluster-broker-0", "kafka");
+        Pod controllerPod = createPod("my-cluster-controller-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(brokerPod, controllerPod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("pod", "my-cluster-broker-0", "strimzi_io_broker_role", "true"), 0.0),
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("pod", "my-cluster-controller-0", "strimzi_io_broker_role", "false"), 0.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.sampleCount());
+    }
+
+    @Test
+    void controllerPodSamplesFilteredByPodNameFallback() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod brokerPod = createPod("my-cluster-broker-0", "kafka");
+        Pod controllerPod = createPod("my-cluster-controller-0", "kafka", "controller");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(brokerPod, controllerPod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("pod", "my-cluster-broker-0", "namespace", "kafka"), 0.0),
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("pod", "my-cluster-controller-0", "namespace", "kafka"), 0.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(1, response.sampleCount());
+    }
+
+    @Test
+    void samplesWithoutRoleOrPodLabelArePreserved() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod brokerPod = createPod("my-cluster-broker-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(brokerPod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("namespace", "kafka"), 0.0),
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("pod", "my-cluster-broker-0", "namespace", "kafka"), 0.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void performanceCategoryFiltersToDefaultQuantiles() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce", "quantile", "0.50"), 5.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce", "quantile", "0.75"), 7.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce", "quantile", "0.95"), 10.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce", "quantile", "0.99"), 15.0),
+            MetricSample.of("kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent",
+                Map.of(), 0.8));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "performance", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        // p50 + p99 + the gauge without quantile label = 3 samples
+        assertEquals(3, response.sampleCount());
+    }
+
+    @Test
+    void nonPerformanceCategoryDoesNotFilterQuantiles() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("jvm_gc_collection_seconds_count",
+                Map.of("quantile", "0.75"), 100.0),
+            MetricSample.of("jvm_gc_collection_seconds_count",
+                Map.of("quantile", "0.95"), 200.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "resources", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void performanceCategoryFiltersZeroValues() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "Produce", "quantile", "0.99"), 15.0),
+            MetricSample.of("kafka_network_requestmetrics_totaltimems",
+                Map.of("request", "AddRaftVoter", "quantile", "0.99"), 0.0),
+            MetricSample.of("kafka_server_kafkarequesthandlerpool_brokerrequesthandleravgidle_percent",
+                Map.of(), 0.8));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "performance", null, null, null, null, null, null, null);
+
+        assertNotNull(response);
+        // Produce p99 + idle gauge = 2 (AddRaftVoter zero filtered out)
+        assertEquals(2, response.sampleCount());
+    }
+
+    @Test
+    void replicationCategoryPreservesZeroValues() {
+        Kafka kafka = createKafka("my-cluster", "kafka");
+        Pod pod = createPod("my-cluster-kafka-0", "kafka");
+
+        when(kafkaService.findKafkaCluster("kafka", "my-cluster"))
+            .thenReturn(kafka);
+        when(k8sService.queryResourcesByLabel(eq(Pod.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("my-cluster")))
+            .thenReturn(List.of(pod));
+
+        List<MetricSample> samples = List.of(
+            MetricSample.of("kafka_server_replicamanager_underreplicatedpartitions",
+                Map.of("pod", "my-cluster-kafka-0"), 0.0),
+            MetricSample.of("kafka_server_replicamanager_leadercount",
+                Map.of("pod", "my-cluster-kafka-0"), 42.0));
+        when(metricsQueryService.queryMetrics(anyList(), anyMap(), anyList(), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(samples);
+
+        KafkaMetricsResponse response = kafkaMetricsService.getKafkaMetrics(
+            "kafka", "my-cluster", "replication", null, null, null, null, null, null, null);
 
         assertNotNull(response);
         assertEquals(2, response.sampleCount());


### PR DESCRIPTION
## Description

Improves aggregation for collected metrics based on strimzi related labels and filters out data that are not relevant. For performance metrics of Kafka it collect only p50 and p99 to significantly reduce payload. Default aggregation level is `cluster` but user can change it. 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
