### PR TITLE
Fix wrong assumption of operator ns

### DIFF
--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AssessUpgradeReadinessPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/AssessUpgradeReadinessPrompt.java
@@ -97,8 +97,9 @@ public class AssessUpgradeReadinessPrompt {
             Record the current Kafka version and Strimzi operator version.
 
             ## Step 2: Operator health [GO/NO-GO]
-            Use `list_strimzi_operators(%s)` and `get_strimzi_operator` to check \
-            operator status.
+            Use `list_strimzi_operators` **without passing a namespace** and `get_strimzi_operator` \
+            to check operator status. The operator is typically deployed in a different namespace \
+            than the Kafka cluster.
 
             **GO conditions**:
             - Operator deployment is available with all replicas ready
@@ -108,7 +109,7 @@ public class AssessUpgradeReadinessPrompt {
             - Operator not available or degraded
             - Operator pod restarting or in error state
 
-            Use `get_strimzi_operator_logs(%s)` to check for recent errors.
+            Use `get_strimzi_operator_logs` **without passing a namespace** to check for recent errors.
             Any recurring reconciliation errors indicate instability.
 
             ## Step 3: Node pool and pod health [GO/NO-GO]
@@ -252,8 +253,6 @@ public class AssessUpgradeReadinessPrompt {
                 clusterName, nsClause, versionClause,
                 StrimziToolsPrompts.ERROR_HANDLING_INSTRUCTION,
                 clusterName, nsArg,
-                nsArg.isEmpty() ? "" : "namespace='" + namespace + "'",
-                nsArg,
                 clusterName, nsArg,
                 clusterName, nsArg,
                 clusterName, nsArg,

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/TroubleshootTopicPrompt.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/prompt/TroubleshootTopicPrompt.java
@@ -132,7 +132,8 @@ public class TroubleshootTopicPrompt {
             validate replication factor) and continue.
 
             ## Step 4: Check Topic Operator reconciliation
-            Use `get_strimzi_operator_logs(%s)` and look specifically for \
+            Use `get_strimzi_operator_logs` **without passing a namespace** (the operator \
+            is typically in a different namespace) and look specifically for \
             Topic Operator log entries mentioning `%s`.
             Look for:
             - Reconciliation errors or exceptions for this topic
@@ -180,7 +181,6 @@ public class TroubleshootTopicPrompt {
                 topicName, clusterArg, nsArg,
                 clusterLead, nsArg,
                 clusterLead, nsArg,
-                nsArg,
                 topicName,
                 clusterLead, nsArg);
     }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterDiagnosticService.java
@@ -190,9 +190,9 @@ public class KafkaClusterDiagnosticService {
         StrimziOperatorResponse operator = null;
         StrimziOperatorLogsResponse operatorLogs = null;
         if (areas.operatorLogs) {
-            operator = gatherOperatorStatus(resolvedNs, completed, failed, mcpLog);
+            operator = gatherOperatorStatus(null, completed, failed, mcpLog);
             operatorLogs = gatherOperatorLogs(
-                resolvedNs, sinceMinutes, completed, failed, mcpLog);
+                null, sinceMinutes, completed, failed, mcpLog);
             DiagnosticHelper.sendProgress(progress, ++stepIndex, totalSteps, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterOverviewService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterOverviewService.java
@@ -121,7 +121,7 @@ public class KafkaClusterOverviewService {
 
         return new KafkaClusterOverviewResponse(
             buildClusterSummary(cluster),
-            gatherOperator(resolvedNs),
+            gatherOperator(null),
             gatherNodePools(resolvedNs, name),
             countTopics(resolvedNs, name),
             countUsers(resolvedNs, name),

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/UpgradeReadinessDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/UpgradeReadinessDiagnosticService.java
@@ -160,7 +160,7 @@ public class UpgradeReadinessDiagnosticService {
         String resolvedNs = cluster.namespace();
 
         StrimziOperatorResponse operator = gatherOperatorStatus(
-            resolvedNs, completed, failed, mcpLog);
+            null, completed, failed, mcpLog);
         DiagnosticHelper.sendProgress(progress, ++stepIndex, maxSteps, DIAGNOSTIC_LABEL);
         DiagnosticHelper.checkCancellation(cancellation);
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkatopic/KafkaTopicDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkatopic/KafkaTopicDiagnosticService.java
@@ -167,7 +167,7 @@ public class KafkaTopicDiagnosticService {
         StrimziOperatorLogsResponse operatorLogs = null;
         if (areas.operatorLogs) {
             operatorLogs = gatherOperatorLogs(
-                resolvedNs, name, completed, failed, mcpLog);
+                null, name, completed, failed, mcpLog);
             DiagnosticHelper.sendProgress(progress, ++stepIndex, totalSteps, DIAGNOSTIC_LABEL);
             DiagnosticHelper.checkCancellation(cancellation);
         }


### PR DESCRIPTION
## Description

Some tools and prompt templates wrongly uses kafka cluster ns as a ns for strimzi cluster operator

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
