### PR TITLE
Fix OTEL to work in container image with mcp

### DIFF
--- a/dev/scripts/setup-jaeger.sh
+++ b/dev/scripts/setup-jaeger.sh
@@ -10,7 +10,7 @@
 #   ./setup-jaeger.sh help     - Show usage
 #
 # After deployment, configure the MCP server to export traces:
-#   QUARKUS_OTEL_ENABLED=true
+#   QUARKUS_OTEL_SDK_DISABLED=false
 #   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-collector.observability.svc.cluster.local:4317
 
 set -e
@@ -77,12 +77,12 @@ deploy() {
     echo "            jaeger-collector.$JAEGER_NS.svc.cluster.local:4318 (OTLP HTTP)"
     echo ""
     echo "MCP server configuration (in-cluster):"
-    echo "  QUARKUS_OTEL_ENABLED=true"
+    echo "  QUARKUS_OTEL_SDK_DISABLED=false"
     echo "  QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-collector.$JAEGER_NS.svc.cluster.local:4317"
     echo ""
     if [ -n "$collector_route_host" ]; then
         echo "MCP server configuration (local dev mode via Route):"
-        echo "  QUARKUS_OTEL_ENABLED=true"
+        echo "  QUARKUS_OTEL_SDK_DISABLED=false"
         echo "  QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf"
         echo "  QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT=https://$collector_route_host"
         echo "  QUARKUS_OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer \$(oc whoami -t)"

--- a/docs/strimzi-mcp/configuration.md
+++ b/docs/strimzi-mcp/configuration.md
@@ -269,7 +269,7 @@ When enabled, the server exports traces via OTLP to a collector (e.g., Jaeger, G
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `quarkus.otel.enabled` | `false` | Enable OpenTelemetry tracing |
+| `quarkus.otel.sdk.disabled` | `true` | Set to `false` to enable tracing. OTEL is included in the image but disabled at runtime by default. |
 | `quarkus.otel.exporter.otlp.endpoint` | `http://localhost:4317` | OTLP collector endpoint (gRPC) |
 | `quarkus.otel.exporter.otlp.protocol` | `grpc` | OTLP protocol: `grpc` (port 4317) or `http/protobuf` (port 4318) |
 | `quarkus.otel.exporter.otlp.headers` | - | Auth headers (e.g., `Authorization=Bearer <token>`) |
@@ -302,14 +302,14 @@ On OpenShift, it also creates Routes for the UI and OTLP collector.
 **In-cluster (gRPC):**
 
 ```bash
-QUARKUS_OTEL_ENABLED=true
+QUARKUS_OTEL_SDK_DISABLED=false
 QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-collector.observability.svc.cluster.local:4317
 ```
 
 **Local dev mode via OpenShift Route (HTTP):**
 
 ```bash
-QUARKUS_OTEL_ENABLED=true
+QUARKUS_OTEL_SDK_DISABLED=false
 QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT=https://<collector-route-host>
 QUARKUS_OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer $(oc whoami -t)
@@ -324,7 +324,7 @@ kind: ConfigMap
 metadata:
   name: strimzi-mcp-config
 data:
-  QUARKUS_OTEL_ENABLED: "true"
+  QUARKUS_OTEL_SDK_DISABLED: "false"
   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger-collector.observability.svc.cluster.local:4317"
 ```
 

--- a/strimzi-mcp/src/main/resources/application.properties
+++ b/strimzi-mcp/src/main/resources/application.properties
@@ -139,8 +139,11 @@ mcp.sampling.analysis-max-tokens=1500
 # =============================================================================
 # OpenTelemetry Configuration
 # =============================================================================
-# Disabled by default. Enable for production deployments with an OTLP collector.
-quarkus.otel.enabled=false
+# Build-time: include OTLP exporter in the image.
+quarkus.otel.enabled=true
+# Runtime: disabled by default so no connection errors when no collector is present.
+# To enable tracing, set QUARKUS_OTEL_SDK_DISABLED=false and configure the endpoint.
+quarkus.otel.sdk.disabled=true
 quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
 quarkus.otel.service.name=strimzi-mcp
 quarkus.otel.propagators=tracecontext,baggage


### PR DESCRIPTION
## Description

Fix enable/disable OTEL. Otel enable property is build time and has to be enabled in build phase, So we can disable otel by different runtime property.

## Type of change


* Bug fix (non-breaking change which fixes an issue)



