### PR TITLE
Add fleet overview tool to speedup kubernetes cluster quick overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,9 @@ io.streamshub.mcp.strimzi.
 │   └── metrics/       → MetricsTools
 ├── service/           → Business logic (KafkaService, KafkaTopicService, KafkaNodePoolService,
 │                        KafkaCertificateService, KafkaConfigService, KafkaConfigComparisonService,
-│                        KafkaRebalanceService, KafkaClusterOverviewService,
-│                        StrimziOperatorService, StrimziEventsService, DrainCleanerService,
-│                        CompletionService)
+│                        KafkaRebalanceService, KafkaClusterOverviewService, KafkaFleetOverviewService,
+│                        BootstrapMatcher, StrimziOperatorService, StrimziEventsService,
+│                        DrainCleanerService, CompletionService)
 │                        Diagnostic orchestrators: KafkaClusterDiagnosticService,
 │                        KafkaConnectivityDiagnosticService, KafkaMetricsDiagnosticService,
 │                        OperatorMetricsDiagnosticService

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - Unreleased
 
-## Added
+### Added
 
-## Changed
+- **Fleet overview tool** -- `get_kafka_fleet_overview` returns aggregated health across all Kafka clusters in a single call, including status distribution, total broker count, per-cluster summaries with cross-resource relationship counts (topics, users, active rebalances, connected KafkaConnect/Bridge/MirrorMaker2), and warnings for clusters that need attention
 
-## Fixed
+### Changed
+
+### Fixed
+
+- Replaced deprecated `Elicitation.isSupported()` with `isFormModeSupported()` across all diagnostic services
 
 ## [0.1.0] - 2026-06-02
 

--- a/docs/strimzi-mcp/tools/kafka-clusters.md
+++ b/docs/strimzi-mcp/tools/kafka-clusters.md
@@ -31,6 +31,7 @@ Get aggregated health overview across all Kafka clusters in a single call. Shows
 - **Status distribution** -- count of clusters by readiness (ready, not_ready, error, unknown)
 - **Clusters** -- per-cluster summary with name, namespace, readiness, Kafka version, broker counts, age, and relationship counts (topics, users, active rebalances, connected KafkaConnect/Bridge/MirrorMaker2 instances)
 - **Warnings** -- clusters with health issues: NotReady, Error, or broker replica mismatch (capped at 20)
+- **Resource errors** -- resource types that failed to load (fleet-level and per-cluster), distinguishing "0 found" from "failed to read"
 
 **Example**:
 ```

--- a/docs/strimzi-mcp/tools/kafka-clusters.md
+++ b/docs/strimzi-mcp/tools/kafka-clusters.md
@@ -19,6 +19,24 @@ List Kafka clusters with status and configuration.
 List all Kafka clusters
 ```
 
+## get_kafka_fleet_overview
+
+Get aggregated health overview across all Kafka clusters in a single call. Shows status distribution, total broker count, per-cluster summaries, and warnings for clusters that need attention. Designed for fleet-level triage without inspecting each cluster individually.
+
+**Parameters**:
+- `namespace` (optional) -- Limit to a specific namespace
+
+**Returns**: Aggregated fleet summary including:
+- **Total clusters and brokers** -- aggregate counts
+- **Status distribution** -- count of clusters by readiness (ready, not_ready, error, unknown)
+- **Clusters** -- per-cluster summary with name, namespace, readiness, Kafka version, broker counts, age, and relationship counts (topics, users, active rebalances, connected KafkaConnect/Bridge/MirrorMaker2 instances)
+- **Warnings** -- clusters with health issues: NotReady, Error, or broker replica mismatch (capped at 20)
+
+**Example**:
+```
+Give me a fleet overview of all Kafka clusters
+```
+
 ## get_kafka_cluster
 
 Get detailed information about a specific Kafka cluster including status, version, and configuration.

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponse.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto.kafka;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.List;
+/**
+ * Aggregated health overview across all Kafka clusters.
+ * Provides status distribution, total broker count, per-cluster summaries,
+ * and warnings for clusters that need attention.
+ *
+ * @param totalClusters      the total number of Kafka clusters
+ * @param totalBrokers       the total number of broker replicas across all clusters
+ * @param statusDistribution the count of clusters by readiness status
+ * @param clusters           per-cluster summary list
+ * @param warnings           clusters with health issues (capped at 20)
+ * @param timestamp          when this overview was generated
+ * @param namespaceFilter    the namespace filter applied, or null for all namespaces
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KafkaFleetOverviewResponse(
+    @JsonProperty("total_clusters") int totalClusters,
+    @JsonProperty("total_brokers") int totalBrokers,
+    @JsonProperty("status_distribution") StatusDistribution statusDistribution,
+    @JsonProperty("clusters") List<ClusterSummary> clusters,
+    @JsonProperty("warnings") List<ClusterWarning> warnings,
+    @JsonProperty("timestamp") Instant timestamp,
+    @JsonProperty("namespace_filter") String namespaceFilter
+) {
+
+    /**
+     * Count of clusters by readiness status.
+     *
+     * @param ready    clusters in Ready state
+     * @param notReady clusters in NotReady state
+     * @param error    clusters in Error state
+     * @param unknown  clusters in Unknown state
+     */
+    public record StatusDistribution(
+        @JsonProperty("ready") int ready,
+        @JsonProperty("not_ready") int notReady,
+        @JsonProperty("error") int error,
+        @JsonProperty("unknown") int unknown
+    ) {
+    }
+
+    /**
+     * Minimal summary of a single Kafka cluster with relationship counts.
+     *
+     * @param name             the cluster name
+     * @param namespace        the Kubernetes namespace
+     * @param readiness        the cluster readiness status
+     * @param kafkaVersion     the Kafka version
+     * @param brokers          the expected broker replica count
+     * @param readyBrokers     the ready broker replica count
+     * @param ageMinutes       the age of the cluster in minutes
+     * @param topicCount       number of KafkaTopic resources (null if unavailable)
+     * @param userCount        number of KafkaUser resources (null if unavailable)
+     * @param activeRebalances number of active KafkaRebalance resources (null if unavailable)
+     * @param connectCount     number of connected KafkaConnect clusters (null if unavailable)
+     * @param bridgeCount      number of connected KafkaBridge instances (null if unavailable)
+     * @param mirrorMakerCount number of connected KafkaMirrorMaker2 instances (null if unavailable)
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ClusterSummary(
+        @JsonProperty("name") String name,
+        @JsonProperty("namespace") String namespace,
+        @JsonProperty("readiness") String readiness,
+        @JsonProperty("kafka_version") String kafkaVersion,
+        @JsonProperty("brokers") int brokers,
+        @JsonProperty("ready_brokers") int readyBrokers,
+        @JsonProperty("age_minutes") Long ageMinutes,
+        @JsonProperty("topic_count") Integer topicCount,
+        @JsonProperty("user_count") Integer userCount,
+        @JsonProperty("active_rebalances") Integer activeRebalances,
+        @JsonProperty("connect_count") Integer connectCount,
+        @JsonProperty("bridge_count") Integer bridgeCount,
+        @JsonProperty("mirror_maker_count") Integer mirrorMakerCount
+    ) {
+    }
+
+    /**
+     * Warning for a cluster that needs attention.
+     *
+     * @param clusterName the cluster name
+     * @param namespace   the Kubernetes namespace
+     * @param warningType the type of warning (e.g., NotReady, Error, ReplicaMismatch)
+     * @param message     human-readable warning description
+     */
+    public record ClusterWarning(
+        @JsonProperty("cluster_name") String clusterName,
+        @JsonProperty("namespace") String namespace,
+        @JsonProperty("warning_type") String warningType,
+        @JsonProperty("message") String message
+    ) {
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponse.java
@@ -21,6 +21,7 @@ import java.util.List;
  * @param warnings           clusters with health issues (capped at 20)
  * @param timestamp          when this overview was generated
  * @param namespaceFilter    the namespace filter applied, or null for all namespaces
+ * @param resourceErrors     resource types that failed to load (null if all succeeded)
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record KafkaFleetOverviewResponse(
@@ -30,7 +31,8 @@ public record KafkaFleetOverviewResponse(
     @JsonProperty("clusters") List<ClusterSummary> clusters,
     @JsonProperty("warnings") List<ClusterWarning> warnings,
     @JsonProperty("timestamp") Instant timestamp,
-    @JsonProperty("namespace_filter") String namespaceFilter
+    @JsonProperty("namespace_filter") String namespaceFilter,
+    @JsonProperty("resource_errors") List<String> resourceErrors
 ) {
 
     /**
@@ -65,6 +67,7 @@ public record KafkaFleetOverviewResponse(
      * @param connectCount     number of connected KafkaConnect clusters (null if unavailable)
      * @param bridgeCount      number of connected KafkaBridge instances (null if unavailable)
      * @param mirrorMakerCount number of connected KafkaMirrorMaker2 instances (null if unavailable)
+     * @param resourceErrors   resource types that failed to load for this cluster (null if all succeeded)
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record ClusterSummary(
@@ -80,7 +83,8 @@ public record KafkaFleetOverviewResponse(
         @JsonProperty("active_rebalances") Integer activeRebalances,
         @JsonProperty("connect_count") Integer connectCount,
         @JsonProperty("bridge_count") Integer bridgeCount,
-        @JsonProperty("mirror_maker_count") Integer mirrorMakerCount
+        @JsonProperty("mirror_maker_count") Integer mirrorMakerCount,
+        @JsonProperty("resource_errors") List<String> resourceErrors
     ) {
     }
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/BootstrapMatcher.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/BootstrapMatcher.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service.kafka;
+
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.ListenerInfo;
+import io.streamshub.mcp.strimzi.dto.kafkamirrormaker2.KafkaMirrorMaker2Response;
+
+import java.util.HashSet;
+import java.util.Set;
+/**
+ * Shared logic for matching Strimzi resources to a Kafka cluster
+ * by comparing bootstrap server addresses.
+ */
+public final class BootstrapMatcher {
+
+    private BootstrapMatcher() {
+    }
+
+    /**
+     * Extract all possible bootstrap addresses for a cluster:
+     * the conventional service DNS name plus every listener's bootstrap address and host.
+     *
+     * @param cluster     the cluster response
+     * @param clusterName the cluster name (used to build the DNS name)
+     * @return the set of bootstrap addresses
+     */
+    public static Set<String> extractBootstrapAddresses(final KafkaClusterResponse cluster,
+                                                         final String clusterName) {
+        Set<String> addresses = new HashSet<>();
+        addresses.add(clusterName + "-kafka-bootstrap");
+
+        if (cluster.listeners() != null) {
+            for (ListenerInfo listener : cluster.listeners()) {
+                if (listener.bootstrapAddress() != null) {
+                    addresses.add(listener.bootstrapAddress());
+                    String host = listener.bootstrapAddress().split(":")[0];
+                    addresses.add(host);
+                }
+            }
+        }
+        return addresses;
+    }
+
+    /**
+     * Check whether a resource's {@code spec.bootstrapServers} string
+     * contains any of the cluster's bootstrap addresses.
+     *
+     * @param specBootstrapServers the bootstrap servers from the resource spec
+     * @param clusterAddresses     the cluster's known bootstrap addresses
+     * @return true if there is a match
+     */
+    public static boolean matchesBootstrap(final String specBootstrapServers,
+                                            final Set<String> clusterAddresses) {
+        if (specBootstrapServers == null || specBootstrapServers.isBlank()) {
+            return false;
+        }
+        for (String address : clusterAddresses) {
+            if (specBootstrapServers.contains(address)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check whether a KafkaMirrorMaker2 connects to a cluster,
+     * matching by bootstrap servers, target cluster name, or source cluster aliases.
+     *
+     * @param mm2              the MM2 response
+     * @param clusterAddresses the cluster's known bootstrap addresses
+     * @return true if the MM2 connects to the cluster
+     */
+    public static boolean mm2ConnectsToCluster(final KafkaMirrorMaker2Response mm2,
+                                                final Set<String> clusterAddresses) {
+        if (matchesBootstrap(mm2.bootstrapServers(), clusterAddresses)) {
+            return true;
+        }
+        if (mm2.targetCluster() != null
+                && anyAddressContains(clusterAddresses, mm2.targetCluster())) {
+            return true;
+        }
+        if (mm2.sourceClusterAliases() != null) {
+            return mm2.sourceClusterAliases().stream()
+                .anyMatch(alias -> anyAddressContains(clusterAddresses, alias));
+        }
+        return false;
+    }
+
+    private static boolean anyAddressContains(final Set<String> addresses, final String value) {
+        return addresses.stream().anyMatch(addr -> addr.contains(value));
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterDiagnosticService.java
@@ -275,7 +275,7 @@ public class KafkaClusterDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "diagnosed");
                 return gatherClusterStatus(resolved, clusterName, null,
                     completed, mcpLog);
@@ -691,7 +691,7 @@ public class KafkaClusterDiagnosticService {
                                                             final Elicitation elicitation,
                                                             final McpLog mcpLog,
                                                             final KafkaClusterLogsResponse currentResult) {
-        if (elicitation == null || !elicitation.isSupported()) {
+        if (elicitation == null || !elicitation.isFormModeSupported()) {
             return currentResult;
         }
 

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterOverviewService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterOverviewService.java
@@ -41,7 +41,6 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +116,7 @@ public class KafkaClusterOverviewService {
         KafkaClusterResponse cluster = kafkaService.getCluster(ns, name);
         String resolvedNs = cluster.namespace();
 
-        Set<String> bootstrapAddresses = extractBootstrapAddresses(cluster, name);
+        Set<String> bootstrapAddresses = BootstrapMatcher.extractBootstrapAddresses(cluster, name);
 
         return new KafkaClusterOverviewResponse(
             buildClusterSummary(cluster),
@@ -221,7 +220,7 @@ public class KafkaClusterOverviewService {
         try {
             List<KafkaConnectResponse> allConnects = connectService.listConnects(namespace);
             return allConnects.stream()
-                .filter(c -> matchesBootstrap(c.bootstrapServers(), bootstrapAddresses))
+                .filter(c -> BootstrapMatcher.matchesBootstrap(c.bootstrapServers(), bootstrapAddresses))
                 .map(c -> {
                     int connectorCount = countConnectors(namespace, c.name());
                     Integer replicas = c.replicas() != null ? c.replicas().expected() : null;
@@ -240,7 +239,7 @@ public class KafkaClusterOverviewService {
         try {
             List<KafkaMirrorMaker2Response> allMm2 = mirrorMakerService.listMirrorMakers(namespace);
             return allMm2.stream()
-                .filter(m -> mm2ConnectsToCluster(m, bootstrapAddresses))
+                .filter(m -> BootstrapMatcher.mm2ConnectsToCluster(m, bootstrapAddresses))
                 .map(m -> {
                     Integer replicas = m.replicas() != null ? m.replicas().expected() : null;
                     int mirrorCount = m.sourceClusterAliases() != null
@@ -260,7 +259,7 @@ public class KafkaClusterOverviewService {
         try {
             List<KafkaBridgeResponse> allBridges = bridgeService.listBridges(namespace);
             return allBridges.stream()
-                .filter(b -> matchesBootstrap(b.bootstrapServers(), bootstrapAddresses))
+                .filter(b -> BootstrapMatcher.matchesBootstrap(b.bootstrapServers(), bootstrapAddresses))
                 .map(b -> {
                     Integer replicas = b.replicas() != null ? b.replicas().expected() : null;
                     return new BridgeSummary(b.name(), b.namespace(), b.readiness(), replicas);
@@ -286,60 +285,6 @@ public class KafkaClusterOverviewService {
     }
 
     // ---- Helpers ----
-
-    private Set<String> extractBootstrapAddresses(final KafkaClusterResponse cluster,
-                                                   final String clusterName) {
-        Set<String> addresses = new HashSet<>();
-        addresses.add(clusterName + "-kafka-bootstrap");
-
-        if (cluster.listeners() != null) {
-            for (var listener : cluster.listeners()) {
-                if (listener.bootstrapAddress() != null) {
-                    addresses.add(listener.bootstrapAddress());
-                    String host = listener.bootstrapAddress().split(":")[0];
-                    addresses.add(host);
-                }
-            }
-        }
-        return addresses;
-    }
-
-    private boolean mm2ConnectsToCluster(final KafkaMirrorMaker2Response mm2,
-                                         final Set<String> clusterAddresses) {
-        if (matchesBootstrap(mm2.bootstrapServers(), clusterAddresses)) {
-            return true;
-        }
-        if (mm2.targetCluster() != null) {
-            for (String addr : clusterAddresses) {
-                if (addr.contains(mm2.targetCluster())) {
-                    return true;
-                }
-            }
-        }
-        if (mm2.sourceClusterAliases() != null) {
-            for (String alias : mm2.sourceClusterAliases()) {
-                for (String addr : clusterAddresses) {
-                    if (addr.contains(alias)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean matchesBootstrap(final String specBootstrapServers,
-                                     final Set<String> clusterAddresses) {
-        if (specBootstrapServers == null || specBootstrapServers.isBlank()) {
-            return false;
-        }
-        for (String address : clusterAddresses) {
-            if (specBootstrapServers.contains(address)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     private int countConnectors(final String namespace, final String connectClusterName) {
         try {

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaConfigComparisonService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaConfigComparisonService.java
@@ -145,7 +145,7 @@ public class KafkaConfigComparisonService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, elicitationContext);
                 return gatherConfigResolved(resolved, clusterName, step, completed, failed, mcpLog);
             }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaConnectivityDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaConnectivityDiagnosticService.java
@@ -206,7 +206,7 @@ public class KafkaConnectivityDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "checked for connectivity");
                 return gatherClusterStatus(resolved, clusterName, null,
                     completed, mcpLog);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaFleetOverviewService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaFleetOverviewService.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 /**
  * Service that aggregates health information across all Kafka clusters
  * into a single fleet-level overview with cross-resource relationship counts.
@@ -69,78 +70,125 @@ public class KafkaFleetOverviewService {
      * @param namespace optional namespace filter (null for all namespaces)
      * @return the fleet overview response
      */
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public KafkaFleetOverviewResponse getFleetOverview(final String namespace) {
         String ns = InputUtils.normalizeInput(namespace);
         LOG.infof("Getting fleet overview (namespace=%s)", ns != null ? ns : "all");
 
         List<KafkaClusterResponse> clusters = kafkaService.listClusters(ns);
 
-        List<KafkaConnectResponse> allConnects = bulkListConnects(ns);
-        List<KafkaBridgeResponse> allBridges = bulkListBridges(ns);
-        List<KafkaMirrorMaker2Response> allMirrorMakers = bulkListMirrorMakers(ns);
+        List<String> fleetResourceErrors = new ArrayList<>();
+        List<KafkaConnectResponse> allConnects = bulkFetch(
+            () -> connectService.listConnects(ns), "KafkaConnect", fleetResourceErrors);
+        List<KafkaBridgeResponse> allBridges = bulkFetch(
+            () -> bridgeService.listBridges(ns), "KafkaBridge", fleetResourceErrors);
+        List<KafkaMirrorMaker2Response> allMirrorMakers = bulkFetch(
+            () -> mirrorMakerService.listMirrorMakers(ns), "KafkaMirrorMaker2", fleetResourceErrors);
 
         int totalBrokers = 0;
-        int ready = 0;
-        int notReady = 0;
-        int error = 0;
-        int unknown = 0;
+        int[] statusCounts = new int[4];
 
         List<ClusterSummary> summaries = new ArrayList<>(clusters.size());
         List<ClusterWarning> warnings = new ArrayList<>();
 
         for (KafkaClusterResponse cluster : clusters) {
-            int brokers = cluster.replicas() != null && cluster.replicas().expected() != null
-                ? cluster.replicas().expected() : 0;
-            int readyBrokers = cluster.replicas() != null && cluster.replicas().ready() != null
-                ? cluster.replicas().ready() : 0;
+            int brokers = extractBrokerCount(cluster, true);
+            int readyBrokers = extractBrokerCount(cluster, false);
             totalBrokers += brokers;
 
-            Set<String> bootstrapAddresses = BootstrapMatcher.extractBootstrapAddresses(
-                cluster, cluster.name());
-
-            summaries.add(new ClusterSummary(
-                cluster.name(), cluster.namespace(), cluster.readiness(),
-                cluster.kafkaVersion(), brokers, readyBrokers, cluster.ageMinutes(),
-                countTopics(cluster.namespace(), cluster.name()),
-                countUsers(cluster.namespace(), cluster.name()),
-                countActiveRebalances(cluster.namespace(), cluster.name()),
-                countMatching(allConnects, bootstrapAddresses),
-                countMatchingBridges(allBridges, bootstrapAddresses),
-                countMatchingMirrorMakers(allMirrorMakers, bootstrapAddresses)));
-
-            switch (cluster.readiness()) {
-                case KubernetesConstants.ResourceStatus.READY -> ready++;
-                case KubernetesConstants.ResourceStatus.NOT_READY -> {
-                    notReady++;
-                    addWarning(warnings, cluster.name(), cluster.namespace(),
-                        KubernetesConstants.ResourceStatus.NOT_READY,
-                        "Cluster is not ready: condition Ready=False");
-                }
-                case KubernetesConstants.ResourceStatus.ERROR -> {
-                    error++;
-                    addWarning(warnings, cluster.name(), cluster.namespace(),
-                        KubernetesConstants.ResourceStatus.ERROR,
-                        "Cluster is in error state");
-                }
-                default -> unknown++;
-            }
-
-            if (brokers > 0 && readyBrokers < brokers) {
-                addWarning(warnings, cluster.name(), cluster.namespace(),
-                    "ReplicaMismatch",
-                    String.format("Broker replica mismatch: %d/%d ready", readyBrokers, brokers));
-            }
+            summaries.add(buildClusterSummary(
+                cluster, brokers, readyBrokers,
+                allConnects, allBridges, allMirrorMakers, fleetResourceErrors));
+            accumulateStatus(cluster, statusCounts, warnings);
+            checkReplicaMismatch(cluster, brokers, readyBrokers, warnings);
         }
 
         return new KafkaFleetOverviewResponse(
             clusters.size(),
             totalBrokers,
-            new StatusDistribution(ready, notReady, error, unknown),
+            new StatusDistribution(statusCounts[0], statusCounts[1], statusCounts[2], statusCounts[3]),
             summaries,
             warnings,
             Instant.now(),
-            ns);
+            ns,
+            fleetResourceErrors.isEmpty() ? null : fleetResourceErrors);
+    }
+
+    private int extractBrokerCount(final KafkaClusterResponse cluster, final boolean expected) {
+        if (cluster.replicas() == null) {
+            return 0;
+        }
+        Integer value = expected ? cluster.replicas().expected() : cluster.replicas().ready();
+        return value != null ? value : 0;
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    private ClusterSummary buildClusterSummary(
+            final KafkaClusterResponse cluster,
+            final int brokers, final int readyBrokers,
+            final List<KafkaConnectResponse> allConnects,
+            final List<KafkaBridgeResponse> allBridges,
+            final List<KafkaMirrorMaker2Response> allMirrorMakers,
+            final List<String> fleetErrors) {
+
+        Set<String> bootstrapAddresses = BootstrapMatcher.extractBootstrapAddresses(
+            cluster, cluster.name());
+
+        List<String> clusterErrors = new ArrayList<>(fleetErrors);
+        Integer topicCount = countTopics(cluster.namespace(), cluster.name());
+        if (topicCount == null) {
+            clusterErrors.add("KafkaTopic");
+        }
+        Integer userCount = countUsers(cluster.namespace(), cluster.name());
+        if (userCount == null) {
+            clusterErrors.add("KafkaUser");
+        }
+        Integer activeRebalances = countActiveRebalances(cluster.namespace(), cluster.name());
+        if (activeRebalances == null) {
+            clusterErrors.add("KafkaRebalance");
+        }
+
+        return new ClusterSummary(
+            cluster.name(), cluster.namespace(), cluster.readiness(),
+            cluster.kafkaVersion(), brokers, readyBrokers, cluster.ageMinutes(),
+            topicCount, userCount, activeRebalances,
+            fleetErrors.contains("KafkaConnect")
+                ? null : countIfPresent(allConnects, bootstrapAddresses),
+            fleetErrors.contains("KafkaBridge")
+                ? null : countMatchingBridges(allBridges, bootstrapAddresses),
+            fleetErrors.contains("KafkaMirrorMaker2")
+                ? null : countMatchingMirrorMakers(allMirrorMakers, bootstrapAddresses),
+            clusterErrors.isEmpty() ? null : clusterErrors);
+    }
+
+    private void accumulateStatus(final KafkaClusterResponse cluster,
+                                  final int[] statusCounts,
+                                  final List<ClusterWarning> warnings) {
+        switch (cluster.readiness()) {
+            case KubernetesConstants.ResourceStatus.READY -> statusCounts[0]++;
+            case KubernetesConstants.ResourceStatus.NOT_READY -> {
+                statusCounts[1]++;
+                addWarning(warnings, cluster.name(), cluster.namespace(),
+                    KubernetesConstants.ResourceStatus.NOT_READY,
+                    "Cluster is not ready: condition Ready=False");
+            }
+            case KubernetesConstants.ResourceStatus.ERROR -> {
+                statusCounts[2]++;
+                addWarning(warnings, cluster.name(), cluster.namespace(),
+                    KubernetesConstants.ResourceStatus.ERROR,
+                    "Cluster is in error state");
+            }
+            default -> statusCounts[3]++;
+        }
+    }
+
+    private void checkReplicaMismatch(final KafkaClusterResponse cluster,
+                                      final int brokers, final int readyBrokers,
+                                      final List<ClusterWarning> warnings) {
+        if (brokers > 0 && readyBrokers < brokers) {
+            addWarning(warnings, cluster.name(), cluster.namespace(),
+                "ReplicaMismatch",
+                String.format("Broker replica mismatch: %d/%d ready", readyBrokers, brokers));
+        }
     }
 
     // ---- Label-based counts (per cluster) ----
@@ -182,35 +230,23 @@ public class KafkaFleetOverviewService {
 
     // ---- Bulk-fetched infrastructure (one query total, matched per cluster) ----
 
-    private List<KafkaConnectResponse> bulkListConnects(final String namespace) {
+    private <T> List<T> bulkFetch(final Supplier<List<T>> fetcher,
+                                   final String resourceType,
+                                   final List<String> errors) {
         try {
-            return connectService.listConnects(namespace);
+            return fetcher.get();
         } catch (Exception e) {
-            LOG.warnf("Could not list KafkaConnects: %s", e.getMessage());
+            LOG.warnf("Could not list %s resources: %s", resourceType, e.getMessage());
+            errors.add(resourceType);
             return List.of();
         }
     }
 
-    private List<KafkaBridgeResponse> bulkListBridges(final String namespace) {
-        try {
-            return bridgeService.listBridges(namespace);
-        } catch (Exception e) {
-            LOG.warnf("Could not list KafkaBridges: %s", e.getMessage());
-            return List.of();
+    private Integer countIfPresent(final List<KafkaConnectResponse> connects,
+                                   final Set<String> bootstrapAddresses) {
+        if (connects.isEmpty()) {
+            return 0;
         }
-    }
-
-    private List<KafkaMirrorMaker2Response> bulkListMirrorMakers(final String namespace) {
-        try {
-            return mirrorMakerService.listMirrorMakers(namespace);
-        } catch (Exception e) {
-            LOG.warnf("Could not list KafkaMirrorMaker2 instances: %s", e.getMessage());
-            return List.of();
-        }
-    }
-
-    private Integer countMatching(final List<KafkaConnectResponse> connects,
-                                  final Set<String> bootstrapAddresses) {
         return (int) connects.stream()
             .filter(c -> BootstrapMatcher.matchesBootstrap(c.bootstrapServers(), bootstrapAddresses))
             .count();

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaFleetOverviewService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaFleetOverviewService.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service.kafka;
+
+import io.streamshub.mcp.common.config.KubernetesConstants;
+import io.streamshub.mcp.common.service.KubernetesResourceService;
+import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterSummary;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterWarning;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.StatusDistribution;
+import io.streamshub.mcp.strimzi.dto.kafkabridge.KafkaBridgeResponse;
+import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectResponse;
+import io.streamshub.mcp.strimzi.dto.kafkamirrormaker2.KafkaMirrorMaker2Response;
+import io.streamshub.mcp.strimzi.dto.kafkarebalance.KafkaRebalanceResponse;
+import io.streamshub.mcp.strimzi.service.kafkabridge.KafkaBridgeService;
+import io.streamshub.mcp.strimzi.service.kafkaconnect.KafkaConnectService;
+import io.streamshub.mcp.strimzi.service.kafkamirrormaker2.KafkaMirrorMaker2Service;
+import io.streamshub.mcp.strimzi.service.kafkarebalance.KafkaRebalanceService;
+import io.strimzi.api.ResourceLabels;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+/**
+ * Service that aggregates health information across all Kafka clusters
+ * into a single fleet-level overview with cross-resource relationship counts.
+ */
+@ApplicationScoped
+public class KafkaFleetOverviewService {
+
+    private static final Logger LOG = Logger.getLogger(KafkaFleetOverviewService.class);
+
+    private static final int MAX_WARNINGS = 20;
+
+    @Inject
+    KafkaService kafkaService;
+
+    @Inject
+    KubernetesResourceService k8sService;
+
+    @Inject
+    KafkaRebalanceService rebalanceService;
+
+    @Inject
+    KafkaConnectService connectService;
+
+    @Inject
+    KafkaBridgeService bridgeService;
+
+    @Inject
+    KafkaMirrorMaker2Service mirrorMakerService;
+
+    KafkaFleetOverviewService() {
+    }
+
+    /**
+     * Get an aggregated health overview across all Kafka clusters.
+     *
+     * @param namespace optional namespace filter (null for all namespaces)
+     * @return the fleet overview response
+     */
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    public KafkaFleetOverviewResponse getFleetOverview(final String namespace) {
+        String ns = InputUtils.normalizeInput(namespace);
+        LOG.infof("Getting fleet overview (namespace=%s)", ns != null ? ns : "all");
+
+        List<KafkaClusterResponse> clusters = kafkaService.listClusters(ns);
+
+        List<KafkaConnectResponse> allConnects = bulkListConnects(ns);
+        List<KafkaBridgeResponse> allBridges = bulkListBridges(ns);
+        List<KafkaMirrorMaker2Response> allMirrorMakers = bulkListMirrorMakers(ns);
+
+        int totalBrokers = 0;
+        int ready = 0;
+        int notReady = 0;
+        int error = 0;
+        int unknown = 0;
+
+        List<ClusterSummary> summaries = new ArrayList<>(clusters.size());
+        List<ClusterWarning> warnings = new ArrayList<>();
+
+        for (KafkaClusterResponse cluster : clusters) {
+            int brokers = cluster.replicas() != null && cluster.replicas().expected() != null
+                ? cluster.replicas().expected() : 0;
+            int readyBrokers = cluster.replicas() != null && cluster.replicas().ready() != null
+                ? cluster.replicas().ready() : 0;
+            totalBrokers += brokers;
+
+            Set<String> bootstrapAddresses = BootstrapMatcher.extractBootstrapAddresses(
+                cluster, cluster.name());
+
+            summaries.add(new ClusterSummary(
+                cluster.name(), cluster.namespace(), cluster.readiness(),
+                cluster.kafkaVersion(), brokers, readyBrokers, cluster.ageMinutes(),
+                countTopics(cluster.namespace(), cluster.name()),
+                countUsers(cluster.namespace(), cluster.name()),
+                countActiveRebalances(cluster.namespace(), cluster.name()),
+                countMatching(allConnects, bootstrapAddresses),
+                countMatchingBridges(allBridges, bootstrapAddresses),
+                countMatchingMirrorMakers(allMirrorMakers, bootstrapAddresses)));
+
+            switch (cluster.readiness()) {
+                case KubernetesConstants.ResourceStatus.READY -> ready++;
+                case KubernetesConstants.ResourceStatus.NOT_READY -> {
+                    notReady++;
+                    addWarning(warnings, cluster.name(), cluster.namespace(),
+                        KubernetesConstants.ResourceStatus.NOT_READY,
+                        "Cluster is not ready: condition Ready=False");
+                }
+                case KubernetesConstants.ResourceStatus.ERROR -> {
+                    error++;
+                    addWarning(warnings, cluster.name(), cluster.namespace(),
+                        KubernetesConstants.ResourceStatus.ERROR,
+                        "Cluster is in error state");
+                }
+                default -> unknown++;
+            }
+
+            if (brokers > 0 && readyBrokers < brokers) {
+                addWarning(warnings, cluster.name(), cluster.namespace(),
+                    "ReplicaMismatch",
+                    String.format("Broker replica mismatch: %d/%d ready", readyBrokers, brokers));
+            }
+        }
+
+        return new KafkaFleetOverviewResponse(
+            clusters.size(),
+            totalBrokers,
+            new StatusDistribution(ready, notReady, error, unknown),
+            summaries,
+            warnings,
+            Instant.now(),
+            ns);
+    }
+
+    // ---- Label-based counts (per cluster) ----
+
+    private Integer countTopics(final String namespace, final String clusterName) {
+        try {
+            return k8sService.queryResourcesByLabel(
+                KafkaTopic.class, namespace,
+                ResourceLabels.STRIMZI_CLUSTER_LABEL, clusterName).size();
+        } catch (Exception e) {
+            LOG.warnf("Could not count topics for %s: %s", clusterName, e.getMessage());
+            return null;
+        }
+    }
+
+    private Integer countUsers(final String namespace, final String clusterName) {
+        try {
+            return k8sService.queryResourcesByLabel(
+                KafkaUser.class, namespace,
+                ResourceLabels.STRIMZI_CLUSTER_LABEL, clusterName).size();
+        } catch (Exception e) {
+            LOG.warnf("Could not count users for %s: %s", clusterName, e.getMessage());
+            return null;
+        }
+    }
+
+    private Integer countActiveRebalances(final String namespace, final String clusterName) {
+        try {
+            List<KafkaRebalanceResponse> rebalances = rebalanceService.listRebalances(
+                namespace, clusterName);
+            return (int) rebalances.stream()
+                .filter(r -> KafkaRebalanceService.isActiveRebalanceState(r.state()))
+                .count();
+        } catch (Exception e) {
+            LOG.warnf("Could not count rebalances for %s: %s", clusterName, e.getMessage());
+            return null;
+        }
+    }
+
+    // ---- Bulk-fetched infrastructure (one query total, matched per cluster) ----
+
+    private List<KafkaConnectResponse> bulkListConnects(final String namespace) {
+        try {
+            return connectService.listConnects(namespace);
+        } catch (Exception e) {
+            LOG.warnf("Could not list KafkaConnects: %s", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private List<KafkaBridgeResponse> bulkListBridges(final String namespace) {
+        try {
+            return bridgeService.listBridges(namespace);
+        } catch (Exception e) {
+            LOG.warnf("Could not list KafkaBridges: %s", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private List<KafkaMirrorMaker2Response> bulkListMirrorMakers(final String namespace) {
+        try {
+            return mirrorMakerService.listMirrorMakers(namespace);
+        } catch (Exception e) {
+            LOG.warnf("Could not list KafkaMirrorMaker2 instances: %s", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private Integer countMatching(final List<KafkaConnectResponse> connects,
+                                  final Set<String> bootstrapAddresses) {
+        return (int) connects.stream()
+            .filter(c -> BootstrapMatcher.matchesBootstrap(c.bootstrapServers(), bootstrapAddresses))
+            .count();
+    }
+
+    private Integer countMatchingBridges(final List<KafkaBridgeResponse> bridges,
+                                         final Set<String> bootstrapAddresses) {
+        return (int) bridges.stream()
+            .filter(b -> BootstrapMatcher.matchesBootstrap(b.bootstrapServers(), bootstrapAddresses))
+            .count();
+    }
+
+    private Integer countMatchingMirrorMakers(final List<KafkaMirrorMaker2Response> mirrorMakers,
+                                              final Set<String> bootstrapAddresses) {
+        return (int) mirrorMakers.stream()
+            .filter(m -> BootstrapMatcher.mm2ConnectsToCluster(m, bootstrapAddresses))
+            .count();
+    }
+
+    private void addWarning(final List<ClusterWarning> warnings,
+                            final String clusterName, final String namespace,
+                            final String warningType, final String message) {
+        if (warnings.size() < MAX_WARNINGS) {
+            warnings.add(new ClusterWarning(clusterName, namespace, warningType, message));
+        }
+    }
+}

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaMetricsDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaMetricsDiagnosticService.java
@@ -188,7 +188,7 @@ public class KafkaMetricsDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "analyzed for metrics");
                 return gatherClusterStatus(resolved, clusterName, null,
                     completed, mcpLog);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/UpgradeReadinessDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/UpgradeReadinessDiagnosticService.java
@@ -258,7 +258,7 @@ public class UpgradeReadinessDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(
                     e, elicitation, "checked for upgrade readiness");
                 return gatherClusterStatus(resolved, clusterName, null, completed, mcpLog);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectDiagnosticService.java
@@ -181,7 +181,7 @@ public class KafkaConnectDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(
                     e, elicitation, "diagnosed");
                 return gatherConnectStatus(resolved, name, null, completed, mcpLog);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectorDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkaconnect/KafkaConnectorDiagnosticService.java
@@ -196,7 +196,7 @@ public class KafkaConnectorDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "diagnosed");
                 return gatherConnectorStatus(resolved, connectorName, null, completed, mcpLog);
             }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkamirrormaker2/KafkaMirrorMaker2DiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkamirrormaker2/KafkaMirrorMaker2DiagnosticService.java
@@ -162,7 +162,7 @@ public class KafkaMirrorMaker2DiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(
                     e, elicitation, "diagnosed");
                 return gatherMm2Status(resolved, name, null, completed, mcpLog);

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkatopic/KafkaTopicDiagnosticService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafkatopic/KafkaTopicDiagnosticService.java
@@ -214,7 +214,7 @@ public class KafkaTopicDiagnosticService {
             return result;
         } catch (ToolCallException e) {
             if (NamespaceElicitationHelper.isMultipleNamespacesError(e)
-                    && elicitation != null && elicitation.isSupported()) {
+                    && elicitation != null && elicitation.isFormModeSupported()) {
                 String resolved = NamespaceElicitationHelper.elicitNamespace(e, elicitation, "diagnosed");
                 return gatherTopicStatus(resolved, clusterName, topicName, null, completed, mcpLog);
             }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTools.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/tool/KafkaTools.java
@@ -22,8 +22,10 @@ import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterLogsResponse;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterOverviewResponse;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterPodsResponse;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse;
 import io.streamshub.mcp.strimzi.service.kafka.KafkaCertificateService;
 import io.streamshub.mcp.strimzi.service.kafka.KafkaClusterOverviewService;
+import io.streamshub.mcp.strimzi.service.kafka.KafkaFleetOverviewService;
 import io.streamshub.mcp.strimzi.service.kafka.KafkaService;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -50,6 +52,9 @@ public class KafkaTools {
 
     @Inject
     KafkaClusterOverviewService overviewService;
+
+    @Inject
+    KafkaFleetOverviewService fleetOverviewService;
 
     @ConfigProperty(name = "mcp.log.tail-lines", defaultValue = "200")
     int defaultTailLines;
@@ -83,6 +88,34 @@ public class KafkaTools {
         ) final String namespace
     ) {
         return kafkaService.listClusters(namespace);
+    }
+
+    /**
+     * Get aggregated fleet overview across all Kafka clusters.
+     *
+     * @param namespace optional namespace filter
+     * @return the fleet overview response
+     */
+    @WithSpan("tool.get_kafka_fleet_overview")
+    @Tool(
+        name = "get_kafka_fleet_overview",
+        description = "Get aggregated health overview across all Kafka clusters."
+            + " Shows status distribution, total broker count, and clusters with warnings."
+            + " Optionally filter by namespace.",
+        annotations = @Tool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
+    )
+    public KafkaFleetOverviewResponse getKafkaFleetOverview(
+        @ToolArg(
+            description = StrimziToolsPrompts.NS_DESC,
+            required = false
+        ) final String namespace
+    ) {
+        return fleetOverviewService.getFleetOverview(namespace);
     }
 
     /**

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponseTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponseTest.java
@@ -36,12 +36,13 @@ class KafkaFleetOverviewResponseTest {
             new StatusDistribution(1, 1, 0, 0),
             List.of(
                 new ClusterSummary("prod", "kafka-prod", "Ready", "4.2.0", 3, 3, 1000L,
-                    42, 5, 0, 1, 0, 0),
+                    42, 5, 0, 1, 0, 0, null),
                 new ClusterSummary("staging", "kafka-staging", "NotReady", "4.2.0", 3, 2, 500L,
-                    10, 2, 1, 0, 0, 0)
+                    10, 2, 1, 0, 0, 0, null)
             ),
             List.of(new ClusterWarning("staging", "kafka-staging", "NotReady", "Cluster is not ready")),
             Instant.parse("2026-06-05T10:00:00Z"),
+            null,
             null
         );
 
@@ -64,6 +65,7 @@ class KafkaFleetOverviewResponseTest {
             new StatusDistribution(0, 0, 0, 0),
             List.of(), List.of(),
             Instant.now(),
+            null,
             null
         );
 
@@ -75,7 +77,7 @@ class KafkaFleetOverviewResponseTest {
     void clusterSummaryRelationshipFieldsSerialized() throws Exception {
         ClusterSummary summary = new ClusterSummary(
             "prod", "kafka", "Ready", "4.2.0", 3, 3, 1000L,
-            42, 5, 1, 2, 1, 0);
+            42, 5, 1, 2, 1, 0, null);
 
         String json = MAPPER.writeValueAsString(summary);
         @SuppressWarnings("unchecked")
@@ -93,7 +95,7 @@ class KafkaFleetOverviewResponseTest {
     void clusterSummaryNullRelationshipsExcludedFromJson() throws Exception {
         ClusterSummary summary = new ClusterSummary(
             "test", "ns", "Ready", "4.2.0", 3, 3, 1000L,
-            null, null, null, null, null, null);
+            null, null, null, null, null, null, null);
 
         String json = MAPPER.writeValueAsString(summary);
         assertFalse(json.contains("topic_count"));
@@ -108,7 +110,7 @@ class KafkaFleetOverviewResponseTest {
     void clusterSummaryNullAgeIsExcludedFromJson() throws Exception {
         ClusterSummary summary = new ClusterSummary(
             "test", "ns", "Ready", "4.2.0", 3, 3, null,
-            null, null, null, null, null, null);
+            null, null, null, null, null, null, null);
 
         String json = MAPPER.writeValueAsString(summary);
         assertFalse(json.contains("age_minutes"));
@@ -143,13 +145,53 @@ class KafkaFleetOverviewResponseTest {
     }
 
     @Test
+    void resourceErrorsIncludedWhenPresent() throws Exception {
+        KafkaFleetOverviewResponse response = new KafkaFleetOverviewResponse(
+            1, 3,
+            new StatusDistribution(1, 0, 0, 0),
+            List.of(new ClusterSummary("prod", "kafka", "Ready", "4.2.0", 3, 3, 1000L,
+                null, null, 0, 1, 0, 0, List.of("KafkaTopic", "KafkaUser"))),
+            List.of(),
+            Instant.now(),
+            null,
+            List.of("KafkaBridge")
+        );
+
+        String json = MAPPER.writeValueAsString(response);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = MAPPER.readValue(json, Map.class);
+
+        assertEquals(List.of("KafkaBridge"), map.get("resource_errors"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> clusters = (List<Map<String, Object>>) map.get("clusters");
+        assertEquals(List.of("KafkaTopic", "KafkaUser"), clusters.get(0).get("resource_errors"));
+    }
+
+    @Test
+    void resourceErrorsExcludedWhenNull() throws Exception {
+        KafkaFleetOverviewResponse response = new KafkaFleetOverviewResponse(
+            0, 0,
+            new StatusDistribution(0, 0, 0, 0),
+            List.of(), List.of(),
+            Instant.now(),
+            null,
+            null
+        );
+
+        String json = MAPPER.writeValueAsString(response);
+        assertFalse(json.contains("resource_errors"));
+    }
+
+    @Test
     void namespaceFilterIsIncludedWhenSet() throws Exception {
         KafkaFleetOverviewResponse response = new KafkaFleetOverviewResponse(
             1, 3,
             new StatusDistribution(1, 0, 0, 0),
             List.of(), List.of(),
             Instant.now(),
-            "kafka-prod"
+            "kafka-prod",
+            null
         );
 
         String json = MAPPER.writeValueAsString(response);

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponseTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaFleetOverviewResponseTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.dto.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterSummary;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterWarning;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.StatusDistribution;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+/**
+ * Unit tests for {@link KafkaFleetOverviewResponse}.
+ */
+class KafkaFleetOverviewResponseTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule());
+
+    KafkaFleetOverviewResponseTest() {
+    }
+
+    @Test
+    void jsonSerializationUsesSnakeCaseFieldNames() throws Exception {
+        KafkaFleetOverviewResponse response = new KafkaFleetOverviewResponse(
+            2, 6,
+            new StatusDistribution(1, 1, 0, 0),
+            List.of(
+                new ClusterSummary("prod", "kafka-prod", "Ready", "4.2.0", 3, 3, 1000L,
+                    42, 5, 0, 1, 0, 0),
+                new ClusterSummary("staging", "kafka-staging", "NotReady", "4.2.0", 3, 2, 500L,
+                    10, 2, 1, 0, 0, 0)
+            ),
+            List.of(new ClusterWarning("staging", "kafka-staging", "NotReady", "Cluster is not ready")),
+            Instant.parse("2026-06-05T10:00:00Z"),
+            null
+        );
+
+        String json = MAPPER.writeValueAsString(response);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = MAPPER.readValue(json, Map.class);
+
+        assertEquals(2, map.get("total_clusters"));
+        assertEquals(6, map.get("total_brokers"));
+        assertTrue(map.containsKey("status_distribution"));
+        assertTrue(map.containsKey("clusters"));
+        assertTrue(map.containsKey("warnings"));
+        assertFalse(map.containsKey("namespace_filter"));
+    }
+
+    @Test
+    void nullNamespaceFilterIsExcludedFromJson() throws Exception {
+        KafkaFleetOverviewResponse response = new KafkaFleetOverviewResponse(
+            0, 0,
+            new StatusDistribution(0, 0, 0, 0),
+            List.of(), List.of(),
+            Instant.now(),
+            null
+        );
+
+        String json = MAPPER.writeValueAsString(response);
+        assertFalse(json.contains("namespace_filter"));
+    }
+
+    @Test
+    void clusterSummaryRelationshipFieldsSerialized() throws Exception {
+        ClusterSummary summary = new ClusterSummary(
+            "prod", "kafka", "Ready", "4.2.0", 3, 3, 1000L,
+            42, 5, 1, 2, 1, 0);
+
+        String json = MAPPER.writeValueAsString(summary);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = MAPPER.readValue(json, Map.class);
+
+        assertEquals(42, map.get("topic_count"));
+        assertEquals(5, map.get("user_count"));
+        assertEquals(1, map.get("active_rebalances"));
+        assertEquals(2, map.get("connect_count"));
+        assertEquals(1, map.get("bridge_count"));
+        assertEquals(0, map.get("mirror_maker_count"));
+    }
+
+    @Test
+    void clusterSummaryNullRelationshipsExcludedFromJson() throws Exception {
+        ClusterSummary summary = new ClusterSummary(
+            "test", "ns", "Ready", "4.2.0", 3, 3, 1000L,
+            null, null, null, null, null, null);
+
+        String json = MAPPER.writeValueAsString(summary);
+        assertFalse(json.contains("topic_count"));
+        assertFalse(json.contains("user_count"));
+        assertFalse(json.contains("active_rebalances"));
+        assertFalse(json.contains("connect_count"));
+        assertFalse(json.contains("bridge_count"));
+        assertFalse(json.contains("mirror_maker_count"));
+    }
+
+    @Test
+    void clusterSummaryNullAgeIsExcludedFromJson() throws Exception {
+        ClusterSummary summary = new ClusterSummary(
+            "test", "ns", "Ready", "4.2.0", 3, 3, null,
+            null, null, null, null, null, null);
+
+        String json = MAPPER.writeValueAsString(summary);
+        assertFalse(json.contains("age_minutes"));
+    }
+
+    @Test
+    void statusDistributionSerializesAllFields() throws Exception {
+        StatusDistribution dist = new StatusDistribution(5, 2, 1, 0);
+
+        String json = MAPPER.writeValueAsString(dist);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = MAPPER.readValue(json, Map.class);
+
+        assertEquals(5, map.get("ready"));
+        assertEquals(2, map.get("not_ready"));
+        assertEquals(1, map.get("error"));
+        assertEquals(0, map.get("unknown"));
+    }
+
+    @Test
+    void clusterWarningSerializesAllFields() throws Exception {
+        ClusterWarning warning = new ClusterWarning("prod", "kafka", "Error", "Cluster in error");
+
+        String json = MAPPER.writeValueAsString(warning);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = MAPPER.readValue(json, Map.class);
+
+        assertEquals("prod", map.get("cluster_name"));
+        assertEquals("kafka", map.get("namespace"));
+        assertEquals("Error", map.get("warning_type"));
+        assertEquals("Cluster in error", map.get("message"));
+    }
+
+    @Test
+    void namespaceFilterIsIncludedWhenSet() throws Exception {
+        KafkaFleetOverviewResponse response = new KafkaFleetOverviewResponse(
+            1, 3,
+            new StatusDistribution(1, 0, 0, 0),
+            List.of(), List.of(),
+            Instant.now(),
+            "kafka-prod"
+        );
+
+        String json = MAPPER.writeValueAsString(response);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = MAPPER.readValue(json, Map.class);
+
+        assertEquals("kafka-prod", map.get("namespace_filter"));
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaFleetOverviewServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaFleetOverviewServiceTest.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright StreamsHub authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.streamshub.mcp.strimzi.service;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.streamshub.mcp.common.dto.ReplicasInfo;
+import io.streamshub.mcp.common.service.KubernetesResourceService;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterWarning;
+import io.streamshub.mcp.strimzi.dto.kafkabridge.KafkaBridgeResponse;
+import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectResponse;
+import io.streamshub.mcp.strimzi.dto.kafkamirrormaker2.KafkaMirrorMaker2Response;
+import io.streamshub.mcp.strimzi.dto.kafkarebalance.KafkaRebalanceResponse;
+import io.streamshub.mcp.strimzi.service.kafka.KafkaFleetOverviewService;
+import io.streamshub.mcp.strimzi.service.kafka.KafkaService;
+import io.streamshub.mcp.strimzi.service.kafkabridge.KafkaBridgeService;
+import io.streamshub.mcp.strimzi.service.kafkaconnect.KafkaConnectService;
+import io.streamshub.mcp.strimzi.service.kafkamirrormaker2.KafkaMirrorMaker2Service;
+import io.streamshub.mcp.strimzi.service.kafkarebalance.KafkaRebalanceService;
+import io.strimzi.api.ResourceLabels;
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+/**
+ * Service-level tests for {@link KafkaFleetOverviewService}.
+ */
+@QuarkusTest
+class KafkaFleetOverviewServiceTest {
+
+    @InjectMock
+    KafkaService kafkaService;
+
+    @InjectMock
+    KubernetesResourceService k8sService;
+
+    @InjectMock
+    KafkaRebalanceService rebalanceService;
+
+    @InjectMock
+    KafkaConnectService connectService;
+
+    @InjectMock
+    KafkaBridgeService bridgeService;
+
+    @InjectMock
+    KafkaMirrorMaker2Service mirrorMakerService;
+
+    @Inject
+    KafkaFleetOverviewService fleetOverviewService;
+
+    KafkaFleetOverviewServiceTest() {
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        lenient().when(k8sService.queryResourcesByLabel(
+            any(Class.class), anyString(), anyString(), anyString())).thenReturn(List.of());
+        lenient().when(rebalanceService.listRebalances(anyString(), anyString()))
+            .thenReturn(List.of());
+        lenient().when(connectService.listConnects(any())).thenReturn(List.of());
+        lenient().when(bridgeService.listBridges(any())).thenReturn(List.of());
+        lenient().when(mirrorMakerService.listMirrorMakers(any())).thenReturn(List.of());
+    }
+
+    @Test
+    void testEmptyFleetReturnsZeros() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of());
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertNotNull(response);
+        assertEquals(0, response.totalClusters());
+        assertEquals(0, response.totalBrokers());
+        assertEquals(0, response.statusDistribution().ready());
+        assertEquals(0, response.statusDistribution().notReady());
+        assertEquals(0, response.statusDistribution().error());
+        assertEquals(0, response.statusDistribution().unknown());
+        assertTrue(response.clusters().isEmpty());
+        assertTrue(response.warnings().isEmpty());
+        assertNotNull(response.timestamp());
+        assertNull(response.namespaceFilter());
+    }
+
+    @Test
+    void testMixedStatusDistribution() {
+        List<KafkaClusterResponse> clusters = List.of(
+            buildCluster("prod", "kafka-prod", "Ready", "4.2.0", 3, 3),
+            buildCluster("staging", "kafka-staging", "NotReady", "4.2.0", 3, 3),
+            buildCluster("dev", "kafka-dev", "Error", "4.1.0", 3, 3),
+            buildCluster("test", "kafka-test", "Unknown", "4.2.0", 1, 0)
+        );
+        when(kafkaService.listClusters(null)).thenReturn(clusters);
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(4, response.totalClusters());
+        assertEquals(10, response.totalBrokers());
+        assertEquals(1, response.statusDistribution().ready());
+        assertEquals(1, response.statusDistribution().notReady());
+        assertEquals(1, response.statusDistribution().error());
+        assertEquals(1, response.statusDistribution().unknown());
+    }
+
+    @Test
+    void testWarningsGeneratedForNotReadyAndError() {
+        List<KafkaClusterResponse> clusters = List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3),
+            buildCluster("staging", "kafka", "NotReady", "4.2.0", 3, 3),
+            buildCluster("dev", "kafka", "Error", "4.1.0", 3, 3)
+        );
+        when(kafkaService.listClusters(null)).thenReturn(clusters);
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(2, response.warnings().size());
+        assertTrue(response.warnings().stream()
+            .anyMatch(w -> "staging".equals(w.clusterName()) && "NotReady".equals(w.warningType())));
+        assertTrue(response.warnings().stream()
+            .anyMatch(w -> "dev".equals(w.clusterName()) && "Error".equals(w.warningType())));
+    }
+
+    @Test
+    void testReplicaMismatchWarning() {
+        List<KafkaClusterResponse> clusters = List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 2)
+        );
+        when(kafkaService.listClusters(null)).thenReturn(clusters);
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(1, response.warnings().size());
+        ClusterWarning warning = response.warnings().get(0);
+        assertEquals("prod", warning.clusterName());
+        assertEquals("ReplicaMismatch", warning.warningType());
+        assertTrue(warning.message().contains("2/3"));
+    }
+
+    @Test
+    void testWarningsCappedAtTwenty() {
+        List<KafkaClusterResponse> clusters = new ArrayList<>();
+        IntStream.range(0, 25).forEach(i ->
+            clusters.add(buildCluster("cluster-" + i, "ns", "Error", "4.2.0", 3, 1)));
+        when(kafkaService.listClusters(null)).thenReturn(clusters);
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(20, response.warnings().size());
+    }
+
+    @Test
+    void testNamespaceFilterPassedThrough() {
+        when(kafkaService.listClusters("kafka-prod")).thenReturn(List.of(
+            buildCluster("prod", "kafka-prod", "Ready", "4.2.0", 3, 3)
+        ));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview("kafka-prod");
+
+        assertEquals(1, response.totalClusters());
+        assertEquals("kafka-prod", response.namespaceFilter());
+    }
+
+    @Test
+    void testNullReplicasHandled() {
+        KafkaClusterResponse cluster = KafkaClusterResponse.of(
+            "test", "ns", "Kafka", "4.2.0", "Ready",
+            null, null, null, null, null,
+            null, null, null, null, null, null);
+        when(kafkaService.listClusters(null)).thenReturn(List.of(cluster));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(1, response.totalClusters());
+        assertEquals(0, response.totalBrokers());
+        assertEquals(0, response.clusters().get(0).brokers());
+        assertEquals(0, response.clusters().get(0).readyBrokers());
+    }
+
+    @Test
+    void testClusterSummaryFields() {
+        List<KafkaClusterResponse> clusters = List.of(
+            buildCluster("prod", "kafka-prod", "Ready", "4.2.0", 3, 3)
+        );
+        when(kafkaService.listClusters(null)).thenReturn(clusters);
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(1, response.clusters().size());
+        var summary = response.clusters().get(0);
+        assertEquals("prod", summary.name());
+        assertEquals("kafka-prod", summary.namespace());
+        assertEquals("Ready", summary.readiness());
+        assertEquals("4.2.0", summary.kafkaVersion());
+        assertEquals(3, summary.brokers());
+        assertEquals(3, summary.readyBrokers());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testTopicAndUserCounts() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        KafkaTopic topic1 = new KafkaTopic();
+        KafkaTopic topic2 = new KafkaTopic();
+        when(k8sService.queryResourcesByLabel(
+            eq(KafkaTopic.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("prod")))
+            .thenReturn(List.of(topic1, topic2));
+
+        KafkaUser user1 = new KafkaUser();
+        when(k8sService.queryResourcesByLabel(
+            eq(KafkaUser.class), eq("kafka"),
+            eq(ResourceLabels.STRIMZI_CLUSTER_LABEL), eq("prod")))
+            .thenReturn(List.of(user1));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        var summary = response.clusters().get(0);
+        assertEquals(2, summary.topicCount());
+        assertEquals(1, summary.userCount());
+    }
+
+    @Test
+    void testActiveRebalanceCounts() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        when(rebalanceService.listRebalances("kafka", "prod")).thenReturn(List.of(
+            buildRebalance("rebalance-1", "Rebalancing"),
+            buildRebalance("rebalance-2", "Ready"),
+            buildRebalance("rebalance-3", "ProposalReady")
+        ));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(2, response.clusters().get(0).activeRebalances());
+    }
+
+    @Test
+    void testConnectedConnectCount() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        when(connectService.listConnects(null)).thenReturn(List.of(
+            buildConnect("my-connect", "prod-kafka-bootstrap:9092"),
+            buildConnect("other-connect", "other-cluster-kafka-bootstrap:9092")
+        ));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(1, response.clusters().get(0).connectCount());
+    }
+
+    @Test
+    void testConnectedBridgeCount() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        when(bridgeService.listBridges(null)).thenReturn(List.of(
+            buildBridge("my-bridge", "prod-kafka-bootstrap:9092")
+        ));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(1, response.clusters().get(0).bridgeCount());
+    }
+
+    @Test
+    void testConnectedMirrorMakerCount() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        when(mirrorMakerService.listMirrorMakers(null)).thenReturn(List.of(
+            buildMirrorMaker("my-mm2", "prod-kafka-bootstrap:9092",
+                "prod", List.of("source-cluster"))
+        ));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertEquals(1, response.clusters().get(0).mirrorMakerCount());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testFailedResourceQueryReturnsNull() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        when(k8sService.queryResourcesByLabel(
+            eq(KafkaTopic.class), anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("API unavailable"));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertNull(response.clusters().get(0).topicCount());
+    }
+
+    // ---- Test helpers ----
+
+    private static KafkaClusterResponse buildCluster(String name, String namespace,
+                                                      String readiness, String version,
+                                                      int expected, int ready) {
+        return KafkaClusterResponse.of(
+            name, namespace, "Kafka", version, readiness,
+            null, null, ReplicasInfo.of(expected, ready),
+            null, null, null, null, null, null, 1000L, null);
+    }
+
+    private static KafkaRebalanceResponse buildRebalance(String name, String state) {
+        return KafkaRebalanceResponse.of(
+            name, "kafka", "prod", state, null, null, null, null, null, null, null);
+    }
+
+    private static KafkaConnectResponse buildConnect(String name, String bootstrapServers) {
+        return KafkaConnectResponse.of(
+            name, "kafka", "Ready", null, null, bootstrapServers,
+            null, null, null, null, null, null);
+    }
+
+    private static KafkaBridgeResponse buildBridge(String name, String bootstrapServers) {
+        return KafkaBridgeResponse.of(
+            name, "kafka", "Ready", null, bootstrapServers,
+            null, null, null, null, null,
+            null, null, null, null, null, null, null, null);
+    }
+
+    private static KafkaMirrorMaker2Response buildMirrorMaker(String name,
+                                                               String bootstrapServers,
+                                                               String targetCluster,
+                                                               List<String> sourceAliases) {
+        return KafkaMirrorMaker2Response.of(
+            name, "kafka", "Ready", null,
+            targetCluster, sourceAliases, null, null, null,
+            null, bootstrapServers, null, null, null);
+    }
+}

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaFleetOverviewServiceTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/service/KafkaFleetOverviewServiceTest.java
@@ -10,6 +10,7 @@ import io.streamshub.mcp.common.dto.ReplicasInfo;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterResponse;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse;
+import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterSummary;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaFleetOverviewResponse.ClusterWarning;
 import io.streamshub.mcp.strimzi.dto.kafkabridge.KafkaBridgeResponse;
 import io.streamshub.mcp.strimzi.dto.kafkaconnect.KafkaConnectResponse;
@@ -100,6 +101,7 @@ class KafkaFleetOverviewServiceTest {
         assertTrue(response.warnings().isEmpty());
         assertNotNull(response.timestamp());
         assertNull(response.namespaceFilter());
+        assertNull(response.resourceErrors());
     }
 
     @Test
@@ -206,7 +208,7 @@ class KafkaFleetOverviewServiceTest {
         KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
 
         assertEquals(1, response.clusters().size());
-        var summary = response.clusters().get(0);
+        ClusterSummary summary = response.clusters().get(0);
         assertEquals("prod", summary.name());
         assertEquals("kafka-prod", summary.namespace());
         assertEquals("Ready", summary.readiness());
@@ -236,7 +238,7 @@ class KafkaFleetOverviewServiceTest {
 
         KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
 
-        var summary = response.clusters().get(0);
+        ClusterSummary summary = response.clusters().get(0);
         assertEquals(2, summary.topicCount());
         assertEquals(1, summary.userCount());
     }
@@ -303,17 +305,64 @@ class KafkaFleetOverviewServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void testFailedResourceQueryReturnsNull() {
+    void testFailedResourceQueryReturnsNullAndReportsError() {
         when(kafkaService.listClusters(null)).thenReturn(List.of(
             buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
         ));
         when(k8sService.queryResourcesByLabel(
             eq(KafkaTopic.class), anyString(), anyString(), anyString()))
             .thenThrow(new RuntimeException("API unavailable"));
+        when(k8sService.queryResourcesByLabel(
+            eq(KafkaUser.class), anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("API unavailable"));
 
         KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
 
-        assertNull(response.clusters().get(0).topicCount());
+        ClusterSummary summary = response.clusters().get(0);
+        assertNull(summary.topicCount());
+        assertNull(summary.userCount());
+        assertNotNull(summary.resourceErrors());
+        assertTrue(summary.resourceErrors().contains("KafkaTopic"));
+        assertTrue(summary.resourceErrors().contains("KafkaUser"));
+        assertNull(response.resourceErrors());
+    }
+
+    @Test
+    void testBulkFetchFailureReportsFleetError() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+        when(connectService.listConnects(any()))
+            .thenThrow(new RuntimeException("CRD not installed"));
+        when(bridgeService.listBridges(any()))
+            .thenThrow(new RuntimeException("CRD not installed"));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertNotNull(response.resourceErrors());
+        assertTrue(response.resourceErrors().contains("KafkaConnect"));
+        assertTrue(response.resourceErrors().contains("KafkaBridge"));
+        ClusterSummary summary = response.clusters().get(0);
+        assertNull(summary.connectCount());
+        assertNull(summary.bridgeCount());
+        assertNotNull(summary.mirrorMakerCount());
+        assertNotNull(summary.resourceErrors());
+        assertTrue(summary.resourceErrors().contains("KafkaConnect"));
+        assertTrue(summary.resourceErrors().contains("KafkaBridge"));
+    }
+
+    @Test
+    void testSuccessfulQueriesReportNoErrors() {
+        when(kafkaService.listClusters(null)).thenReturn(List.of(
+            buildCluster("prod", "kafka", "Ready", "4.2.0", 3, 3)
+        ));
+
+        KafkaFleetOverviewResponse response = fleetOverviewService.getFleetOverview(null);
+
+        assertNull(response.resourceErrors());
+        assertNull(response.clusters().get(0).resourceErrors());
+        assertEquals(0, response.clusters().get(0).topicCount());
+        assertEquals(0, response.clusters().get(0).userCount());
     }
 
     // ---- Test helpers ----

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpDiscoveryTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/McpDiscoveryTest.java
@@ -54,6 +54,7 @@ class McpDiscoveryTest {
             .toolsList(page -> {
                 List<String> expectedTools = List.of(
                     "list_kafka_clusters",
+                    "get_kafka_fleet_overview",
                     "get_kafka_cluster",
                     "get_strimzi_kafka_cluster_overview",
                     "get_kafka_cluster_pods",


### PR DESCRIPTION
## Description

* Added new tool for quick kubernetes fleet overview of kafka env
* Fixed deprecated usage of elicitation methods

## Type of change


* New feature (non-breaking change which adds functionality)

