### PR TITLE
Add more infor about DC in kafka overview tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced deprecated `Elicitation.isSupported()` with `isFormModeSupported()` across all diagnostic services
 - Fixed `auth-mode` documentation to use correct values (`sa-token` and `bearer-token`) matching the actual implementation
 - Fixed diagnostic services and prompt templates incorrectly passing KafkaConnect/KafkaMirrorMaker2 names to `get_strimzi_events` as Kafka cluster names (#145)
+- Fixed cluster overview Drain Cleaner summary missing namespace, readiness, and replica count
 
 ## [0.1.0] - 2026-06-02
 

--- a/docs/strimzi-mcp/tools/kafka-clusters.md
+++ b/docs/strimzi-mcp/tools/kafka-clusters.md
@@ -73,7 +73,7 @@ KafkaConnect and KafkaBridge resources are matched by comparing their `spec.boot
 - **KafkaConnects** -- connected clusters with connector counts
 - **KafkaMirrorMaker2** -- connected MM2 instances with mirror counts
 - **KafkaBridges** -- connected bridge instances
-- **Drain Cleaner** -- deployment and readiness status
+- **Drain Cleaner** -- name, namespace, readiness, and replica count
 
 **Example**:
 ```

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaClusterOverviewResponse.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/dto/kafka/KafkaClusterOverviewResponse.java
@@ -199,13 +199,17 @@ public record KafkaClusterOverviewResponse(
     /**
      * Drain Cleaner summary.
      *
-     * @param name  the drain cleaner deployment name
-     * @param ready whether the drain cleaner is ready
+     * @param name      the drain cleaner deployment name
+     * @param namespace the Kubernetes namespace
+     * @param readiness the readiness status
+     * @param replicas  the replica count
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record DrainCleanerSummary(
         @JsonProperty("name") String name,
-        @JsonProperty("ready") boolean ready
+        @JsonProperty("namespace") String namespace,
+        @JsonProperty("readiness") String readiness,
+        @JsonProperty("replicas") Integer replicas
     ) {
     }
 }

--- a/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterOverviewService.java
+++ b/strimzi-mcp/src/main/java/io/streamshub/mcp/strimzi/service/kafka/KafkaClusterOverviewService.java
@@ -8,6 +8,7 @@ import io.quarkiverse.mcp.server.ToolCallException;
 import io.streamshub.mcp.common.config.KubernetesConstants;
 import io.streamshub.mcp.common.service.KubernetesResourceService;
 import io.streamshub.mcp.common.util.InputUtils;
+import io.streamshub.mcp.strimzi.dto.draincleaner.DrainCleanerResponse;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterOverviewResponse;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterOverviewResponse.BridgeSummary;
 import io.streamshub.mcp.strimzi.dto.kafka.KafkaClusterOverviewResponse.ClusterSummary;
@@ -273,11 +274,13 @@ public class KafkaClusterOverviewService {
 
     private DrainCleanerSummary gatherDrainCleaner() {
         try {
-            var readiness = drainCleanerService.checkReadiness(null);
-            if (!readiness.deployed()) {
+            List<DrainCleanerResponse> drainCleaners = drainCleanerService.listDrainCleaners(null);
+            if (drainCleaners.isEmpty()) {
                 return null;
             }
-            return new DrainCleanerSummary("strimzi-drain-cleaner", readiness.overallReady());
+            DrainCleanerResponse dc = drainCleaners.getFirst();
+            String readiness = dc.ready() ? "Ready" : "NotReady";
+            return new DrainCleanerSummary(dc.name(), dc.namespace(), readiness, dc.replicas());
         } catch (Exception e) {
             LOG.warnf("Could not check Drain Cleaner: %s", e.getMessage());
             return null;

--- a/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/KafkaClusterOverviewToolsTest.java
+++ b/strimzi-mcp/src/test/java/io/streamshub/mcp/strimzi/tool/KafkaClusterOverviewToolsTest.java
@@ -77,7 +77,7 @@ class KafkaClusterOverviewToolsTest {
                 List.of(new ConnectSummary("my-connect", "kafka", "Ready", 2, 3)),
                 List.of(),
                 List.of(),
-                new DrainCleanerSummary("strimzi-drain-cleaner", true),
+                new DrainCleanerSummary("strimzi-drain-cleaner", "strimzi-drain-cleaner", "Ready", 1),
                 Instant.now())
         );
 
@@ -96,6 +96,8 @@ class KafkaClusterOverviewToolsTest {
                     assertTrue(json.contains("my-connect"));
                     assertTrue(json.contains("\"connector_count\":3"));
                     assertTrue(json.contains("strimzi-drain-cleaner"));
+                    assertTrue(json.contains("\"readiness\":\"Ready\""));
+                    assertTrue(json.contains("\"replicas\":1"));
                 })
             .thenAssertResults();
     }


### PR DESCRIPTION
## Description

kafka overview toll returned only infor that drain cleaner is deployed not namespace aand toher info, this PR added more info.

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
