### PR TITLE
Fix diagnostic tools returning empty metrics with pod-scraping provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `auth-mode` documentation to use correct values (`sa-token` and `bearer-token`) matching the actual implementation
 - Fixed diagnostic services and prompt templates incorrectly passing KafkaConnect/KafkaMirrorMaker2 names to `get_strimzi_events` as Kafka cluster names (#145)
 - Fixed cluster overview Drain Cleaner summary missing namespace, readiness, and replica count
+- Fixed diagnostic tools returning empty metrics when using the pod-scraping provider because range queries dropped pod targets
 
 ## [0.1.0] - 2026-06-02
 

--- a/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricsQueryParams.java
+++ b/common/src/main/java/io/streamshub/mcp/common/dto/metrics/MetricsQueryParams.java
@@ -52,6 +52,7 @@ public record MetricsQueryParams(
      *
      * @param metricNames   the metric names to retrieve
      * @param labelMatchers label matchers for Prometheus filtering
+     * @param podTargets    pod endpoints to scrape (used by pod-scraping provider)
      * @param startTime     the range start time
      * @param endTime       the range end time
      * @param stepSeconds   the step interval in seconds
@@ -60,11 +61,12 @@ public record MetricsQueryParams(
      */
     public static MetricsQueryParams range(final List<String> metricNames,
                                             final Map<String, String> labelMatchers,
+                                            final List<PodTarget> podTargets,
                                             final Instant startTime,
                                             final Instant endTime,
                                             final int stepSeconds,
                                             final int maxSamples) {
-        return new MetricsQueryParams(metricNames, labelMatchers, List.of(),
+        return new MetricsQueryParams(metricNames, labelMatchers, podTargets,
             startTime, endTime, stepSeconds, maxSamples);
     }
 

--- a/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
+++ b/common/src/main/java/io/streamshub/mcp/common/service/metrics/MetricsQueryService.java
@@ -143,7 +143,7 @@ public class MetricsQueryService {
             }
 
             int step = stepSeconds != null ? stepSeconds : defaultStepSeconds;
-            return MetricsQueryParams.range(metricNames, labelMatchers, start, end, step, maxSamples);
+            return MetricsQueryParams.range(metricNames, labelMatchers, podTargets, start, end, step, maxSamples);
         }
 
         // Relative time range
@@ -155,7 +155,7 @@ public class MetricsQueryService {
             Instant end = Instant.now();
             Instant start = end.minusSeconds((long) rangeMinutes * SECONDS_PER_MINUTE);
             int step = stepSeconds != null ? stepSeconds : defaultStepSeconds;
-            return MetricsQueryParams.range(metricNames, labelMatchers, start, end, step, maxSamples);
+            return MetricsQueryParams.range(metricNames, labelMatchers, podTargets, start, end, step, maxSamples);
         }
 
         // Instant query

--- a/common/src/test/java/io/streamshub/mcp/common/service/metrics/MetricsQueryServiceTest.java
+++ b/common/src/test/java/io/streamshub/mcp/common/service/metrics/MetricsQueryServiceTest.java
@@ -121,6 +121,8 @@ class MetricsQueryServiceTest {
         assertNotNull(params.startTime());
         assertNotNull(params.endTime());
         assertEquals(30, params.stepSeconds());
+        assertEquals(1, params.podTargets().size());
+        assertEquals("pod", params.podTargets().get(0).podName());
     }
 
     @Test


### PR DESCRIPTION
## Description

Range queries in MetricsQueryParams.range() hardcoded podTargets to an empty list, assuming only the Prometheus provider would handle them. When diagnostic tools set a time window (default 30 minutes), the pod-scraping provider received no targets and silently returned zero samples.

Pass podTargets through in range queries so the pod-scraping provider can fall back to point-in-time scraping. The Prometheus provider is unaffected as it never uses podTargets.

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
