### PR TITLE
Use renamed allure maven package

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -79,7 +79,7 @@
         <!-- Allure reporting -->
         <dependency>
             <groupId>io.qameta.allure</groupId>
-            <artifactId>allure-junit5</artifactId>
+            <artifactId>allure-jupiter</artifactId>
             <version>${allure.junit.version}</version>
         </dependency>
 


### PR DESCRIPTION
## Description

fix warning
```
[WARNING] The artifact io.qameta.allure:allure-junit5:jar:2.35.2 has been relocated to io.qameta.allure:allure-jupiter:jar:2.35.2: allure-junit5 has been renamed to allure-jupiter.
```

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
