### PR TITLE
Disable fabric8 trust cert for prod deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tool metadata** -- tools now include `_meta` fields (`type`, `resource`, `composite`) in `tools/list` responses, enabling AI agents and clients to discover and filter tools by purpose and target resource (#151)
 - **Fleet overview tool** -- `get_kafka_fleet_overview` returns aggregated health across all Kafka clusters in a single call, including status distribution, total broker count, per-cluster summaries with cross-resource relationship counts (topics, users, active rebalances, connected KafkaConnect/Bridge/MirrorMaker2), and warnings for clusters that need attention
 - **AI agent best practices documentation** -- expanded usage examples and troubleshooting with guidance on response interpretation, script avoidance, pagination handling, diagnostic report structure, Sampling/Elicitation, and parameter optimization (#135)
+- **Production deployment checklist** in configuration docs covering authentication, rate limiting, CORS, TLS, and log redaction hardening
 
 ### Changed
 
+- `quarkus.kubernetes-client.trust-certs` is now scoped to the `%dev` profile only -- production builds validate Kubernetes API server certificates by default using the in-cluster CA. Override with `QUARKUS_KUBERNETES_CLIENT_TRUST_CERTS=true` if needed.
 - Reorganized tool classes into domain sub-packages (`kafka/`, `kafkatopic/`, `operator/`, `diagnostic/`, etc.) matching the existing service and DTO package structure
 - Resource subscriptions (`mcp.resource-watches.enabled`) are now **disabled by default** because most AI clients do not yet support MCP resource subscriptions; resource templates still work for on-demand queries
 - Renamed deployment and related resources from `streamshub-strimzi-mcp` to `streamshub-mcp-strimzi` for consistent naming

--- a/docs/strimzi-mcp/configuration.md
+++ b/docs/strimzi-mcp/configuration.md
@@ -46,6 +46,24 @@ Override with a specific domain:
 QUARKUS_HTTP_CORS_ORIGINS=https://your-domain.com
 ```
 
+### Kubernetes API TLS
+
+When running inside a Kubernetes cluster, the MCP server automatically trusts the cluster CA certificate mounted at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+No additional TLS configuration is needed for standard in-cluster deployments.
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `quarkus.kubernetes-client.trust-certs` | `false` | Skip Kubernetes API server certificate validation. Only set to `true` for development or clusters with untrusted CAs. |
+
+If your cluster uses a custom CA that is not covered by the mounted service account CA bundle, you can override this setting:
+
+```bash
+QUARKUS_KUBERNETES_CLIENT_TRUST_CERTS=true
+```
+
+**Warning:** Setting `trust-certs=true` disables certificate validation for all Kubernetes API connections, exposing the server to man-in-the-middle attacks.
+Only use this in development or when you understand the security implications.
+
 ## Log configuration
 
 ### Log provider selection
@@ -784,6 +802,69 @@ kubectl -n streamshub-mcp logs -l app=streamshub-mcp-strimzi
 # Test metrics query through your AI assistant
 # Ask: "Query Kafka metrics for mcp-cluster"
 ```
+
+## Production deployment checklist
+
+Before deploying to production, review these security-relevant settings.
+Most defaults are tuned for development convenience and should be hardened for production use.
+
+### Authentication for external services
+
+Both Loki and Prometheus default to `auth-mode=none`.
+Configure authentication for production:
+
+```bash
+# Loki: use ServiceAccount token (recommended for Kubernetes)
+MCP_LOG_LOKI_AUTH_MODE=sa-token
+
+# Prometheus: use ServiceAccount token
+MCP_METRICS_PROMETHEUS_AUTH_MODE=sa-token
+```
+
+See [Loki authentication](#loki-authentication) and [Prometheus authentication](#prometheus-authentication) for all options.
+
+### Rate limiting
+
+All rate limits default to `0` (unlimited).
+Set per-category limits to prevent resource exhaustion:
+
+```bash
+MCP_GUARDRAIL_RATE_LIMIT_LOG_RPM=30
+MCP_GUARDRAIL_RATE_LIMIT_METRICS_RPM=60
+MCP_GUARDRAIL_RATE_LIMIT_GENERAL_RPM=120
+```
+
+See [Rate limiting](#rate-limiting) for details.
+
+### CORS origins
+
+The default allows `localhost` origins only.
+Override with your actual domain:
+
+```bash
+QUARKUS_HTTP_CORS_ORIGINS=https://your-domain.com
+```
+
+See [CORS configuration](#cors-configuration) for details.
+
+### TLS for external services
+
+Configure trust stores when Loki, Prometheus, or the OTEL collector use TLS:
+
+- [Loki TLS configuration](#loki-tls-configuration)
+- [Prometheus TLS configuration](#prometheus-tls-configuration)
+- [OTLP TLS configuration](#otlp-tls-configuration)
+
+### Log redaction
+
+Log redaction is enabled by default and redacts common credential patterns.
+Add custom patterns for organization-specific secrets:
+
+```bash
+MCP_GUARDRAIL_LOG_REDACTION_CUSTOM_PATTERNS_0='(?i)x-internal-token:\s*\S+'
+```
+
+See [Log redaction](#log-redaction) for built-in patterns and configuration.
 
 ## Configuration examples
 

--- a/strimzi-mcp/src/main/resources/application.properties
+++ b/strimzi-mcp/src/main/resources/application.properties
@@ -20,7 +20,11 @@ quarkus.http.cors.headers=Accept,Content-Type,Mcp-Session-Id
 %dev.quarkus.http.cors.origins=/.*/
 
 # Kubernetes Configuration
-quarkus.kubernetes-client.trust-certs=true
+# In production (in-cluster), the Kubernetes client automatically trusts
+# the cluster CA from /var/run/secrets/kubernetes.io/serviceaccount/ca.crt.
+# Override with QUARKUS_KUBERNETES_CLIENT_TRUST_CERTS=true if your cluster
+# uses certificates not covered by the mounted CA.
+%dev.quarkus.kubernetes-client.trust-certs=true
 
 # Application Configuration
 quarkus.http.port=8080


### PR DESCRIPTION
## Description

There was still leftover from dev phase which trust all fabric8 kubernetes connection. Now it is disabled by default and enabled only for dev mode.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
